### PR TITLE
add query parameter

### DIFF
--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -48,10 +48,11 @@ export const spec = {
       });
 
       data.params = request.params;
+      const searchParams = new URLSearchParams(request.params);
 
       serverRequests.push({
         method: 'POST',
-        url: END_POINT,
+        url: END_POINT + '?' + searchParams.toString(),
         options: {
           contentType: 'application/json',
           withCredentials: true,

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -78,6 +78,11 @@ describe('fluctAdapter', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.method).to.equal('POST');
     });
+
+    it('sends bid request to ENDPOINT with query parameter', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.url).to.equal('https://hb.adingo.jp/prebid?dfpUnitCode=%2F100000%2Funit_code&tagId=10000%3A100000001&groupId=1000000002');
+    });
   });
 
   describe('interpretResponse', function() {


### PR DESCRIPTION
`bid.params` の内容をクエリパラメータとして付与した上でhbサーバーへリクエストする

> groupId=xxx&tagId=xxx みたいのをつけておくと、アクセスログでわかるのでいまよりデバッグしやすくなるやつ

related: https://cartaholdings.slack.com/archives/C01U01TPTV3/p1629083001275500