### PR TITLE
Update browsi event handling.

### DIFF
--- a/modules/fluctAnalyticsAdapter.js
+++ b/modules/fluctAnalyticsAdapter.js
@@ -59,11 +59,11 @@ export const convertReplicatedAdUnit = (_adUnit, adUnits = $$PREBID_GLOBAL$$.adU
       adUnit._code = code;
       adUnit.mediaTypes.banner.name = name;
     } catch (_error) {
-      logError({
+      logError(JSON.stringify({
         message: '対応するDWIDを持つ枠が見つかりませんでした。',
         adUnitCode: adUnit.code,
         adUnitPath,
-      });
+      }));
     }
   }
   adUnit.bids = undefined;

--- a/modules/fluctAnalyticsAdapter.js
+++ b/modules/fluctAnalyticsAdapter.js
@@ -12,6 +12,7 @@ import {
   deepClone,
 } from '../src/utils.js'
 import find from 'core-js-pure/features/array/find.js'
+import $$PREBID_GLOBAL$$ from '../src/prebid.js'
 
 const url = 'https://an.adingo.jp'
 
@@ -29,6 +30,7 @@ const cache = {
   gpt: {},
   timeouts: {},
 }
+$$PREBID_GLOBAL$$.cache = cache
 
 /** @type {(id: string) => boolean} */
 const isBrowsiId = (id) => Boolean(id.match(/^browsi_/g))

--- a/modules/fluctAnalyticsAdapter.js
+++ b/modules/fluctAnalyticsAdapter.js
@@ -53,7 +53,8 @@ export const convertReplicatedAdUnit = (_adUnit, adUnits = $$PREBID_GLOBAL$$.adU
   const adUnit = deepClone(_adUnit);
   if (isBrowsiId(adUnit.code)) {
     try {
-      const { analytics, code, mediaTypes: { banner: { name } } } = find(adUnits, adUnit => adUnit.path === slots[adUnit.code]);
+      const adUnitPath = slots[adUnit.code];
+      const { analytics, code, mediaTypes: { banner: { name } } } = find(adUnits, adUnit => adUnit.path === adUnitPath);
       adUnit.analytics = analytics;
       adUnit._code = code;
       adUnit.mediaTypes.banner.name = name;

--- a/modules/fluctAnalyticsAdapter.js
+++ b/modules/fluctAnalyticsAdapter.js
@@ -135,10 +135,8 @@ let fluctAnalyticsAdapter = Object.assign(
           const auction = find(Object.values(cache.auctions), auction =>
             auction.adUnitCodes.every(adUnitCode => adUnitCodes.includes(adUnitCode)))
           adUnitCodes.forEach(adUnitCode => {
-            if (isBrowsiId(adUnitCode)) {
-              const adUnit = convertReplicatedAdUnit(find(cache.auctions[auction.auctionId].adUnits, adUnit => adUnit.code === adUnitCode))
-              Object.assign(cache.adUnits, { [adUnitCode]: adUnit })
-            }
+            const adUnit = convertReplicatedAdUnit(find(cache.auctions[auction.auctionId].adUnits, adUnit => adUnit.code === adUnitCode))
+            Object.assign(cache.adUnits, { [adUnitCode]: adUnit })
           })
           sendMessage(auction.auctionId)
           break

--- a/modules/fluctAnalyticsAdapter.js
+++ b/modules/fluctAnalyticsAdapter.js
@@ -53,11 +53,13 @@ export const convertReplicatedAdUnit = (_adUnit, adUnits = cache.adUnits, slots 
   /** @type {?string} */
   const adUnitPath = slots[adUnit.code]
   if (adUnitPath) {
-    const { analytics, code, mediaTypes: { banner: { name } } } =
+    const { analytics, code, mediaTypes: { banner: { name } }, sizes, transactionId } =
       find(Object.values(adUnits), adUnit => Boolean(adUnitPath.match(new RegExp(`${adUnit.mediaTypes.banner.name}$`, 'g'))))
     adUnit.analytics = analytics
     adUnit._code = code
     adUnit.mediaTypes.banner.name = name
+    adUnit.sizes = sizes
+    adUnit.transactionId = transactionId
   }
   adUnit.bids = undefined
   return adUnit

--- a/modules/fluctAnalyticsAdapter.js
+++ b/modules/fluctAnalyticsAdapter.js
@@ -53,13 +53,11 @@ export const convertReplicatedAdUnit = (_adUnit, adUnits = cache.adUnits, slots 
   /** @type {?string} */
   const adUnitPath = slots[adUnit.code]
   if (adUnitPath) {
-    const { analytics, code, mediaTypes: { banner: { name } }, sizes, transactionId } =
+    const { analytics, code, mediaTypes: { banner: { name } } } =
       find(Object.values(adUnits), adUnit => Boolean(adUnitPath.match(new RegExp(`${adUnit.mediaTypes.banner.name}$`, 'g'))))
     adUnit.analytics = analytics
     adUnit._code = code
     adUnit.mediaTypes.banner.name = name
-    adUnit.sizes = sizes
-    adUnit.transactionId = transactionId
   }
   adUnit.bids = undefined
   return adUnit
@@ -133,15 +131,15 @@ let fluctAnalyticsAdapter = Object.assign(
         case EVENTS.SET_TARGETING: {
           let setTargetingEvent = args
           const adUnitCodes = Object.keys(setTargetingEvent)
-          adUnitCodes.forEach(adUnitCode => {
-            if (isBrowsiId(adUnitCode)) {
-              const adUnit = convertReplicatedAdUnit(find($$PREBID_GLOBAL$$.adUnits, adUnit => adUnit.code === adUnitCode))
-              Object.assign(cache.adUnits, { [adUnitCode]: adUnit })
-            }
-          })
           /** @type {PbAuction} */
           const auction = find(Object.values(cache.auctions), auction =>
             auction.adUnitCodes.every(adUnitCode => adUnitCodes.includes(adUnitCode)))
+          adUnitCodes.forEach(adUnitCode => {
+            if (isBrowsiId(adUnitCode)) {
+              const adUnit = convertReplicatedAdUnit(find(cache.auctions[auction.auctionId].adUnits, adUnit => adUnit.code === adUnitCode))
+              Object.assign(cache.adUnits, { [adUnitCode]: adUnit })
+            }
+          })
           sendMessage(auction.auctionId)
           break
         }

--- a/modules/fluctAnalyticsAdapter.js
+++ b/modules/fluctAnalyticsAdapter.js
@@ -51,21 +51,16 @@ const getAdUnitMap = () => window.googletag.pubads().getSlots().reduce((prev, sl
 export const convertReplicatedAdUnit = (_adUnit, adUnits = $$PREBID_GLOBAL$$.adUnits, slots = getAdUnitMap()) => {
   /** @type {AdUnit} */
   const adUnit = deepClone(_adUnit);
-  if (isBrowsiId(adUnit.code)) {
-    try {
+  try {
+    if (isBrowsiId(adUnit.code)) {
       const adUnitPath = slots[adUnit.code];
       const { analytics, code, mediaTypes: { banner: { name } } } = find(adUnits, adUnit => adUnit.path === adUnitPath);
       adUnit.analytics = analytics;
       adUnit._code = code;
       adUnit.mediaTypes.banner.name = name;
-    } catch (_error) {
-      logError({
-        message: 'dwid is not found.',
-        adUnit,
-        adUnits,
-        slots,
-      })
     }
+  } catch (_error) {
+    logError(`ad unit not found with same path ${adUnitPath} as ${adUnit.code}.`);
   }
   adUnit.bids = undefined;
   return adUnit;

--- a/modules/fluctAnalyticsAdapter.js
+++ b/modules/fluctAnalyticsAdapter.js
@@ -55,7 +55,7 @@ export const convertReplicatedAdUnit = (_adUnit, adUnits, slots = getAdUnitMap()
   const adUnitPath = slots[adUnit.code];
   if (adUnitPath) {
     const { analytics, code, mediaTypes: { banner: { name } } } =
-      find(Object.values(adUnits), adUnit => Boolean(adUnitPath.match(new RegExp(`${adUnit.mediaTypes.banner.name}$`, 'g'))));
+      find(adUnits, adUnit => Boolean(adUnitPath.match(new RegExp(`${adUnit.mediaTypes.banner.name}$`, 'g'))));
     adUnit.analytics = analytics;
     adUnit._code = code;
     adUnit.mediaTypes.banner.name = name;

--- a/modules/fluctAnalyticsAdapter.js
+++ b/modules/fluctAnalyticsAdapter.js
@@ -29,7 +29,7 @@ const cache = {
   gpt: {},
   timeouts: {},
 };
-$$PREBID_GLOBAL$$.cache = cache;
+$$PREBID_GLOBAL$$.fluct = {cache: cache};
 
 /** @type {(id: string) => boolean} */
 const isBrowsiId = (id) => Boolean(id.match(/^browsi_/g));

--- a/modules/fluctAnalyticsAdapter.js
+++ b/modules/fluctAnalyticsAdapter.js
@@ -29,11 +29,11 @@ const cache = {
   adUnits: {},
   gpt: {},
   timeouts: {},
-}
-$$PREBID_GLOBAL$$.cache = cache
+};
+$$PREBID_GLOBAL$$.cache = cache;
 
 /** @type {(id: string) => boolean} */
-const isBrowsiId = (id) => Boolean(id.match(/^browsi_/g))
+const isBrowsiId = (id) => Boolean(id.match(/^browsi_/g));
 
 /**
  * 各adUnitCodeに対応したadUnitPathを取得する
@@ -46,45 +46,45 @@ const isBrowsiId = (id) => Boolean(id.match(/^browsi_/g))
  * }
  * ```
  */
-const getAdUnitMap = () => window.googletag.pubads().getSlots().reduce((prev, slot) => Object.assign(prev, { [slot.getSlotElementId()]: slot.getAdUnitPath() }), {})
+const getAdUnitMap = () => window.googletag.pubads().getSlots().reduce((prev, slot) => Object.assign(prev, { [slot.getSlotElementId()]: slot.getAdUnitPath() }), {});
 
 /** @type {(_adUnit: AdUnit, adUnits: AdUnit[], slots: Slots) => AdUnit} */
 export const convertReplicatedAdUnit = (_adUnit, adUnits = cache.adUnits, slots = getAdUnitMap()) => {
   /** @type {adUnit} */
-  const adUnit = deepClone(_adUnit)
+  const adUnit = deepClone(_adUnit);
   /** @type {?string} */
-  const adUnitPath = slots[adUnit.code]
+  const adUnitPath = slots[adUnit.code];
   if (adUnitPath) {
     const { analytics, code, mediaTypes: { banner: { name } } } =
-      find(Object.values(adUnits), adUnit => Boolean(adUnitPath.match(new RegExp(`${adUnit.mediaTypes.banner.name}$`, 'g'))))
-    adUnit.analytics = analytics
-    adUnit._code = code
-    adUnit.mediaTypes.banner.name = name
-  }
-  adUnit.bids = undefined
-  return adUnit
-}
+      find(Object.values(adUnits), adUnit => Boolean(adUnitPath.match(new RegExp(`${adUnit.mediaTypes.banner.name}$`, 'g'))));
+    adUnit.analytics = analytics;
+    adUnit._code = code;
+    adUnit.mediaTypes.banner.name = name;
+  };
+  adUnit.bids = undefined;
+  return adUnit;
+};
 
 let fluctAnalyticsAdapter = Object.assign(
   adapter({ url, analyticsType: 'endpoint' }), {
   track({ eventType, args }) {
-    logInfo(`[${eventType}] ${Date.now()} :`, args)
+    logInfo(`[${eventType}] ${Date.now()} :`, args);
     try {
       switch (eventType) {
         case EVENTS.AUCTION_INIT: {
           /** @type {PbAuction} */
-          let auctionInitEvent = args
-          cache.auctions[auctionInitEvent.auctionId] = { ...auctionInitEvent, bids: {} }
+          let auctionInitEvent = args;
+          cache.auctions[auctionInitEvent.auctionId] = { ...auctionInitEvent, bids: {} };
           if (!cache.gpt.registered) {
-            window.googletag = window.googletag || { cmd: [] }
-            cache.gpt.registered = true
-            $$PREBID_GLOBAL$$.adUnits.forEach(adUnit => Object.assign(cache.adUnits, { [adUnit.code]: adUnit }))
+            window.googletag = window.googletag || { cmd: [] };
+            cache.gpt.registered = true;
+            $$PREBID_GLOBAL$$.adUnits.forEach(adUnit => Object.assign(cache.adUnits, { [adUnit.code]: adUnit }));;
           }
-          break
+          break;
         }
         case EVENTS.BID_TIMEOUT: {
           /** @type {BidResponse[]} */
-          let timeoutEvent = args
+          let timeoutEvent = args;
           timeoutEvent.forEach(bid => {
             cache.auctions[bid.auctionId].bids[bid.bidId] = {
               ...bid,
@@ -92,15 +92,15 @@ let fluctAnalyticsAdapter = Object.assign(
               prebidWon: false,
               bidWon: false,
               timeout: true,
-            }
-          })
-          break
+            };
+          });
+          break;
         }
         case EVENTS.AUCTION_END: {
           /** @type {PbAuction} */
-          let auctionEndEvent = args
-          let { adUnitCodes, auctionId, bidsReceived, noBids } = auctionEndEvent
-          Object.assign(cache.auctions[auctionId], auctionEndEvent, { aidSuffix: isBrowsiId(auctionId) ? generateUUID() : undefined })
+          let auctionEndEvent = args;
+          let { adUnitCodes, auctionId, bidsReceived, noBids } = auctionEndEvent;
+          Object.assign(cache.auctions[auctionId], auctionEndEvent, { aidSuffix: isBrowsiId(auctionId) ? generateUUID() : undefined });
 
           let prebidWonBidRequestIds = adUnitCodes.map(adUnitCode =>
             bidsReceived.reduce((highestCpmBid, bid) =>
@@ -127,52 +127,52 @@ let fluctAnalyticsAdapter = Object.assign(
             })),
           ].forEach(bid => {
             cache.auctions[auctionId].bids[bid.requestId || bid.bidId] = bid
-          })
-          break
+          });
+          break;
         }
         case EVENTS.SET_TARGETING: {
-          let setTargetingEvent = args
-          const adUnitCodes = Object.keys(setTargetingEvent)
+          let setTargetingEvent = args;
+          const adUnitCodes = Object.keys(setTargetingEvent);
           /** @type {PbAuction} */
           const auction = find(Object.values(cache.auctions), auction =>
-            auction.adUnitCodes.every(adUnitCode => adUnitCodes.includes(adUnitCode)))
+            auction.adUnitCodes.every(adUnitCode => adUnitCodes.includes(adUnitCode)));
           adUnitCodes.forEach(adUnitCode => {
-            const adUnit = convertReplicatedAdUnit(find(cache.auctions[auction.auctionId].adUnits, adUnit => adUnit.code === adUnitCode))
-            Object.assign(cache.adUnits, { [adUnitCode]: adUnit })
-          })
-          sendMessage(auction.auctionId)
-          break
+            const adUnit = convertReplicatedAdUnit(find(cache.auctions[auction.auctionId].adUnits, adUnit => adUnit.code === adUnitCode));
+            Object.assign(cache.adUnits, { [adUnitCode]: adUnit });
+          });
+          sendMessage(auction.auctionId);
+          break;
         }
         case EVENTS.BID_WON: {
           /** @type {Bid} */
-          let bidWonEvent = args
-          let { auctionId, requestId } = bidWonEvent
+          let bidWonEvent = args;
+          let { auctionId, requestId } = bidWonEvent;
           Object.assign(cache.auctions[auctionId].bids[requestId], bidWonEvent, {
             noBid: false,
             prebidWon: true,
             bidWon: true,
             timeout: false,
-          })
-          // clearTimeout(cache.timeouts[auctionId])
+          });
+          // clearTimeout(cache.timeouts[auctionId]);
           // cache.timeouts[auctionId] = setTimeout(() => {
-          sendMessage(auctionId)
-          // }, config.getConfig('bidderTimeout'))
-          break
+          sendMessage(auctionId);
+          // }, config.getConfig('bidderTimeout'));
+          break;
         }
         default:
-          break
+          break;
       }
     } catch (error) {
-      logError({ eventType, args, error })
+      logError({ eventType, args, error });
     }
   }
-})
+});
 
 /** @type {(auctionId: string) => void} */
 const sendMessage = (auctionId) => {
-  let { adUnitCodes, auctionEnd, aidSuffix, auctionStatus, bids } = cache.auctions[auctionId]
-  const adUnits = Object.values(cache.adUnits).filter(adUnit => adUnitCodes.includes(adUnit.code))
-  logInfo(adUnits)
+  let { adUnitCodes, auctionEnd, aidSuffix, auctionStatus, bids } = cache.auctions[auctionId];
+  const adUnits = Object.values(cache.adUnits).filter(adUnit => adUnitCodes.includes(adUnit.code));
+  logInfo(adUnits);
 
   const payload = {
     auctionId: aidSuffix ? `${auctionId}_${aidSuffix}` : auctionId,
@@ -180,7 +180,7 @@ const sendMessage = (auctionId) => {
     bids: Object.values(bids).map(bid => {
       const { noBid, prebidWon, bidWon, timeout, adId, adUnitCode, adUrl, bidder, status, netRevenue, cpm, currency, originalCpm, originalCurrency, requestId, size, source, timeToRespond } = bid
       /** @type {AdUnit} */
-      const adUnit = find(adUnits, adUnit => adUnit.code === adUnitCode) || {}
+      const adUnit = find(adUnits, adUnit => adUnit.code === adUnitCode) || {};
       return {
         noBid,
         prebidWon,
@@ -205,24 +205,24 @@ const sendMessage = (auctionId) => {
           ...bid,
           ad: undefined
         },
-      }
+      };
     }),
     timestamp: Date.now(),
     auctionEnd,
     auctionStatus,
   }
-  ajax(url, () => logInfo(`[sendMessage] ${Date.now()} :`, payload), JSON.stringify(payload), { contentType: 'application/json', method: 'POST' })
+  ajax(url, () => logInfo(`[sendMessage] ${Date.now()} :`, payload), JSON.stringify(payload), { contentType: 'application/json', method: 'POST' });
 }
 
-fluctAnalyticsAdapter.originEnableAnalytics = fluctAnalyticsAdapter.enableAnalytics
+fluctAnalyticsAdapter.originEnableAnalytics = fluctAnalyticsAdapter.enableAnalytics;
 fluctAnalyticsAdapter.enableAnalytics = (config) => {
-  fluctAnalyticsAdapter.initOptions = config.options
-  fluctAnalyticsAdapter.originEnableAnalytics(config)
-}
+  fluctAnalyticsAdapter.initOptions = config.options;
+  fluctAnalyticsAdapter.originEnableAnalytics(config);
+};
 
 adapterManager.registerAnalyticsAdapter({
   adapter: fluctAnalyticsAdapter,
   code: 'fluct',
-})
+});
 
-export default fluctAnalyticsAdapter
+export default fluctAnalyticsAdapter;

--- a/modules/fluctAnalyticsAdapter.js
+++ b/modules/fluctAnalyticsAdapter.js
@@ -51,16 +51,20 @@ const getAdUnitMap = () => window.googletag.pubads().getSlots().reduce((prev, sl
 export const convertReplicatedAdUnit = (_adUnit, adUnits = $$PREBID_GLOBAL$$.adUnits, slots = getAdUnitMap()) => {
   /** @type {AdUnit} */
   const adUnit = deepClone(_adUnit);
-  try {
-    if (isBrowsiId(adUnit.code)) {
-      const adUnitPath = slots[adUnit.code];
+  if (isBrowsiId(adUnit.code)) {
+    const adUnitPath = slots[adUnit.code];
+    try {
       const { analytics, code, mediaTypes: { banner: { name } } } = find(adUnits, adUnit => adUnit.path === adUnitPath);
       adUnit.analytics = analytics;
       adUnit._code = code;
       adUnit.mediaTypes.banner.name = name;
+    } catch (_error) {
+      logError({
+        message: '対応するDWIDを持つ枠が見つかりませんでした。',
+        adUnitCode: adUnit.code,
+        adUnitPath,
+      });
     }
-  } catch (_error) {
-    logError(`ad unit not found with same path ${adUnitPath} as ${adUnit.code}.`);
   }
   adUnit.bids = undefined;
   return adUnit;

--- a/test/spec/modules/fluctAnalyticsAdapter_spec.js
+++ b/test/spec/modules/fluctAnalyticsAdapter_spec.js
@@ -12,6 +12,7 @@ import $$PREBID_GLOBAL$$ from '../../../src/prebid';
 const adUnits = [
   {
     'code': 'div-gpt-ad-1587114265584-0',
+    'path': '/62532913/p_fluctmagazine_320x50_surface_15377',
     'mediaTypes': {
       'banner': {
         'sizes': [

--- a/test/spec/modules/fluctAnalyticsAdapter_spec.js
+++ b/test/spec/modules/fluctAnalyticsAdapter_spec.js
@@ -3,7 +3,6 @@ import fluctAnalyticsAdapter, {
 } from '../../../modules/fluctAnalyticsAdapter';
 import { expect } from 'chai';
 import * as events from 'src/events.js';
-import find from 'core-js-pure/features/array/find.js';
 import { EVENTS } from 'src/constants.json';
 import { server } from 'test/mocks/xhr.js';
 import * as mockGpt from '../integration/faker/googletag.js';
@@ -40,23 +39,6 @@ const adUnits = [
     ],
     'ext': {
       'device': 'SP'
-    }
-  },
-  {
-    'code': 'browsi_ad_0_ai_1_rc_0',
-    'mediaTypes': {
-      'banner': {
-        'sizes': [
-          [
-            300,
-            250
-          ],
-          [
-            336,
-            280
-          ]
-        ]
-      }
     }
   }
 ]
@@ -98,8 +80,24 @@ describe('複製枠のadUnitsをマッピングできる', () => {
         }
       }
     }
-    const adUnit = find(adUnits, adUnit => adUnit.code === 'browsi_ad_0_ai_1_rc_0')
-    const actual = convertReplicatedAdUnit(adUnit, adUnits, slots)
+    const adUnit = {
+      'code': 'browsi_ad_0_ai_1_rc_0',
+      'mediaTypes': {
+        'banner': {
+          'sizes': [
+            [
+              300,
+              250
+            ],
+            [
+              336,
+              280
+            ]
+          ]
+        }
+      }
+    }
+    const actual = convertReplicatedAdUnit(adUnit, [...adUnits, adUnit], slots)
     expect(expected).to.deep.equal(actual)
   })
 })
@@ -200,7 +198,6 @@ describe('fluct analytics adapter', () => {
   it('EVENT: `AUCTION_END` 時に値を送信できる', () => {
     events.emit(EVENTS.AUCTION_INIT, MOCK.AUCTION_INIT)
     events.emit(EVENTS.AUCTION_END, MOCK.AUCTION_END)
-    events.emit(EVENTS.SET_TARGETING, MOCK.SET_TARGETING)
     expect(server.requests.length).to.equal(1)
 
     const actual = JSON.parse(server.requests[0].requestBody)

--- a/test/spec/modules/fluctAnalyticsAdapter_spec.js
+++ b/test/spec/modules/fluctAnalyticsAdapter_spec.js
@@ -200,8 +200,87 @@ describe('fluct analytics adapter', () => {
     events.emit(EVENTS.AUCTION_END, MOCK.AUCTION_END)
     expect(server.requests.length).to.equal(1)
 
-    const actual = JSON.parse(server.requests[0].requestBody)
-    expect(actual.auctionId).to.equal(MOCK.AUCTION_END.auctionId)
-    expect(actual.adUnits.every(adUnit => adUnit.analytics)).to.equal(true)
+    const { auctionId, adUnits, bidsReceived } = MOCK.AUCTION_END
+    const expected = {
+      auctionId,
+      adUnits,
+      timestamp: undefined,
+      auctionEnd: undefined,
+      "bids": [
+        {
+          "noBid": false,
+          "prebidWon": true,
+          "bidWon": false,
+          "timeout": false,
+          "status": "rendered",
+          "adId": "5c28bc93-b1a0-481b-ae59-0641f316ad1a",
+          "adUnitCode": "div-gpt-ad-1587114265584-0",
+          "bidder": "criteo",
+          "netRevenue": true,
+          "cpm": 5.386152744293213,
+          "currency": "JPY",
+          "originalCpm": 5.386152744293213,
+          "originalCurrency": "JPY",
+          "requestId": "22697ff3e5bf7ee",
+          "size": "320x100",
+          "source": "client",
+          "timeToRespond": 216,
+          "bid": {
+            "bidderCode": "criteo",
+            "width": 320,
+            "height": 100,
+            "statusMessage": "Bid available",
+            "adId": "5c28bc93-b1a0-481b-ae59-0641f316ad1a",
+            "requestId": "22697ff3e5bf7ee",
+            "mediaType": "banner",
+            "source": "client",
+            "cpm": 5.386152744293213,
+            "currency": "JPY",
+            "netRevenue": true,
+            "ttl": 60,
+            "creativeId": "11017985",
+            "dealId": "",
+            "originalCpm": 5.386152744293213,
+            "originalCurrency": "JPY",
+            "meta": {},
+            "auctionId": "eeca6754-525b-4c4c-a697-b06b1fc6c352",
+            "responseTimestamp": 1635837149448,
+            "requestTimestamp": 1635837149232,
+            "bidder": "criteo",
+            "adUnitCode": "div-gpt-ad-1587114265584-0",
+            "timeToRespond": 216,
+            "pbLg": "5.00",
+            "pbMg": "5.30",
+            "pbHg": "5.38",
+            "pbAg": "5.30",
+            "pbDg": "5.35",
+            "pbCg": "4.00",
+            "size": "320x100",
+            "adserverTargeting": {
+              "fbs_bidder": "criteo",
+              "fbs_adid": "5c28bc93-b1a0-481b-ae59-0641f316ad1a",
+              "fbs_pb": "4.00",
+              "fbs_size": "320x100",
+              "fbs_source": "client",
+              "fbs_format": "banner",
+              "fbs_adomain": ""
+            },
+            "status": "rendered",
+            "params": [
+              {
+                "networkId": "11021"
+              }
+            ],
+            "noBid": false,
+            "prebidWon": true,
+            "bidWon": false,
+            "timeout": false
+          }
+        }
+      ],
+      "auctionStatus": "completed"
+    }
+    const actual = Object.assign(JSON.parse(server.requests[0].requestBody), { timestamp: undefined, auctionEnd: undefined })
+    expect(expected).to.deep.equal(actual)
   })
 })


### PR DESCRIPTION
- [adUnit[].code をdiv-idからad unit pathに変更するwrapperに追従](https://vg-ceg.backlog.com/view/FLUCT_SSP-15310)
- #12 で変更したauctionEnd eventの送信タイミングを戻す
  - 全てnoBidのケースで送信しないため
  - browsi auctionは `googletag.pubads()?.addEventListener('slotOnload'` で送信する
- browsi複製枠から対応するdwidを取得できなかった際のエラーハンドリング

動作確認 && CI: https://github.com/voyagegroup/fluct_tag_manager/pull/712