### PR TITLE
Add fluct bid adapter

### DIFF
--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -1,0 +1,121 @@
+import * as utils from '../src/utils';
+import { registerBidder } from '../src/adapters/bidderFactory';
+
+const BIDDER_CODE = 'fluct';
+const END_POINT = 'https://hb.adingo.jp/prebid';
+const VERSION = '1.2';
+const NET_REVENUE = true;
+const TTL = 300;
+
+export const spec = {
+  code: BIDDER_CODE,
+  aliases: ['adingo'],
+
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: (bid) => {
+    return !!(bid.params.groupId && bid.params.tagId && bid.params.dfpUnitCode);
+  },
+
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids.
+   * @return ServerRequest Info describing the request to the server.
+   */
+  buildRequests: (validBidRequests, bidderRequest) => {
+    const serverRequests = [];
+    const referer = bidderRequest.refererInfo.referer;
+
+    utils._each(validBidRequests, (request) => {
+      const data = Object();
+
+      data.referer = referer;
+      data.adUnitCode = request.adUnitCode;
+      data.bidId = request.bidId;
+      data.transactionId = request.transactionId;
+
+      data.sizes = [];
+      utils._each(request.sizes, (size) => {
+        data.sizes.push({
+          w: size[0],
+          h: size[1]
+        });
+      });
+
+      data.params = request.params;
+
+      serverRequests.push({
+        method: 'POST',
+        url: END_POINT,
+        options: {
+          contentType: 'application/json',
+          withCredentials: true,
+          customHeaders: {
+            'x-fluct-app': 'prebid/fluctBidAdapter',
+            'x-fluct-version': VERSION,
+            'x-openrtb-version': 2.5
+          }
+        },
+        data: data
+      });
+    });
+
+    return serverRequests;
+  },
+
+  /*
+   * Unpack the respnse from the server into a list of bids.
+   *
+   * @param {serverResponse} serverResponse A successful response from the server.
+   * @return {bid[]} An array of bids which weer nested inside the server.
+   */
+  interpretResponse: (serverResponse, serverRequest) => {
+    const bidResponses = [];
+
+    const res = serverResponse.body;
+    if (!utils.isEmpty(res) && !utils.isEmpty(res.seatbid) && !utils.isEmpty(res.seatbid[0].bid)) {
+      const bid = res.seatbid[0].bid[0];
+      const dealId = bid.dealid;
+      const beaconUrl = bid.burl;
+      const callImpBeacon = `<script type="application/javascript">` +
+        `(function() { var img = new Image(); img.src = "${beaconUrl}"})()` +
+        `</script>`;
+      let data = {
+        bidderCode: BIDDER_CODE,
+        requestId: res.id,
+        currency: res.cur,
+        cpm: parseFloat(bid.price) || 0,
+        netRevenue: NET_REVENUE,
+        width: bid.w,
+        height: bid.h,
+        creativeId: bid.crid,
+        ttl: TTL,
+        ad: bid.adm + callImpBeacon,
+      };
+      if (!utils.isEmpty(dealId)) {
+        data.dealId = dealId;
+      }
+      bidResponses.push(data);
+    }
+    return bidResponses;
+  },
+
+  /*
+   * Register the user sync pixels which should be dropped after the auction.
+   *
+   * @params {syncOptions} syncOptions which user syncs are allowed?
+   * @params {ServerResponse[]} serverResponses List of server's responses.
+   * @return {UserSync[]} The user syncs which should be dropped.
+   *
+   */
+  getUserSyncs: (syncOptions, serverResponses) => {
+    return [];
+  },
+};
+
+registerBidder(spec);

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -18,7 +18,7 @@ export const spec = {
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: (bid) => {
-    return !!(bid.params.groupId && bid.params.tagId && bid.params.dfpUnitCode);
+    return !!(bid.params.groupId && bid.params.tagId);
   },
 
   /**

--- a/modules/fluctBidAdapter.md
+++ b/modules/fluctBidAdapter.md
@@ -3,7 +3,7 @@
 ```
 Module Name: fluct Bid Adapter
 Module Type: Bidder Adapter
-Maintainer: fluct_developer@fluct.jp
+Maintainer: developer@fluct.jp
 ```
 
 # Description

--- a/modules/fluctBidAdapter.md
+++ b/modules/fluctBidAdapter.md
@@ -1,0 +1,36 @@
+# Overview
+
+```
+Module Name: fluct Bid Adapter
+Module Type: Bidder Adapter
+Maintainer: fluct_developer@fluct.jp
+```
+
+# Description
+
+Connects to fluct exchange for bids.
+
+# Test parameters
+
+```
+var adUnits = [
+    {
+        code: 'test-div',
+        mediaTypes: {
+            banner: {
+                sizes: [[300, 250]],
+            }
+       },
+        bids: [
+            {
+                bidder: 'fluct',
+                params: {
+                    dfpUnitCode: '/62532913/s_fluct.test_hb_prebid_11940',
+                    tagId: '25405:1000192893',
+                    groupId: '1000105712',
+                }
+            }
+        ]
+    }
+]
+```

--- a/modules/fluctBidAdapter.md
+++ b/modules/fluctBidAdapter.md
@@ -25,9 +25,9 @@ var adUnits = [
             {
                 bidder: 'fluct',
                 params: {
-                    dfpUnitCode: '/62532913/s_fluct.test_hb_prebid_11940',
                     tagId: '25405:1000192893',
                     groupId: '1000105712',
+                    dfpUnitCode: '/62532913/s_fluct.test_hb_prebid_11940', // Optional
                 }
             }
         ]

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -36,10 +36,10 @@ describe('fluctAdapter', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;
       bid.params = {
-        dfpUnitCode: '/1000/dfp_unit_code',
         tagId: '10000:100000001',
+        groupId: '1000000002',
       };
-      expect(spec.isBidRequestValid(bid)).to.equal(false);
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
     it('should return false when groupId is not passed', function () {

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -32,6 +32,16 @@ describe('fluctAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
+    it('should return true when dfpUnitCode is not passed', function () {
+      let bid = Object.assign({}, bid);
+      delete bid.params;
+      bid.params = {
+        dfpUnitCode: '/1000/dfp_unit_code',
+        tagId: '10000:100000001',
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
     it('should return false when groupId is not passed', function () {
       let bid = Object.assign({}, bid);
       delete bid.params;

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -1,0 +1,191 @@
+import {expect} from 'chai';
+import {spec} from 'modules/fluctBidAdapter';
+import {newBidder} from 'src/adapters/bidderFactory';
+import {config} from 'src/config';
+
+describe('fluctAdapter', function () {
+  const adapter = newBidder(spec);
+
+  describe('inherited functions', function () {
+    it('exists and is a function', function () {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+  });
+
+  describe('isBidRequestValid', function () {
+    const bid = {
+      bidder: 'fluct',
+      params: {
+        dfpUnitCode: '/1000/dfp_unit_code',
+        tagId: '10000:100000001',
+        groupId: '1000000002',
+      }
+    };
+    it('should return true when required params found', function () {
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('should return false when required params are not passed', function () {
+      let bid = Object.assign({}, bid);
+      delete bid.params;
+      bid.params = {};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when groupId is not passed', function () {
+      let bid = Object.assign({}, bid);
+      delete bid.params;
+      bid.params = {
+        dfpUnitCode: '/1000/dfp_unit_code',
+        tagId: '10000:100000001',
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', function () {
+    const bidRequests = [{
+      bidder: 'fluct',
+      params: {
+        dfpUnitCode: '/100000/unit_code',
+        tagId: '10000:100000001',
+        groupId: '1000000002',
+      },
+      adUnitCode: '/10000/unit_code',
+      sizes: [[300, 250], [336, 280]],
+      bidId: '237f4d1a293f99',
+      bidderRequestId: '1a857fa34c1c96',
+      auctionId: 'a297d1aa-7900-4ce4-a0aa-caa8d46c4af7',
+      transactionId: '00b2896c-2731-4f01-83e4-7a3ad5da13b6',
+    }];
+    const bidderRequest = {
+      refererInfo: {
+        referer: 'http://example.com'
+      }
+    };
+
+    it('sends bid request to ENDPOINT via POST', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.method).to.equal('POST');
+    });
+  });
+
+  describe('interpretResponse', function() {
+    const callBeaconSnippet = '<script type="application/javascript">' +
+      '(function() { var img = new Image(); img.src = ' +
+      '"https://i.adingo.jp/?test=1&et=hb&bidid=237f4d1a293f99"' +
+      '})()</script>';
+
+    it('should get correct bid response', function() {
+      const bidRequest = {
+        bidder: 'fluct',
+        params: {
+          dfpUnitCode: '/10000/unit_code',
+          tagid: '10000:100000001',
+          groupId: '1000000002',
+        },
+        adUnitCode: '/10000/unit_code',
+        sizes: [[300, 250], [336, 280]],
+        bidId: '237f4d1a293f99',
+        bidderRequestId: '1a857fa34c1c96',
+        auctionId: 'a297d1aa-7900-4ce4-a0aa-caa8d46c4af7',
+        transactionId: '00b2896c-2731-4f01-83e4-7a3ad5da13b6',
+      };
+
+      const serverResponse = {
+        body: {
+          id: '237f4d1a293f99',
+          cur: 'JPY',
+          seatbid: [{
+            bid: [{
+              price: 100,
+              w: 300,
+              h: 250,
+              adm: '<!-- test creative -->',
+              burl: 'https://i.adingo.jp/?test=1&et=hb&bidid=237f4d1a293f99',
+              crid: 'test_creative',
+            }]
+          }]
+        }
+      };
+
+      const expectedResponse = [
+        {
+          bidderCode: 'fluct',
+          requestId: '237f4d1a293f99',
+          currency: 'JPY',
+          cpm: 100,
+          netRevenue: true,
+          width: 300,
+          height: 250,
+          creativeId: 'test_creative',
+          ttl: 300,
+          ad: '<!-- test creative -->' + callBeaconSnippet,
+        }
+      ];
+
+      const result = spec.interpretResponse(serverResponse, bidRequest);
+      expect(result).to.have.lengthOf(1);
+      expect(result).to.deep.have.same.members(expectedResponse);
+    });
+
+    it('should get correct bid response with dealId', function() {
+      const bidRequest = {
+        bidder: 'fluct',
+        params: {
+          dfpUnitCode: '/10000/unit_code',
+          tagid: '10000:100000001',
+          groupId: '1000000002'
+        },
+        adUnitCode: '/10000/unit_code',
+        sizes: [[300, 250], [336, 280]],
+        bidId: '237f4d1a293f99',
+        bidderRequestId: '1a857fa34c1c96',
+        auctionId: 'a297d1aa-7900-4ce4-a0aa-caa8d46c4af7',
+        transactionId: '00b2896c-2731-4f01-83e4-7a3ad5da13b6',
+      };
+
+      const serverResponse = {
+        body: {
+          id: '237f4d1a293f99',
+          cur: 'JPY',
+          seatbid: [{
+            bid: [{
+              price: 100,
+              w: 300,
+              h: 250,
+              adm: '<!-- test creative -->',
+              burl: 'https://i.adingo.jp/?test=1&et=hb&bidid=237f4d1a293f99',
+              crid: 'test_creative',
+              dealid: 'test_deal',
+            }]
+          }]
+        }
+      };
+
+      const expectedResponse = [
+        {
+          bidderCode: 'fluct',
+          requestId: '237f4d1a293f99',
+          currency: 'JPY',
+          cpm: 100,
+          netRevenue: true,
+          width: 300,
+          height: 250,
+          creativeId: 'test_creative',
+          ttl: 300,
+          ad: '<!-- test creative -->' + callBeaconSnippet,
+          dealId: 'test_deal',
+        }
+      ];
+
+      const result = spec.interpretResponse(serverResponse, bidRequest);
+      expect(result).to.have.lengthOf(1);
+      expect(result).to.deep.have.same.members(expectedResponse);
+    });
+
+    it('should get empty response when bid server returns 204', function() {
+      expect(spec.interpretResponse({})).to.be.empty;
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: 'fluct',
  params: {
      dfpUnitCode: '/62532913/s_fluct.test_hb_prebid_11940',
      tagId: '25405:1000192893',
      groupId: '1000105712',
  }
}
```

- contact email of the adapter’s maintainer
developer@fluct.jp
- [x] official adapter submission

- A link to a PR on the docs repo at https://github.com/voyagegroup/prebid.github.io/pull/1
