### PR TITLE
fluct Bid Adapter: Add user data support

### DIFF
--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -7,6 +7,16 @@ const VERSION = '1.2';
 const NET_REVENUE = true;
 const TTL = 300;
 
+/**
+ * See modules/userId/eids.js for supported sources
+ */
+const SUPPORTED_USER_ID_SOURCES = [
+  'adserver.org',
+  'criteo.com',
+  'intimatemerger.com',
+  'liveramp.com',
+];
+
 export const spec = {
   code: BIDDER_CODE,
   aliases: ['adingo'],
@@ -38,6 +48,9 @@ export const spec = {
       data.adUnitCode = request.adUnitCode;
       data.bidId = request.bidId;
       data.transactionId = request.transactionId;
+      data.user = {
+        eids: (request.userIdAsEids || []).filter((eid) => SUPPORTED_USER_ID_SOURCES.indexOf(eid.source) !== -1)
+      };
 
       data.sizes = [];
       _each(request.sizes, (size) => {
@@ -48,7 +61,11 @@ export const spec = {
       });
 
       data.params = request.params;
-      const searchParams = new URLSearchParams(request.params);
+      const searchParams = new URLSearchParams({
+        dfpUnitCode: request.params.dfpUnitCode,
+        tagId: request.params.tagId,
+        groupId: request.params.groupId,
+      });
 
       serverRequests.push({
         method: 'POST',

--- a/modules/imRtdProvider.js
+++ b/modules/imRtdProvider.js
@@ -60,6 +60,16 @@ export function getBidderFunction(bidderName) {
         );
       }
       return bid
+    },
+    fluct: function (bid, data) {
+      if (data.im_segments && data.im_segments.length) {
+        deepSetValue(
+          bid,
+          'params.kv.imsids',
+          data.im_segments
+        );
+      }
+      return bid
     }
   }
   return biddersFunction[bidderName] || null;

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -83,6 +83,98 @@ describe('fluctAdapter', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.url).to.equal('https://hb.adingo.jp/prebid?dfpUnitCode=%2F100000%2Funit_code&tagId=10000%3A100000001&groupId=1000000002');
     });
+
+    it('includes data.user.eids = [] by default', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.data.user.eids).to.eql([]);
+    });
+
+    it('includes no data.params.kv by default', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.data.params.kv).to.eql(undefined);
+    });
+
+    it('includes filtered user.eids if any exists', function () {
+      const bidRequests2 = bidRequests.map(
+        (bidReq) => Object.assign(bidReq, {
+          userIdAsEids: [
+            {
+              source: 'foobar.com',
+              uids: [
+                { id: 'foobar-id' }
+              ],
+            },
+            {
+              source: 'adserver.org',
+              uids: [
+                { id: 'tdid' }
+              ],
+            },
+            {
+              source: 'criteo.com',
+              uids: [
+                { id: 'criteo-id' }
+              ],
+            },
+            {
+              source: 'intimatemerger.com',
+              uids: [
+                { id: 'imuid' }
+              ],
+            },
+            {
+              source: 'liveramp.com',
+              uids: [
+                { id: 'idl-env' }
+              ],
+            },
+          ],
+        })
+      );
+      const request = spec.buildRequests(bidRequests2, bidderRequest)[0];
+      expect(request.data.user.eids).to.eql([
+        {
+          source: 'adserver.org',
+          uids: [
+            { id: 'tdid' }
+          ],
+        },
+        {
+          source: 'criteo.com',
+          uids: [
+            { id: 'criteo-id' }
+          ],
+        },
+        {
+          source: 'intimatemerger.com',
+          uids: [
+            { id: 'imuid' }
+          ],
+        },
+        {
+          source: 'liveramp.com',
+          uids: [
+            { id: 'idl-env' }
+          ],
+        },
+      ]);
+    });
+
+    it('includes data.params.kv if any exists', function () {
+      const bidRequests2 = bidRequests.map(
+        (bidReq) => Object.assign(bidReq, {
+          params: {
+            kv: {
+              imsids: ['imsid1', 'imsid2']
+            }
+          }
+        })
+      );
+      const request = spec.buildRequests(bidRequests2, bidderRequest)[0];
+      expect(request.data.params.kv).to.eql({
+        imsids: ['imsid1', 'imsid2']
+      });
+    });
   });
 
   describe('interpretResponse', function() {

--- a/test/spec/modules/imRtdProvider_spec.js
+++ b/test/spec/modules/imRtdProvider_spec.js
@@ -51,7 +51,8 @@ describe('imRtdProvider', function () {
   describe('getBidderFunction', function () {
     const assumedBidder = [
       'ix',
-      'pubmatic'
+      'pubmatic',
+      'fluct'
     ];
     assumedBidder.forEach(bidderName => {
       it(`should return bidderFunction with assumed bidder: ${bidderName}`, function () {
@@ -69,6 +70,35 @@ describe('imRtdProvider', function () {
     });
     it(`should return null with unexpected bidder`, function () {
       expect(getBidderFunction('test')).to.equal(null);
+    });
+
+    describe('fluct bidder function', function () {
+      it('should return a bid w/o im_segments if not any exists', function () {
+        const bid = {bidder: 'fluct'};
+        expect(getBidderFunction('fluct')(bid, '')).to.eql(bid);
+      });
+      it('should return a bid w/ im_segments if any exists', function () {
+        const bid = {
+          bidder: 'fluct',
+          params: {
+            kv: {
+              foo: ['foo1']
+            }
+          }
+        };
+        expect(getBidderFunction('fluct')(bid, {im_segments: ['12345', '67890']}))
+          .to.eql(
+            {
+              bidder: 'fluct',
+              params: {
+                kv: {
+                  foo: ['foo1'],
+                  imsids: ['12345', '67890']
+                }
+              }
+            }
+          );
+      });
     });
   })
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
    bidder: 'fluct',
    params: {
        tagId: '25405:1000192893',
        groupId: '1000105712',
        dfpUnitCode: '/62532913/s_fluct.test_hb_prebid_11940', // Optional
    }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

- Updating [modules/imRtdProvider.js](https://github.com/voyagegroup/Prebid.js/pull/13/files#diff-3e9fda45a0d1774a77b2b59e780347512dee406bce49967587f7f396f8abcc5c) to inject data into Fluct Bid Adapter.