### PR TITLE
Update to Prebid.js v8.32.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,12 +11,25 @@ module.exports = {
       node: {
         moduleDirectory: ['node_modules', './']
       }
+    },
+    'jsdoc': {
+      mode: 'typescript',
+      tagNamePreference: {
+        'tag constructor': 'constructor',
+        extends: 'extends',
+        method: 'method',
+        return: 'return',
+      }
     }
   },
-  extends: 'standard',
+  extends: [
+    'standard',
+    'plugin:jsdoc/recommended'
+  ],
   plugins: [
     'prebid',
-    'import'
+    'import',
+    'jsdoc'
   ],
   globals: {
     'BROWSERSTACK_USERNAME': false,
@@ -46,6 +59,24 @@ module.exports = {
     'no-undef': 2,
     'no-useless-escape': 'off',
     'no-console': 'error',
+    'jsdoc/check-types': 'off',
+    'jsdoc/newline-after-description': 'off',
+    'jsdoc/require-jsdoc': 'off',
+    'jsdoc/require-param': 'off',
+    'jsdoc/require-param-description': 'off',
+    'jsdoc/require-param-name': 'off',
+    'jsdoc/require-param-type': 'off',
+    'jsdoc/require-property': 'off',
+    'jsdoc/require-property-description': 'off',
+    'jsdoc/require-property-name': 'off',
+    'jsdoc/require-property-type': 'off',
+    'jsdoc/require-returns': 'off',
+    'jsdoc/require-returns-check': 'off',
+    'jsdoc/require-returns-description': 'off',
+    'jsdoc/require-returns-type': 'off',
+    'jsdoc/require-yields': 'off',
+    'jsdoc/require-yields-check': 'off',
+    'jsdoc/tag-lines': 'off'
   },
   overrides: Object.keys(allowedModules).map((key) => ({
     files: key + '/**/*.js',

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -57,7 +57,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -70,4 +70,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/integrationExamples/gpt/contxtfulRtdProvider_example.html
+++ b/integrationExamples/gpt/contxtfulRtdProvider_example.html
@@ -1,0 +1,91 @@
+<html>
+
+<head>
+  <script src="http://localhost:9999/build/dev/prebid.js" async></script>
+  <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+  <script async>
+    const FAILSAFE_TIMEOUT = 8000;
+    const PREBID_TIMEOUT = 5000;
+
+    const bidders = [
+      {
+        bidder: 'appnexus',
+        params: {
+          placementId: 13144370
+        }
+      }
+    ];
+
+    var adUnits = [
+      {
+        code: 'div-gpt-ad-1460505748561-0',
+        mediaTypes: {
+          banner: {
+            sizes: [[300, 250], [300, 600]],
+          }
+        },
+        bids: bidders,
+      }
+    ];
+
+
+    var pbjs = pbjs || {};
+    pbjs.que = pbjs.que || [];
+    var googletag = googletag || {};
+    googletag.cmd = googletag.cmd || [];
+    googletag.cmd.push(function () {
+      googletag.pubads().disableInitialLoad();
+      googletag.defineSlot('/19968336/header-bid-tag-0', [[300, 250], [300, 600]], 'div-gpt-ad-1460505748561-0').addService(googletag.pubads());
+      googletag.pubads().enableSingleRequest();
+      googletag.enableServices();
+    });
+
+    pbjs.que.push(function () {
+      pbjs.setConfig({
+        debug: true,
+        realTimeData: {
+          auctionDelay: 100,
+          dataProviders: [
+            {
+              name: "contxtful",
+              waitForIt: true,
+              params: {
+                version: "Contact contact@contxtful.com for the API version",
+                customer: "Contact contact@contxtful.com for the customer ID"
+              }
+            }
+          ]
+        }
+      });
+      pbjs.addAdUnits(adUnits);
+      pbjs.requestBids({
+        bidsBackHandler: sendAdserverRequest,
+        timeout: PREBID_TIMEOUT
+      });
+    });
+
+    function sendAdserverRequest() {
+      if (pbjs.adserverRequestSent) return;
+      pbjs.adserverRequestSent = true;
+      googletag.cmd.push(function () {
+        pbjs.que.push(function () {
+          pbjs.setTargetingForGPTAsync();
+          googletag.pubads().refresh();
+        });
+      });
+    }
+
+    setTimeout(function () {
+      sendAdserverRequest();
+    }, FAILSAFE_TIMEOUT);
+
+  </script>
+</head>
+
+<body>
+  <h2>Contxtful RTD Provider</h2>
+  <div id='div-gpt-ad-1460505748561-0'></div>
+  </div>
+</body>
+
+</html>

--- a/libraries/cmp/cmpClient.js
+++ b/libraries/cmp/cmpClient.js
@@ -4,46 +4,46 @@ import {GreedyPromise} from '../../src/utils/promise.js';
  * @typedef {function} CMPClient
  *
  * @param {{}} params CMP parameters. Currently this is a subset of {command, callback, parameter, version}.
- * @param {bool} once if true, discard cross-frame event listeners once a reply message is received.
+ * @param {boolean} once if true, discard cross-frame event listeners once a reply message is received.
  * @returns {Promise<*>} a promise to the API's "result" - see the `mode` argument to `cmpClient` on how that's determined.
  * @property {boolean} isDirect true if the CMP is directly accessible (no postMessage required)
  * @property {() => void} close close the client; currently, this just stops listening for cross-frame messages.
- */
-
-/**
- * Returns a client function that can interface with a CMP regardless of where it's located.
- *
- * @param apiName name of the CMP api, e.g. "__gpp"
- * @param apiVersion? CMP API version
- * @param apiArgs? names of the arguments taken by the api function, in order.
- * @param callbackArgs? names of the cross-frame response payload properties that should be passed as callback arguments, in order
- * @param mode? controls the callbacks passed to the underlying API, and how the promises returned by the client are resolved.
- *
- *  The client behaves differently when it's provided a `callback` argument vs when it's not - for short, let's name these
- *  cases "subscriptions" and "one-shot calls" respectively:
- *
- *  With `mode: MODE_MIXED` (the default), promises returned on subscriptions are resolved to undefined when the callback
- *  is first run (that is, the promise resolves when the CMP replies, but what it replies with is discarded and
- *  left for the callback to deal with). For one-shot calls, the returned promise is resolved to the API's
- *  return value when it's directly accessible, or with the result from the first (and, presumably, the only)
- *  cross-frame reply when it's not;
- *
- *  With `mode: MODE_RETURN`, the returned promise always resolves to the API's return value - which is taken to be undefined
- *  when cross-frame;
- *
- *  With `mode: MODE_CALLBACK`, the underlying API is expected to never directly return anything significant; instead,
- *  it should always accept a callback and - for one-shot calls - invoke it only once with the result. The client will
- *  automatically generate an appropriate callback for one-shot calls and use the result it's given to resolve
- *  the returned promise. Subscriptions are treated in the same way as MODE_MIXED.
- *
- * @param win
- * @returns {CMPClient} CMP invocation function (or null if no CMP was found).
  */
 
 export const MODE_MIXED = 0;
 export const MODE_RETURN = 1;
 export const MODE_CALLBACK = 2;
 
+/**
+ * Returns a client function that can interface with a CMP regardless of where it's located.
+ *
+ * @param {object} obj
+ * @param obj.apiName name of the CMP api, e.g. "__gpp"
+ * @param [obj.apiVersion] CMP API version
+ * @param [obj.apiArgs] names of the arguments taken by the api function, in order.
+ * @param [obj.callbackArgs] names of the cross-frame response payload properties that should be passed as callback arguments, in order
+ * @param [obj.mode] controls the callbacks passed to the underlying API, and how the promises returned by the client are resolved.
+ *
+ * The client behaves differently when it's provided a `callback` argument vs when it's not - for short, let's name these
+ * cases "subscriptions" and "one-shot calls" respectively:
+ *
+ * With `mode: MODE_MIXED` (the default), promises returned on subscriptions are resolved to undefined when the callback
+ * is first run (that is, the promise resolves when the CMP replies, but what it replies with is discarded and
+ * left for the callback to deal with). For one-shot calls, the returned promise is resolved to the API's
+ * return value when it's directly accessible, or with the result from the first (and, presumably, the only)
+ * cross-frame reply when it's not;
+ *
+ * With `mode: MODE_RETURN`, the returned promise always resolves to the API's return value - which is taken to be undefined
+ * when cross-frame;
+ *
+ * With `mode: MODE_CALLBACK`, the underlying API is expected to never directly return anything significant; instead,
+ * it should always accept a callback and - for one-shot calls - invoke it only once with the result. The client will
+ * automatically generate an appropriate callback for one-shot calls and use the result it's given to resolve
+ * the returned promise. Subscriptions are treated in the same way as MODE_MIXED.
+ *
+ * @param win
+ * @returns {CMPClient} CMP invocation function (or null if no CMP was found).
+ */
 export function cmpClient(
   {
     apiName,

--- a/libraries/ortbConverter/README.md
+++ b/libraries/ortbConverter/README.md
@@ -80,8 +80,7 @@ However, there are two restrictions (to avoid them, use the [other customization
     )   
     ```
 
-<a id="fine-customization" />
-### Fine grained customization - imp, request, bidResponse, response
+### <a id="fine-customization" /> Fine grained customization - imp, request, bidResponse, response
 
 When invoked, `toORTB({bidRequests, bidderRequest})` first loops through each request in `bidRequests`, converting them into ORTB `imp` objects.
 It then packages them into a single ORTB request, adding other parameters that are not imp-specific (such as for example `request.tmax`).
@@ -91,7 +90,7 @@ a single return value.
 
 You can customize each of these steps using the `ortbConverter` arguments `imp`, `request`, `bidResponse` and `response`:
 
-### <a id="imp" />Customizing imps: `imp(buildImp, bidRequest, context)`
+### <a id="imp" /> Customizing imps: `imp(buildImp, bidRequest, context)`
 
 Invoked once for each input `bidRequest`; should return the ORTB `imp` object to include in the request.
 The arguments are:
@@ -101,7 +100,7 @@ The arguments are:
 - `context`: a [context object](#context) that contains at least:
    - `bidderRequest`: the `bidderRequest` argument passed to `toORTB`.
    
-#### <a id="params" />Example: attaching custom bid params
+#### <a id="params" /> Example: attaching custom bid params
 
 ```javascript
 const converter = ortbConverter({
@@ -351,7 +350,7 @@ const converter = ortbConverter({
 - the `context` argument of `ortbConverter`: e.g. `ortbConverter({context: {ttl: 30}})`. This will set `context.ttl = 30` globally for the converter.
 - the `context` argument of `toORTB`: e.g. `converter.toORTB({bidRequests, bidderRequest, context: {ttl: 30}})`. This will set `context.ttl = 30` only for this request.
 
-### <a id="special-context"/> Special `context` properties
+### <a id="special-context" /> Special `context` properties
 
 For ease of use, the conversion logic gives special meaning to some context properties:
 

--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -47,7 +47,8 @@
       "adqueryIdSystem",
       "gravitoIdSystem",
       "freepassIdSystem",
-      "operaadsIdSystem"
+      "operaadsIdSystem",
+      "mygaruIdSystem"
     ],
     "adpod": [
       "freeWheelAdserverVideo",

--- a/modules/ad2ictionBidAdapter.js
+++ b/modules/ad2ictionBidAdapter.js
@@ -1,0 +1,59 @@
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER } from '../src/mediaTypes.js';
+import { getStorageManager } from '../src/storageManager.js';
+
+export const BIDDER_CODE = 'ad2iction';
+export const SUPPORTED_AD_TYPES = [BANNER];
+export const API_ENDPOINT = 'https://ads.ad2iction.com/html/prebid/';
+export const API_VERSION_NUMBER = 3;
+export const COOKIE_NAME = 'ad2udid';
+
+export const storage = getStorageManager({ bidderCode: BIDDER_CODE });
+
+export const spec = {
+  code: BIDDER_CODE,
+  aliases: ['ad2'],
+  supportedMediaTypes: SUPPORTED_AD_TYPES,
+  isBidRequestValid: (bid) => {
+    return !!bid.params.id && typeof bid.params.id === 'string';
+  },
+  buildRequests: (validBidRequests, bidderRequest) => {
+    const ids = validBidRequests.map((bid) => {
+      return { bannerId: bid.params.id, bidId: bid.bidId };
+    });
+
+    const options = {
+      contentType: 'application/json',
+      withCredentials: false,
+    };
+
+    const udid = storage.cookiesAreEnabled() && storage.getCookie(COOKIE_NAME);
+
+    const data = {
+      ids: JSON.stringify(ids),
+      ortb2: bidderRequest.ortb2,
+      refererInfo: bidderRequest.refererInfo,
+      v: API_VERSION_NUMBER,
+      udid: udid || '',
+      _: Math.round(new Date().getTime()),
+    };
+
+    return {
+      method: 'POST',
+      url: API_ENDPOINT,
+      data,
+      options,
+    };
+  },
+  interpretResponse: (serverResponse, bidRequest) => {
+    if (!Array.isArray(serverResponse.body)) {
+      return [];
+    }
+
+    const bidResponses = serverResponse.body;
+
+    return bidResponses;
+  },
+};
+
+registerBidder(spec);

--- a/modules/ad2ictionBidAdapter.md
+++ b/modules/ad2ictionBidAdapter.md
@@ -1,0 +1,30 @@
+# Overview
+
+**Module Name**: Ad2iction Bidder Adapter
+**Module Type**: Bidder Adapter
+**Maintainer**: prebid@ad2iction.com
+
+# Description
+
+The Ad2iction Bidding adapter requires setup before beginning. Please contact us on https://www.ad2iction.com.
+
+# Sample Ad Unit Config
+```
+var adUnits = [
+   // Banner adUnit
+   {
+      code: 'banner-div',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250], [336, 280]]
+        }
+      },
+      bids: [{
+         bidder: 'ad2iction',
+         params: {
+           id: 'accepted-uuid'
+         }
+       }]
+   }
+];
+```

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -700,9 +700,9 @@ function getPageDimensions() {
 }
 
 /**
-* @todo Move to prebid Core as Utils.
-* @returns
-*/
+ * @todo Move to prebid Core as Utils.
+ * @returns
+ */
 function getViewPortDimensions() {
   if (!isSafeFrameWindow() && !canAccessTopWindow()) {
     return '';
@@ -832,8 +832,8 @@ function getPrintNumber(adUnitCode, bidderRequest) {
 }
 
 /**
-  * domLoading feature is computed on window.top if reachable.
-  */
+ * domLoading feature is computed on window.top if reachable.
+ */
 function getDomLoadingDuration() {
   let domLoadingDuration = -1;
   let performance;
@@ -1020,6 +1020,9 @@ export const spec = {
         }
       }
 
+      // Enforce the organizationId param to be a string
+      bidRequest.params.organizationId = bidRequest.params.organizationId.toString();
+
       // Force the Data Layer key and value to be a String
       if (bidRequest.params.dataLayer) {
         if (isStr(bidRequest.params.dataLayer) || isNumber(bidRequest.params.dataLayer) || isArray(bidRequest.params.dataLayer) || isFn(bidRequest.params.dataLayer)) {
@@ -1120,30 +1123,36 @@ export const spec = {
         bidRequest.gpid = gpid;
       }
 
+      // store the whole bidRequest (adUnit) object in the ADAGIO namespace.
       storeRequestInAdagioNS(bidRequest);
 
-      // Remove these fields at the very end, so we can still use them before.
-      delete bidRequest.transactionId;
-      delete bidRequest.ortb2Imp;
-      delete bidRequest.ortb2;
-      delete bidRequest.sizes;
+      // Remove some params that are not needed on the server side.
+      delete bidRequest.params.siteId;
 
-      return bidRequest;
+      // whitelist the fields that are allowed to be sent to the server.
+      const adUnit = {
+        adUnitCode: bidRequest.adUnitCode,
+        auctionId: bidRequest.auctionId,
+        bidder: bidRequest.bidder,
+        bidId: bidRequest.bidId,
+        params: bidRequest.params,
+        features: bidRequest.features,
+        gpid: bidRequest.gpid,
+        mediaTypes: bidRequest.mediaTypes,
+        nativeParams: bidRequest.nativeParams,
+        score: bidRequest.score,
+        transactionId: bidRequest.transactionId,
+      }
+
+      return adUnit;
     });
 
     // Group ad units by organizationId
     const groupedAdUnits = adUnits.reduce((groupedAdUnits, adUnit) => {
-      const adUnitCopy = deepClone(adUnit);
-      adUnitCopy.params.organizationId = adUnitCopy.params.organizationId.toString();
+      const organizationId = adUnit.params.organizationId
 
-      // remove useless props
-      delete adUnitCopy.floorData;
-      delete adUnitCopy.params.siteId;
-      delete adUnitCopy.userId;
-      delete adUnitCopy.userIdAsEids;
-
-      groupedAdUnits[adUnitCopy.params.organizationId] = groupedAdUnits[adUnitCopy.params.organizationId] || [];
-      groupedAdUnits[adUnitCopy.params.organizationId].push(adUnitCopy);
+      groupedAdUnits[organizationId] = groupedAdUnits[organizationId] || [];
+      groupedAdUnits[organizationId].push(adUnit);
 
       return groupedAdUnits;
     }, {});

--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -67,6 +67,11 @@ const NATIVE_INDEX = NATIVE_MODEL.reduce((acc, val, idx) => {
   return acc;
 }, {});
 
+const MULTI_FORMAT_SUFFIX = '__mf';
+const MULTI_FORMAT_SUFFIX_BANNER = 'b' + MULTI_FORMAT_SUFFIX;
+const MULTI_FORMAT_SUFFIX_VIDEO = 'v' + MULTI_FORMAT_SUFFIX;
+const MULTI_FORMAT_SUFFIX_NATIVE = 'n' + MULTI_FORMAT_SUFFIX;
+
 /**
  * Adapter for requesting bids from AdKernel white-label display platform
  */
@@ -173,6 +178,9 @@ export const spec = {
         ttl: 360,
         netRevenue: true
       };
+      if (prBid.requestId.endsWith(MULTI_FORMAT_SUFFIX)) {
+        prBid.requestId = stripMultiformatSuffix(prBid.requestId);
+      }
       if ('banner' in imp) {
         prBid.mediaType = BANNER;
         prBid.width = rtbBid.w;
@@ -239,13 +247,13 @@ registerBidder(spec);
 function groupImpressionsByHostZone(bidRequests, refererInfo) {
   let secure = (refererInfo && refererInfo.page?.indexOf('https:') === 0);
   return Object.values(
-    bidRequests.map(bidRequest => buildImp(bidRequest, secure))
+    bidRequests.map(bidRequest => buildImps(bidRequest, secure))
       .reduce((acc, curr, index) => {
         let bidRequest = bidRequests[index];
         let {zoneId, host} = bidRequest.params;
         let key = `${host}_${zoneId}`;
         acc[key] = acc[key] || {host: host, zoneId: zoneId, imps: []};
-        acc[key].imps.push(curr);
+        acc[key].imps.push(...curr);
         return acc;
       }, {})
   );
@@ -264,61 +272,90 @@ function getBidFloor(bid, mediaType, sizes) {
 }
 
 /**
- *  Builds rtb imp object for single adunit
+ *  Builds rtb imp object(s) for single adunit
  *  @param bidRequest {BidRequest}
  *  @param secure {boolean}
  */
-function buildImp(bidRequest, secure) {
-  const imp = {
+function buildImps(bidRequest, secure) {
+  let imp = {
     'id': bidRequest.bidId,
     'tagid': bidRequest.adUnitCode
   };
-  var mediaType;
+  if (secure) {
+    imp.secure = 1;
+  }
   var sizes = [];
+  let mediaTypes = bidRequest.mediaTypes;
+  let isMultiformat = (~~!!mediaTypes?.banner + ~~!!mediaTypes?.video + ~~!!mediaTypes?.native) > 1;
+  let result = [];
+  let typedImp;
 
-  if (bidRequest.mediaTypes?.banner) {
+  if (mediaTypes?.banner) {
+    if (isMultiformat) {
+      typedImp = {...imp};
+      typedImp.id = imp.id + MULTI_FORMAT_SUFFIX_BANNER;
+    } else {
+      typedImp = imp;
+    }
     sizes = getAdUnitSizes(bidRequest);
-    let pbBanner = bidRequest.mediaTypes.banner;
-    imp.banner = {
+    let pbBanner = mediaTypes.banner;
+    typedImp.banner = {
       ...getDefinedParamsOrEmpty(bidRequest.ortb2Imp, BANNER_FPD),
       ...getDefinedParamsOrEmpty(pbBanner, BANNER_PARAMS),
       format: sizes.map(wh => parseGPTSingleSizeArrayToRtbSize(wh)),
       topframe: 0
     };
-    mediaType = BANNER;
-  } else if (bidRequest.mediaTypes?.video) {
-    let pbVideo = bidRequest.mediaTypes.video;
-    imp.video = {
+    initImpBidfloor(typedImp, bidRequest, sizes, isMultiformat ? '*' : BANNER);
+    result.push(typedImp);
+  }
+
+  if (mediaTypes?.video) {
+    if (isMultiformat) {
+      typedImp = {...imp};
+      typedImp.id = typedImp.id + MULTI_FORMAT_SUFFIX_VIDEO;
+    } else {
+      typedImp = imp;
+    }
+    let pbVideo = mediaTypes.video;
+    typedImp.video = {
       ...getDefinedParamsOrEmpty(bidRequest.ortb2Imp, VIDEO_FPD),
       ...getDefinedParamsOrEmpty(pbVideo, VIDEO_PARAMS)
     };
     if (pbVideo.playerSize) {
       sizes = pbVideo.playerSize[0];
-      imp.video = Object.assign(imp.video, parseGPTSingleSizeArrayToRtbSize(sizes) || {});
+      typedImp.video = Object.assign(typedImp.video, parseGPTSingleSizeArrayToRtbSize(sizes) || {});
     } else if (pbVideo.w && pbVideo.h) {
-      imp.video.w = pbVideo.w;
-      imp.video.h = pbVideo.h;
+      typedImp.video.w = pbVideo.w;
+      typedImp.video.h = pbVideo.h;
     }
-    mediaType = VIDEO;
-  } else if (bidRequest.mediaTypes?.native) {
-    let nativeRequest = buildNativeRequest(bidRequest.mediaTypes.native);
-    imp.native = {
+    initImpBidfloor(typedImp, bidRequest, sizes, isMultiformat ? '*' : VIDEO);
+    result.push(typedImp);
+  }
+
+  if (mediaTypes?.native) {
+    if (isMultiformat) {
+      typedImp = {...imp};
+      typedImp.id = typedImp.id + MULTI_FORMAT_SUFFIX_NATIVE;
+    } else {
+      typedImp = imp;
+    }
+    let nativeRequest = buildNativeRequest(mediaTypes.native);
+    typedImp.native = {
       ...getDefinedParamsOrEmpty(bidRequest.ortb2Imp, NATIVE_FPD),
       ver: '1.1',
       request: JSON.stringify(nativeRequest)
     };
-    mediaType = NATIVE;
-  } else {
-    throw new Error('Unsupported bid received');
+    initImpBidfloor(typedImp, bidRequest, sizes, isMultiformat ? '*' : NATIVE);
+    result.push(typedImp);
   }
-  let floor = getBidFloor(bidRequest, mediaType, sizes);
-  if (floor) {
-    imp.bidfloor = floor;
+  return result;
+}
+
+function initImpBidfloor(imp, bid, sizes, mediaType) {
+  let bidfloor = getBidFloor(bid, mediaType, sizes);
+  if (bidfloor) {
+    imp.bidfloor = bidfloor;
   }
-  if (secure) {
-    imp.secure = 1;
-  }
-  return imp;
 }
 
 function getDefinedParamsOrEmpty(object, params) {
@@ -642,4 +679,8 @@ function buildNativeAd(nativeResp) {
     });
   });
   return cleanObj(nativeAd);
+}
+
+function stripMultiformatSuffix(impid) {
+  return impid.substr(0, impid.length - MULTI_FORMAT_SUFFIX.length - 1);
 }

--- a/modules/admanBidAdapter.js
+++ b/modules/admanBidAdapter.js
@@ -4,6 +4,7 @@ import { isFn, deepAccess, logMessage } from '../src/utils.js';
 import {config} from '../src/config.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 
+const GVLID = 149;
 const BIDDER_CODE = 'adman';
 const AD_URL = 'https://pub.admanmedia.com/?c=o&m=multi';
 const URL_SYNC = 'https://sync.admanmedia.com';
@@ -57,6 +58,7 @@ function getUserId(eids, id, source, uidExt) {
 
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: GVLID,
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 
   isBidRequestValid: (bid) => {

--- a/modules/admaticBidAdapter.js
+++ b/modules/admaticBidAdapter.js
@@ -1,4 +1,4 @@
-import {getValue, logError, isEmpty, deepAccess, isArray, getBidIdParameter} from '../src/utils.js';
+import {getValue, formatQS, logError, deepAccess, isArray, getBidIdParameter} from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
 import { BANNER, VIDEO, NATIVE } from '../src/mediaTypes.js';
@@ -33,7 +33,8 @@ export const spec = {
     {code: 'pixad'}
   ],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
-  /** f
+  /**
+   * f
    * @param {object} bid
    * @return {boolean}
    */
@@ -56,18 +57,16 @@ export const spec = {
    * @return {ServerRequest}
    */
   buildRequests: (validBidRequests, bidderRequest) => {
+    const tmax = bidderRequest.timeout;
     const bids = validBidRequests.map(buildRequestObject);
-    const blacklist = bidderRequest.ortb2;
+    const ortb = bidderRequest.ortb2;
     const networkId = getValue(validBidRequests[0].params, 'networkId');
     const host = getValue(validBidRequests[0].params, 'host');
     const currency = config.getConfig('currency.adServerCurrency') || 'TRY';
     const bidderName = validBidRequests[0].bidder;
 
     const payload = {
-      user: {
-        ua: navigator.userAgent
-      },
-      blacklist: [],
+      ortb,
       site: {
         page: bidderRequest.refererInfo.page,
         ref: bidderRequest.refererInfo.page,
@@ -80,17 +79,59 @@ export const spec = {
       ext: {
         cur: currency,
         bidder: bidderName
-      }
+      },
+      schain: {},
+      regs: {
+        ext: {
+        }
+      },
+      user: {
+        ext: {}
+      },
+      at: 1,
+      tmax: parseInt(tmax)
     };
 
-    if (!isEmpty(blacklist.badv)) {
-      payload.blacklist = blacklist.badv;
-    };
+    if (bidderRequest && bidderRequest.gdprConsent && bidderRequest.gdprConsent.gdprApplies) {
+      const consentStr = (bidderRequest.gdprConsent.consentString)
+        ? bidderRequest.gdprConsent.consentString.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '') : '';
+      const gdpr = bidderRequest.gdprConsent.gdprApplies ? 1 : 0;
+      payload.regs.ext.gdpr = gdpr;
+      payload.regs.ext.consent = consentStr;
+    }
+
+    if (bidderRequest && bidderRequest.coppa) {
+      payload.regs.ext.coppa = bidderRequest.coppa === true ? 1 : (bidderRequest.coppa === false ? 0 : undefined);
+    }
+
+    if (bidderRequest && bidderRequest.ortb2?.regs?.gpp) {
+      payload.regs.ext.gpp = bidderRequest.ortb2?.regs?.gpp;
+    }
+
+    if (bidderRequest && bidderRequest.ortb2?.regs?.gpp_sid) {
+      payload.regs.ext.gpp_sid = bidderRequest.ortb2?.regs?.gpp_sid;
+    }
+
+    if (bidderRequest && bidderRequest.uspConsent) {
+      payload.regs.ext.uspIab = bidderRequest.uspConsent;
+    }
+
+    if (validBidRequests[0].schain) {
+      const schain = mapSchain(validBidRequests[0].schain);
+      if (schain) {
+        payload.schain = schain;
+      }
+    }
+
+    if (validBidRequests[0].userIdAsEids) {
+      const eids = { eids: validBidRequests[0].userIdAsEids };
+      payload.user.ext = { ...payload.user.ext, ...eids };
+    }
 
     if (payload) {
       switch (bidderName) {
         case 'pixad':
-          SYNC_URL = 'https://static.pixad.com.tr/sync.html';
+          SYNC_URL = 'https://static.cdn.pixad.com.tr/sync.html';
           break;
         default:
           SYNC_URL = 'https://cdn.serve.admatic.com.tr/showad/sync.html';
@@ -101,12 +142,36 @@ export const spec = {
     }
   },
 
-  getUserSyncs: function (syncOptions, responses) {
-    if (syncOptions.iframeEnabled) {
-      return [{
+  getUserSyncs: function (syncOptions, responses, gdprConsent, uspConsent, gppConsent) {
+    if (!hasSynced && syncOptions.iframeEnabled) {
+      // data is only assigned if params are available to pass to syncEndpoint
+      let params = {};
+
+      if (gdprConsent) {
+        if (typeof gdprConsent.gdprApplies === 'boolean') {
+          params['gdpr'] = Number(gdprConsent.gdprApplies);
+        }
+        if (typeof gdprConsent.consentString === 'string') {
+          params['gdpr_consent'] = gdprConsent.consentString;
+        }
+      }
+
+      if (uspConsent) {
+        params['us_privacy'] = encodeURIComponent(uspConsent);
+      }
+
+      if (gppConsent?.gppString) {
+        params['gpp'] = gppConsent.gppString;
+        params['gpp_sid'] = gppConsent.applicableSections?.toString();
+      }
+
+      params = Object.keys(params).length ? `?${formatQS(params)}` : '';
+
+      hasSynced = true;
+      return {
         type: 'iframe',
-        url: SYNC_URL
-      }];
+        url: SYNC_URL + params
+      };
     }
   },
 
@@ -155,6 +220,41 @@ export const spec = {
     return bidResponses;
   }
 };
+
+var hasSynced = false;
+
+export function resetUserSync() {
+  hasSynced = false;
+}
+
+/**
+ * @param {object} schain object set by Publisher
+ * @returns {object} OpenRTB SupplyChain object
+ */
+function mapSchain(schain) {
+  if (!schain) {
+    return null;
+  }
+  if (!validateSchain(schain)) {
+    logError('AdMatic: required schain params missing');
+    return null;
+  }
+  return schain;
+}
+
+/**
+ * @param {object} schain object set by Publisher
+ * @returns {object} bool
+ */
+function validateSchain(schain) {
+  if (!schain.nodes) {
+    return false;
+  }
+  const requiredFields = ['asi', 'sid', 'hp'];
+  return schain.nodes.every(node => {
+    return requiredFields.every(field => node[field]);
+  });
+}
 
 function isUrl(str) {
   try {

--- a/modules/admixerBidAdapter.js
+++ b/modules/admixerBidAdapter.js
@@ -14,6 +14,7 @@ const ALIASES = [
   {code: 'futureads', endpoint: 'https://ads.futureads.io/prebid.1.2.aspx'},
   {code: 'smn', endpoint: 'https://ads.smn.rs/prebid.1.2.aspx'},
   {code: 'admixeradx', endpoint: 'https://inv-nets.admixer.net/adxprebid.1.2.aspx'},
+  {code: 'admixerwl', endpoint: 'https://inv-nets-adxwl.admixer.com/adxwlprebid.aspx'},
 ];
 export const spec = {
   code: BIDDER_CODE,
@@ -23,7 +24,9 @@ export const spec = {
    * Determines whether or not the given bid request is valid.
    */
   isBidRequestValid: function (bid) {
-    return !!bid.params.zone;
+    return bid.bidder === 'admixerwl'
+      ? !!bid.params.clientId && !!bid.params.endpointId
+      : !!bid.params.zone;
   },
   /**
    * Make a server request from the list of BidRequests.
@@ -76,10 +79,11 @@ export const spec = {
       imp.ortb2 && delete imp.ortb2;
       payload.imps.push(imp);
     });
+
+    let urlForRequest = endpointUrl || getEndpointUrl(bidderRequest.bidderCode)
     return {
       method: 'POST',
-      url:
-        endpointUrl || getEndpointUrl(bidderRequest.bidderCode),
+      url: bidderRequest.bidderCode === 'admixerwl' ? `${urlForRequest}?client=${payload.imps[0]?.params?.clientId}` : urlForRequest,
       data: payload,
     };
   },

--- a/modules/admixerBidAdapter.md
+++ b/modules/admixerBidAdapter.md
@@ -50,3 +50,48 @@ Please use ```admixer``` as the bidder code.
            },
        ];
 ```
+
+### AdmixerWL Test Parameters
+```
+    var adUnits = [
+           {
+               code: 'desktop-banner-ad-div',
+               sizes: [[300, 250]],  // a display size
+               bids: [
+                   {
+                       bidder: "admixer",
+                       params: {
+                           endpointId: 41512,
+                           clientId: 62
+                       }
+                   }
+               ]
+           },{
+               code: 'mobile-banner-ad-div',
+               sizes: [[300, 50]],   // a mobile size
+               bids: [
+                   {
+                       bidder: "admixer",
+                       params: {
+                           endpointId: 41512,
+                           clientId: 62
+                       }
+                   }
+               ]
+           },{
+               code: 'video-ad',
+               sizes: [[300, 50]],
+               mediaType: 'video',
+               bids: [
+                   {
+                       bidder: "admixer",
+                       params: {
+                           endpointId: 41512,
+                           clientId: 62
+                       }
+                   }
+               ]
+           },
+       ];
+```
+

--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -18,26 +18,26 @@ const VALID_BID_TYPES = ['netBid', 'grossBid'];
 const META_DATA_KEY = 'adn.metaData';
 
 export const misc = {
-  getUnixTimestamp: function(addDays, asMinutes) {
+  getUnixTimestamp: function (addDays, asMinutes) {
     const multiplication = addDays / (asMinutes ? 1440 : 1);
     return Date.now() + (addDays && addDays > 0 ? (1000 * 60 * 60 * 24 * multiplication) : 0);
   }
 };
 
-const storageTool = (function() {
-  const storage = getStorageManager({bidderCode: BIDDER_CODE});
+const storageTool = (function () {
+  const storage = getStorageManager({ bidderCode: BIDDER_CODE });
   let metaInternal;
 
-  const getMetaInternal = function() {
+  const getMetaInternal = function () {
     if (!storage.localStorageIsEnabled()) {
-      return {};
+      return [];
     }
 
     let parsedJson;
     try {
       parsedJson = JSON.parse(storage.getDataFromLocalStorage(META_DATA_KEY));
     } catch (e) {
-      return {};
+      return [];
     }
 
     let filteredEntries = parsedJson ? parsedJson.filter((datum) => {
@@ -57,24 +57,24 @@ const storageTool = (function() {
     return filteredEntries;
   };
 
-  const setMetaInternal = function(apiResponse) {
+  const setMetaInternal = function (apiResponse) {
     if (!storage.localStorageIsEnabled()) {
       return;
     }
 
-    const updateVoidAuIds = function(currentVoidAuIds, auIdsAsString) {
-      const newAuIds = auIdsAsString ? auIdsAsString.split(';') : [];
+    const updateVoidAuIds = function (currentVoidAuIds, auIdsAsString) {
+      const newAuIds = isStr(auIdsAsString) ? auIdsAsString.split(';') : [];
       const notNewExistingAuIds = currentVoidAuIds.filter(auIdObj => {
         return newAuIds.indexOf(auIdObj.value) < -1;
       }) || [];
       const oneDayFromNow = misc.getUnixTimestamp(1);
       const apiIdsArray = newAuIds.map(auId => {
-        return {exp: oneDayFromNow, auId: auId};
+        return { exp: oneDayFromNow, auId: auId };
       }) || [];
       return notNewExistingAuIds.concat(apiIdsArray) || [];
     }
 
-    const metaAsObj = getMetaInternal().reduce((a, entry) => ({...a, [entry.key]: {value: entry.value, exp: entry.exp}}), {});
+    const metaAsObj = getMetaInternal().reduce((a, entry) => ({ ...a, [entry.key]: { value: entry.value, exp: entry.exp } }), {});
     for (const key in apiResponse) {
       if (key !== 'voidAuIds') {
         metaAsObj[key] = {
@@ -83,9 +83,9 @@ const storageTool = (function() {
         }
       }
     }
-    const currentAuIds = updateVoidAuIds(metaAsObj.voidAuIds || [], apiResponse.voidAuIds || []);
+    const currentAuIds = updateVoidAuIds(metaAsObj.voidAuIds || [], apiResponse.voidAuIds);
     if (currentAuIds.length > 0) {
-      metaAsObj.voidAuIds = {value: currentAuIds};
+      metaAsObj.voidAuIds = { value: currentAuIds };
     }
     const metaDataForSaving = Object.entries(metaAsObj).map((entrySet) => {
       if (entrySet[0] === 'voidAuIds') {
@@ -103,7 +103,7 @@ const storageTool = (function() {
     storage.setDataInLocalStorage(META_DATA_KEY, JSON.stringify(metaDataForSaving));
   };
 
-  const getUsi = function(meta, ortb2) {
+  const getUsi = function (meta, ortb2) {
     let usi = (meta && meta.usi) ? meta.usi : false;
     if (ortb2 && ortb2.user && ortb2.user.id) {
       usi = ortb2.user.id
@@ -128,9 +128,9 @@ const storageTool = (function() {
   }
 
   return {
-    refreshStorage: function(bidderRequest) {
+    refreshStorage: function (bidderRequest) {
       const ortb2 = bidderRequest.ortb2 || {};
-      metaInternal = getMetaInternal().reduce((a, entry) => ({...a, [entry.key]: entry.value}), {});
+      metaInternal = getMetaInternal().reduce((a, entry) => ({ ...a, [entry.key]: entry.value }), {});
       metaInternal.usi = getUsi(metaInternal, ortb2);
       if (!metaInternal.usi) {
         delete metaInternal.usi;
@@ -142,21 +142,21 @@ const storageTool = (function() {
       }
       metaInternal.segments = getSegmentsFromOrtb(ortb2);
     },
-    saveToStorage: function(serverData) {
+    saveToStorage: function (serverData) {
       setMetaInternal(serverData);
     },
-    getUrlRelatedData: function() {
-      const {segments, usi, voidAuIdsArray} = metaInternal;
-      return {segments, usi, voidAuIdsArray};
+    getUrlRelatedData: function () {
+      const { segments, usi, voidAuIdsArray } = metaInternal;
+      return { segments, usi, voidAuIdsArray };
     },
-    getPayloadRelatedData: function() {
-      const {segments, usi, userId, voidAuIdsArray, voidAuIds, ...payloadRelatedData} = metaInternal;
+    getPayloadRelatedData: function () {
+      const { segments, usi, userId, voidAuIdsArray, voidAuIds, ...payloadRelatedData } = metaInternal;
       return payloadRelatedData;
     }
   };
 })();
 
-const validateBidType = function(bidTypeOption) {
+const validateBidType = function (bidTypeOption) {
   return VALID_BID_TYPES.indexOf(bidTypeOption || '') > -1 ? bidTypeOption : 'bid';
 }
 
@@ -177,10 +177,13 @@ export const spec = {
     const queryParamsAndValues = [];
     queryParamsAndValues.push('tzo=' + new Date().getTimezoneOffset())
     queryParamsAndValues.push('format=json')
-
     const gdprApplies = deepAccess(bidderRequest, 'gdprConsent.gdprApplies');
     const consentString = deepAccess(bidderRequest, 'gdprConsent.consentString');
-    if (gdprApplies !== undefined) queryParamsAndValues.push('consentString=' + consentString);
+    if (gdprApplies !== undefined) {
+      const flag = gdprApplies ? '1' : '0'
+      queryParamsAndValues.push('consentString=' + consentString);
+      queryParamsAndValues.push('gdpr=' + flag);
+    }
 
     storageTool.refreshStorage(bidderRequest);
 
@@ -194,6 +197,7 @@ export const spec = {
 
     const bidRequests = {};
     const networks = {};
+
     for (let i = 0; i < validBidRequests.length; i++) {
       const bid = validBidRequests[i];
       if ((urlRelatedMetaData.voidAuIdsArray && (urlRelatedMetaData.voidAuIdsArray.indexOf(bid.params.auId) > -1 || urlRelatedMetaData.voidAuIdsArray.indexOf(bid.params.auId.padStart(16, '0')) > -1))) {

--- a/modules/adpod.js
+++ b/modules/adpod.js
@@ -319,7 +319,7 @@ export function checkAdUnitSetupHook(fn, adUnits) {
  * @param {Object} videoMediaType 'mediaTypes.video' associated to bidResponse
  * @param {Object} bidResponse incoming bidResponse being evaluated by bidderFactory
  * @returns {boolean} return false if bid duration is deemed invalid as per adUnit configuration; return true if fine
-*/
+ */
 function checkBidDuration(videoMediaType, bidResponse) {
   const buffer = 2;
   let bidDuration = deepAccess(bidResponse, 'video.durationSeconds');

--- a/modules/adqueryBidAdapter.js
+++ b/modules/adqueryBidAdapter.js
@@ -17,7 +17,8 @@ export const spec = {
   gvlid: ADQUERY_GVLID,
   supportedMediaTypes: [BANNER],
 
-  /** f
+  /**
+   * f
    * @param {object} bid
    * @return {boolean}
    */

--- a/modules/ampliffyBidAdapter.js
+++ b/modules/ampliffyBidAdapter.js
@@ -1,0 +1,419 @@
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+import {logError, logInfo, triggerPixel} from '../src/utils.js';
+
+const BIDDER_CODE = 'ampliffy';
+const GVLID = 1258;
+const DEFAULT_ENDPOINT = 'bidder.ampliffy.com';
+const TTL = 600; // Time-to-Live - how long (in seconds) Prebid can use this bid.
+const LOG_PREFIX = 'AmpliffyBidder: ';
+
+function isBidRequestValid(bid) {
+  logInfo(LOG_PREFIX + 'isBidRequestValid: Code: ' + bid.adUnitCode + ': Param' + JSON.stringify(bid.params), bid.adUnitCode);
+  if (bid.params) {
+    if (!bid.params.placementId || !bid.params.format) return false;
+
+    if (bid.params.format.toLowerCase() !== 'video' && bid.params.format.toLowerCase() !== 'display' && bid.params.format.toLowerCase() !== 'all') return false;
+    if (bid.params.format.toLowerCase() === 'video' && !bid.mediaTypes['video']) return false;
+    if (bid.params.format.toLowerCase() === 'display' && !bid.mediaTypes['banner']) return false;
+
+    if (!bid.params.server || bid.params.server === '') {
+      const server = bid.params.type + bid.params.region + bid.params.adnetwork;
+      if (server && server !== '') bid.params.server = server;
+      else bid.params.server = DEFAULT_ENDPOINT;
+    }
+    return true;
+  }
+  return false;
+}
+
+function manageConsentArguments(bidderRequest) {
+  let consent = null;
+  if (bidderRequest?.gdprConsent) {
+    consent = {
+      gdpr: bidderRequest.gdprConsent.gdprApplies ? '1' : '0',
+    };
+    if (bidderRequest.gdprConsent.consentString) {
+      consent.consent_string = bidderRequest.gdprConsent.consentString;
+    }
+    if (bidderRequest.gdprConsent.addtlConsent && bidderRequest.gdprConsent.addtlConsent.indexOf('~') !== -1) {
+      consent.addtl_consent = bidderRequest.gdprConsent.addtlConsent;
+    }
+  }
+  return consent;
+}
+
+function buildRequests(validBidRequests, bidderRequest) {
+  const bidRequests = [];
+  for (const bidRequest of validBidRequests) {
+    for (const sizes of bidRequest.sizes) {
+      let extraParams = mergeParams(getDefaultParams(), bidRequest.params.extraParams);
+      // Apply GDPR parameters to request.
+      extraParams = mergeParams(extraParams, manageConsentArguments(bidderRequest));
+      const serverURL = getServerURL(bidRequest.params.server, sizes, bidRequest.params.placementId, extraParams);
+      logInfo(LOG_PREFIX + serverURL, 'requests');
+      extraParams.bidId = bidRequest.bidId;
+      bidRequests.push({
+        method: 'GET',
+        url: serverURL,
+        data: extraParams,
+        bidRequest,
+      });
+    }
+    logInfo(LOG_PREFIX + 'Building request from: ' + bidderRequest.url + ': ' + JSON.stringify(bidRequests), bidRequest.adUnitCode);
+  }
+  return bidRequests;
+}
+export function getDefaultParams() {
+  return {
+    ciu_szs: '1x1',
+    gdfp_req: '1',
+    env: 'vp',
+    output: 'xml_vast4',
+    unviewed_position_start: '1'
+  };
+}
+export function mergeParams(params, extraParams) {
+  if (extraParams) {
+    for (const k in extraParams) {
+      params[k] = extraParams[k];
+    }
+  }
+  return params;
+}
+export function paramsToQueryString(params) {
+  return Object.entries(params).filter(e => typeof e[1] !== 'undefined').map(e => {
+    if (e[1]) return encodeURIComponent(e[0]) + '=' + encodeURIComponent(e[1]);
+    else return encodeURIComponent(e[0]);
+  }).join('&');
+}
+const getCacheBuster = () => Math.floor(Math.random() * (9999999999 - 1000000000));
+
+// For testing purposes
+let currentUrl = null;
+export function getCurrentURL() {
+  if (!currentUrl) currentUrl = top.location.href;
+  return currentUrl;
+}
+export function setCurrentURL(url) {
+  currentUrl = url;
+}
+const getCurrentURLEncoded = () => encodeURIComponent(getCurrentURL());
+function getServerURL(server, sizes, iu, queryParams) {
+  const random = getCacheBuster();
+  const size = sizes[0] + 'x' + sizes[1];
+  let serverURL = '//' + server + '/gampad/ads';
+  queryParams.sz = size;
+  queryParams.iu = iu;
+  queryParams.url = getCurrentURL();
+  queryParams.description_url = getCurrentURL();
+  queryParams.correlator = random;
+
+  return serverURL;
+}
+function interpretResponse(serverResponse, bidRequest) {
+  const bidResponses = [];
+
+  const bidResponse = {};
+  let mediaType = 'video';
+  if (
+    bidRequest.bidRequest?.mediaTypes &&
+    !bidRequest.bidRequest.mediaTypes['video']
+  ) {
+    mediaType = 'banner';
+  }
+  bidResponse.requestId = bidRequest.bidRequest.bidId;
+  bidResponse.width = bidRequest.bidRequest?.sizes[0][0];
+  bidResponse.height = bidRequest.bidRequest?.sizes[0][1];
+  bidResponse.ttl = TTL;
+  bidResponse.creativeId = 'ampCreativeID134';
+  bidResponse.netRevenue = true;
+  bidResponse.mediaType = mediaType;
+  bidResponse.meta = {
+    advertiserDomains: [],
+  };
+  let xmlStr = serverResponse.body;
+  const xml = new window.DOMParser().parseFromString(xmlStr, 'text/xml');
+  const xmlData = parseXML(xml, bidResponse);
+  logInfo(LOG_PREFIX + 'Response from: ' + bidRequest.url + ': ' + JSON.stringify(xmlData), bidRequest.bidRequest.adUnitCode);
+  if (xmlData.cpm < 0 || !xmlData.creativeURL || !xmlData.bidUp) {
+    return [];
+  }
+  bidResponse.cpm = xmlData.cpm;
+  bidResponse.currency = xmlData.currency;
+
+  if (mediaType === 'video') {
+    logInfo(LOG_PREFIX + xmlData.creativeURL, 'requests');
+    bidResponse.vastUrl = xmlData.creativeURL;
+  } else {
+    bidResponse.adUrl = xmlData.creativeURL;
+  }
+  if (xmlData.trackingUrl) {
+    bidResponse.vastImpUrl = xmlData.trackingUrl;
+    bidResponse.trackingUrl = xmlData.trackingUrl;
+  }
+  bidResponses.push(bidResponse);
+  return bidResponses;
+}
+const replaceMacros = (txt, cpm, bid) => {
+  const size = bid.width + 'x' + bid.height;
+  txt = txt.replaceAll('%%CACHEBUSTER%%', getCacheBuster());
+  txt = txt.replaceAll('@@CACHEBUSTER@@', getCacheBuster());
+  txt = txt.replaceAll('%%REFERER%%', getCurrentURLEncoded());
+  txt = txt.replaceAll('@@REFERER@@', getCurrentURLEncoded());
+  txt = txt.replaceAll('%%REFERRER_URL_UNESC%%', getCurrentURLEncoded());
+  txt = txt.replaceAll('@@REFERRER_URL_UNESC@@', getCurrentURLEncoded());
+  txt = txt.replaceAll('%%PRICE_ESC%%', encodePrice(cpm));
+  txt = txt.replaceAll('@@PRICE_ESC@@', encodePrice(cpm));
+  txt = txt.replaceAll('%%SIZES%%', size);
+  txt = txt.replaceAll('@@SIZES@@', size);
+  return txt;
+}
+const encodePrice = (price) => {
+  price = parseFloat(price);
+  const s = 116.54;
+  const c = 1;
+  const a = 1;
+  let encodedPrice = s * Math.log10(price + a) + c;
+  encodedPrice = Math.min(200, encodedPrice);
+  encodedPrice = Math.round(Math.max(1, encodedPrice));
+
+  // Format the encoded price with leading zeros if necessary
+  const formattedEncodedPrice = encodedPrice.toString().padStart(3, '0');
+
+  // Build the encoding key
+  const encodingKey = `H--${formattedEncodedPrice}`;
+
+  return encodeURIComponent(`vch=${encodingKey}`);
+};
+
+function extractCT(xml) {
+  let ct = null;
+  try {
+    try {
+      const vastAdTagURI = xml.getElementsByTagName('VASTAdTagURI')[0]
+      if (vastAdTagURI) {
+        let url = null;
+        for (const childNode of vastAdTagURI.childNodes) {
+          if (childNode.nodeValue.trim().includes('http')) {
+            url = decodeURIComponent(childNode.nodeValue);
+          }
+        }
+        const urlParams = new URLSearchParams(url);
+        ct = urlParams.get('ct')
+      }
+    } catch (e) {
+    }
+    if (!ct) {
+      const geoExtensions = xml.querySelectorAll('Extension[type="geo"]');
+      geoExtensions.forEach((geoExtension) => {
+        const countryElement = geoExtension.querySelector('Country');
+        if (countryElement) {
+          ct = countryElement.textContent;
+        }
+      });
+    }
+  } catch (e) {}
+  return ct;
+}
+
+function extractCPM(htmlContent, ct, cpm) {
+  const cpmMapDiv = htmlContent.querySelectorAll('[cpmMap]')[0];
+  if (cpmMapDiv) {
+    let cpmMapJSON = JSON.parse(cpmMapDiv.getAttribute('cpmMap'));
+    if ((cpmMapJSON)) {
+      if (cpmMapJSON[ct]) {
+        cpm = cpmMapJSON[ct];
+      } else if (cpmMapJSON['default']) {
+        cpm = cpmMapJSON['default'];
+      }
+    }
+  }
+  return cpm;
+}
+
+function extractCurrency(htmlContent, currency) {
+  const currencyDiv = htmlContent.querySelectorAll('[cpmCurrency]')[0];
+  if (currencyDiv) {
+    const currencyValue = currencyDiv.getAttribute('cpmCurrency');
+    if (currencyValue && currencyValue !== '') {
+      currency = currencyValue;
+    }
+  }
+  return currency;
+}
+
+function extractCreativeURL(htmlContent, ct, cpm, bid) {
+  let creativeURL = null;
+  const creativeMap = htmlContent.querySelectorAll('[creativeMap]')[0];
+  if (creativeMap) {
+    const creativeMapString = creativeMap.getAttribute('creativeMap');
+
+    const creativeMapJSON = JSON.parse(creativeMapString);
+    let defaultURL = null;
+    for (const url of Object.keys(creativeMapJSON)) {
+      const geo = creativeMapJSON[url];
+      if (geo.includes(ct)) {
+        creativeURL = replaceMacros(url, cpm, bid);
+      } else if (geo.includes('default')) {
+        defaultURL = url;
+      }
+    }
+    if (!creativeURL && defaultURL) creativeURL = replaceMacros(defaultURL, cpm, bid);
+  }
+  return creativeURL;
+}
+
+function extractSyncs(htmlContent) {
+  let userSyncsJSON = null;
+  const userSyncs = htmlContent.querySelectorAll('[userSyncs]')[0];
+  if (userSyncs) {
+    const userSyncsString = userSyncs.getAttribute('userSyncs');
+
+    userSyncsJSON = JSON.parse(userSyncsString);
+  }
+  return userSyncsJSON;
+}
+
+function extractTrackingURL(htmlContent, ret) {
+  const trackingUrlDiv = htmlContent.querySelectorAll('[bidder-tracking-url]')[0];
+  if (trackingUrlDiv) {
+    const trackingUrl = trackingUrlDiv.getAttribute('bidder-tracking-url');
+    // eslint-disable-next-line no-console
+    logInfo(LOG_PREFIX + 'parseXML: trackingUrl: ', trackingUrl)
+    ret.trackingUrl = trackingUrl;
+  }
+}
+
+export function parseXML(xml, bid) {
+  const ret = { cpm: 0.001, currency: 'EUR', creativeURL: null, bidUp: false };
+  const ct = extractCT(xml);
+  if (!ct) return ret;
+
+  try {
+    if (ct) {
+      const companion = xml.getElementsByTagName('Companion')[0];
+      const htmlResource = companion.getElementsByTagName('HTMLResource')[0];
+      const htmlContent = document.createElement('html');
+      htmlContent.innerHTML = htmlResource.textContent;
+
+      ret.cpm = extractCPM(htmlContent, ct, ret.cpm);
+      ret.currency = extractCurrency(htmlContent, ret.currency);
+      ret.creativeURL = extractCreativeURL(htmlContent, ct, ret.cpm, bid);
+      extractTrackingURL(htmlContent, ret);
+      ret.bidUp = isAllowedToBidUp(htmlContent, getCurrentURL());
+      ret.userSyncs = extractSyncs(htmlContent);
+    }
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    logError(LOG_PREFIX + 'Error parsing XML', e);
+  }
+  // eslint-disable-next-line no-console
+  logInfo(LOG_PREFIX + 'parseXML RET:', ret);
+
+  return ret;
+}
+export function isAllowedToBidUp(html, currentURL) {
+  currentURL = currentURL.split('?')[0]; // Remove parameters
+  let allowedToPush = false;
+  try {
+    const domainsMap = html.querySelectorAll('[domainMap]')[0];
+    if (domainsMap) {
+      let domains = JSON.parse(domainsMap.getAttribute('domainMap'));
+      if (domains.domainMap) {
+        domains = domains.domainMap;
+      }
+      domains.forEach((d) => {
+        if (currentURL.includes(d) || d === 'all' || d === '*') allowedToPush = true;
+      })
+    } else {
+      allowedToPush = true;
+    }
+    if (allowedToPush) {
+      const excludedURL = html.querySelectorAll('[excludedURLs]')[0];
+      if (excludedURL) {
+        const excludedURLsString = domainsMap.getAttribute('excludedURLs');
+        if (excludedURLsString !== '') {
+          let excluded = JSON.parse(excludedURLsString);
+          excluded.forEach((d) => {
+            if (currentURL.includes(d)) allowedToPush = false;
+          })
+        }
+      }
+    }
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    logError(LOG_PREFIX + 'isAllowedToBidUp', e);
+  }
+  return allowedToPush;
+}
+
+function getSyncData(options, syncs) {
+  const ret = [];
+  if (syncs?.length) {
+    for (const sync of syncs) {
+      if (sync.type === 'syncImage' && options.pixelEnabled) {
+        ret.push({url: sync.url, type: 'image'});
+      } else if (sync.type === 'syncIframe' && options.iframeEnabled) {
+        ret.push({url: sync.url, type: 'iframe'});
+      }
+    }
+  }
+  return ret;
+}
+
+function getUserSyncs(syncOptions, serverResponses) {
+  const userSyncs = [];
+  for (const serverResponse of serverResponses) {
+    if (serverResponse.body) {
+      try {
+        const xmlStr = serverResponse.body;
+        const xml = new window.DOMParser().parseFromString(xmlStr, 'text/xml');
+        const xmlData = parseXML(xml, {});
+        if (xmlData.userSyncs) {
+          userSyncs.push(...getSyncData(syncOptions, xmlData.userSyncs));
+        }
+      } catch (e) {}
+    }
+  }
+  return userSyncs;
+}
+
+function onBidWon(bid) {
+  logInfo(`${LOG_PREFIX} WON AMPLIFFY`);
+  if (bid.trackingUrl) {
+    let url = bid.trackingUrl;
+
+    // Replace macros with URL-encoded bid parameters
+    Object.keys(bid).forEach(key => {
+      const macroKey = `%%${key.toUpperCase()}%%`;
+      const value = encodeURIComponent(JSON.stringify(bid[key]));
+      url = url.split(macroKey).join(value);
+    });
+
+    triggerPixel(url, () => {
+      logInfo(`${LOG_PREFIX} send data success`);
+    },
+    (e) => {
+      logError(`${LOG_PREFIX} send data error`, e);
+    });
+  }
+}
+function onTimeOut() {
+  // eslint-disable-next-line no-console
+  logInfo(LOG_PREFIX + 'TIMEOUT');
+}
+
+export const spec = {
+  code: BIDDER_CODE,
+  gvlid: GVLID,
+  aliases: ['ampliffy', 'amp', 'videoffy', 'publiffy'],
+  supportedMediaTypes: ['video', 'banner'],
+  isBidRequestValid,
+  buildRequests,
+  interpretResponse,
+  getUserSyncs,
+  onTimeOut,
+  onBidWon,
+};
+
+registerBidder(spec);

--- a/modules/ampliffyBidAdapter.md
+++ b/modules/ampliffyBidAdapter.md
@@ -1,0 +1,39 @@
+# Overview
+
+```
+Module Name: Ampliffy Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: bidder@ampliffy.com
+```
+
+# Description
+
+Connects to Ampliffy Ad server for bids.
+
+Ampliffy bid adapter supports Video currently, and has initial support for Banner.
+
+For more information about [Ampliffy](https://www.ampliffy.com/en/), please contact [info@ampliffy.com](info@ampliffy.com).
+
+# Sample Ad Unit: For Publishers
+```javascript
+var videoAdUnit = [
+{
+  code: 'video1',
+  mediaTypes: {
+    video: {
+      playerSize: [[640, 480]],
+      context: 'instream'
+    },
+  },
+  bids: [{
+    bidder: 'ampliffy',
+    params: {
+        server: 'bidder.ampliffy.com',
+        placementId: '1213213/example/vrutal_/',
+        format: 'video'
+    }
+  }]
+}];
+```
+
+```

--- a/modules/amxBidAdapter.js
+++ b/modules/amxBidAdapter.js
@@ -14,18 +14,29 @@ import {
 } from '../src/utils.js';
 import { config } from '../src/config.js';
 import { getStorageManager } from '../src/storageManager.js';
+import { fetch } from '../src/ajax.js';
 
 const BIDDER_CODE = 'amx';
 const storage = getStorageManager({ bidderCode: BIDDER_CODE });
 const SIMPLE_TLD_TEST = /\.com?\.\w{2,4}$/;
 const DEFAULT_ENDPOINT = 'https://prebid.a-mo.net/a/c';
-const VERSION = 'pba1.3.3';
+const VERSION = 'pba1.3.4';
 const VAST_RXP = /^\s*<\??(?:vast|xml)/i;
-const TRACKING_ENDPOINT = 'https://1x1.a-mo.net/hbx/';
+const TRACKING_BASE = 'https://1x1.a-mo.net/';
+const TRACKING_ENDPOINT = TRACKING_BASE + 'hbx/';
+const POST_TRACKING_ENDPOINT = TRACKING_BASE + 'e';
 const AMUID_KEY = '__amuidpb';
 
 function getLocation(request) {
   return parseUrl(request.refererInfo?.topmostLocation || window.location.href);
+}
+
+function getTimeoutSize(timeoutData) {
+  if (timeoutData.sizes == null || timeoutData.sizes.length === 0) {
+    return [0, 0];
+  }
+
+  return timeoutData.sizes[0];
 }
 
 const largestSize = (sizes, mediaTypes) => {
@@ -149,7 +160,9 @@ function convertRequest(bid) {
   const tid = deepAccess(bid, 'params.tagId');
 
   const au =
-    bid.params != null && typeof bid.params.adUnitId === 'string' && bid.params.adUnitId !== ''
+    bid.params != null &&
+      typeof bid.params.adUnitId === 'string' &&
+      bid.params.adUnitId !== ''
       ? bid.params.adUnitId
       : bid.adUnitCode;
 
@@ -202,7 +215,10 @@ function isSyncEnabled(syncConfigP, syncType) {
     return false;
   }
 
-  if (syncConfig.bidders === '*' || (isArray(syncConfig.bidders) && syncConfig.bidders.indexOf('amx') !== -1)) {
+  if (
+    syncConfig.bidders === '*' ||
+    (isArray(syncConfig.bidders) && syncConfig.bidders.indexOf('amx') !== -1)
+  ) {
     return syncConfig.filter == null || syncConfig.filter === 'include';
   }
 
@@ -219,12 +235,17 @@ function getSyncSettings() {
       d: 0,
       l: 0,
       t: 0,
-      e: true
+      e: true,
     };
   }
 
-  const settings = { d: syncConfig.syncDelay, l: syncConfig.syncsPerBidder, t: 0, e: syncConfig.syncEnabled }
-  const all = isSyncEnabled(syncConfig.filterSettings, 'all')
+  const settings = {
+    d: syncConfig.syncDelay,
+    l: syncConfig.syncsPerBidder,
+    t: 0,
+    e: syncConfig.syncEnabled,
+  };
+  const all = isSyncEnabled(syncConfig.filterSettings, 'all');
 
   if (all) {
     settings.t = SYNC_IMAGE & SYNC_IFRAME;
@@ -256,12 +277,14 @@ function getGpp(bidderRequest) {
     return bidderRequest.gppConsent;
   }
 
-  return bidderRequest?.ortb2?.regs?.gpp ?? { gppString: '', applicableSections: '' };
+  return (
+    bidderRequest?.ortb2?.regs?.gpp ?? { gppString: '', applicableSections: '' }
+  );
 }
 
 function buildReferrerInfo(bidderRequest) {
   if (bidderRequest.refererInfo == null) {
-    return { r: '', t: false, c: '', l: 0, s: [] }
+    return { r: '', t: false, c: '', l: 0, s: [] };
   }
 
   const re = bidderRequest.refererInfo;
@@ -272,7 +295,7 @@ function buildReferrerInfo(bidderRequest) {
     l: re.numIframes,
     s: re.stack,
     c: re.canonicalUrl,
-  }
+  };
 }
 
 const isTrue = (boolValue) =>
@@ -358,28 +381,35 @@ export const spec = {
     return {
       data: payload,
       method: 'POST',
+      browsingTopics: true,
       url: deepAccess(bidRequests[0], 'params.endpoint', DEFAULT_ENDPOINT),
       withCredentials: true,
     };
   },
 
-  getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) {
+  getUserSyncs(
+    syncOptions,
+    serverResponses,
+    gdprConsent,
+    uspConsent,
+    gppConsent
+  ) {
     const qp = {
       gdpr_consent: enc(gdprConsent?.consentString || ''),
       gdpr: enc(gdprConsent?.gdprApplies ? 1 : 0),
       us_privacy: enc(uspConsent || ''),
       gpp: enc(gppConsent?.gppString || ''),
-      gpp_sid: enc(gppConsent?.applicableSections || '')
+      gpp_sid: enc(gppConsent?.applicableSections || ''),
     };
 
     const iframeSync = {
       url: `https://prebid.a-mo.net/isyn?${formatQS(qp)}`,
-      type: 'iframe'
+      type: 'iframe',
     };
 
     if (serverResponses == null || serverResponses.length === 0) {
       if (syncOptions.iframeEnabled) {
-        return [iframeSync]
+        return [iframeSync];
       }
 
       return [];
@@ -394,7 +424,10 @@ export const spec = {
           const pixelType =
             syncPixel.indexOf('__st=iframe') !== -1 ? 'iframe' : 'image';
           if (syncOptions.iframeEnabled || pixelType === 'image') {
-            hasFrame = hasFrame || (pixelType === 'iframe') || (syncPixel.indexOf('cchain') !== -1)
+            hasFrame =
+              hasFrame ||
+              pixelType === 'iframe' ||
+              syncPixel.indexOf('cchain') !== -1;
             output.push({
               url: syncPixel,
               type: pixelType,
@@ -405,7 +438,7 @@ export const spec = {
     });
 
     if (!hasFrame && output.length < 2) {
-      output.push(iframeSync)
+      output.push(iframeSync);
     }
 
     return output;
@@ -470,19 +503,58 @@ export const spec = {
       aud: targetingData.requestId,
       a: targetingData.adUnitCode,
       c2: nestedQs(targetingData.adserverTargeting),
+      cn3: targetingData.timeToRespond,
     });
   },
 
   onTimeout(timeoutData) {
-    if (timeoutData == null) {
+    if (timeoutData == null || !timeoutData.length) {
       return;
     }
 
-    trackEvent('pbto', {
-      A: timeoutData.bidder,
-      bid: timeoutData.bidId,
-      a: timeoutData.adUnitCode,
-      cn: timeoutData.timeout,
+    let common = null;
+    const events = timeoutData.map((timeout) => {
+      const params = timeout.params || {};
+      const size = getTimeoutSize(timeout);
+      const { domain, page, ref } =
+        timeout.ortb2 != null && timeout.ortb2.site != null
+          ? timeout.ortb2.site
+          : {};
+
+      if (common == null) {
+        common = {
+          do: domain,
+          u: page,
+          U: getUIDSafe(),
+          re: ref,
+          V: '$prebid.version$',
+          vg: '$$PREBID_GLOBAL$$',
+        };
+      }
+
+      return {
+        A: timeout.bidder,
+        mid: params.tagId,
+        a: params.adunitId || timeout.adUnitCode,
+        bid: timeout.bidId,
+        n: 'g_pbto',
+        aud: timeout.transactionId,
+        w: size[0],
+        h: size[1],
+        cn: timeout.timeout,
+        cn2: timeout.bidderRequestsCount,
+        cn3: timeout.bidderWinsCount,
+      };
+    });
+
+    const payload = JSON.stringify({ c: common, e: events });
+    fetch(POST_TRACKING_ENDPOINT, {
+      body: payload,
+      keepalive: true,
+      withCredentials: true,
+      method: 'POST'
+    }).catch((_e) => {
+      // do nothing; ignore errors
     });
   },
 

--- a/modules/beopBidAdapter.js
+++ b/modules/beopBidAdapter.js
@@ -23,11 +23,11 @@ export const spec = {
   gvlid: TCF_VENDOR_ID,
   aliases: ['bp'],
   /**
-    * Test if the bid request is valid.
-    *
-    * @param {bid} : The Bid params
-    * @return boolean true if the bid request is valid (aka contains a valid accountId or networkId and is open for BANNER), false otherwise.
-    */
+   * Test if the bid request is valid.
+   *
+   * @param {bid} : The Bid params
+   * @return boolean true if the bid request is valid (aka contains a valid accountId or networkId and is open for BANNER), false otherwise.
+   */
   isBidRequestValid: function(bid) {
     const id = bid.params.accountId || bid.params.networkId;
     if (id === null || typeof id === 'undefined') {
@@ -39,12 +39,12 @@ export const spec = {
     return bid.mediaTypes.banner !== null && typeof bid.mediaTypes.banner !== 'undefined';
   },
   /**
-    * Create a BeOp server request from a list of BidRequest
-    *
-    * @param {validBidRequests[], ...} : The array of validated bidRequests
-    * @param {... , bidderRequest} : Common params for each bidRequests
-    * @return ServerRequest Info describing the request to the BeOp's server
-    */
+   * Create a BeOp server request from a list of BidRequest
+   *
+   * @param {validBidRequests[], ...} : The array of validated bidRequests
+   * @param {... , bidderRequest} : Common params for each bidRequests
+   * @return ServerRequest Info describing the request to the BeOp's server
+   */
   buildRequests: function(validBidRequests, bidderRequest) {
     const slots = validBidRequests.map(beOpRequestSlotsMaker);
     const firstPartyData = bidderRequest.ortb2 || {};

--- a/modules/bizzclickBidAdapter.md
+++ b/modules/bizzclickBidAdapter.md
@@ -11,94 +11,99 @@ Maintainer: support@bizzclick.com
 Module that connects to BizzClick SSP demand sources
 
 # Test Parameters
-```
-    var adUnits = [{
-                code: 'placementId',
-                      mediaTypes: {
-                          banner: {
-                              sizes: [[300, 250], [300,600]]
-                              }
-                              },
-                bids: [{
-                        bidder: 'bizzclick',
-                        params: {
-                            placementId: 'hash',
-                            accountId: 'accountId'
-                        }
-                    }]
-                },
-                {
-                    code: 'native_example',
-                    // sizes: [[1, 1]],
-                    mediaTypes: {
-                      native: {
-                        title: {
-                          required: true,
-                          len: 800
-                        },
-                        image: {
-                          required: true,
-                            len: 80
-                        },
-                        sponsoredBy: {
-                            required: true
-                        },
-                        clickUrl: {
-                            required: true
-                        },
-                        privacyLink: {
-                            required: false
-                        },
-                        body: {
-                            required: true
-                        },
-                        icon: {
-                            required: true,
-                            sizes: [50, 50]
-                        }
-                    }
 
-                    },
-                    bids: [    {
-                            bidder: 'bizzclick',
-                            params: {
-                                  placementId: 'hash',
-                            accountId: 'accountId'
-                            }
-                        }]
-            }, 
-            {
-    code: 'video1',
-    sizes: [640,480],
-    mediaTypes: { video: {
-      minduration:0,
-                maxduration:999,
-                boxingallowed:1,
-                skip:0,
-                mimes:[
-                    'application/javascript',
-                    'video/mp4'
-                ],
-                w:1920,
-                h:1080,
-                protocols:[
-                    2
-                ],
-                linearity:1,
-                api:[
-                    1,
-                    2
-                ]
-    } },
+```js
+const adUnits = [
+  {
+    code: "placementId",
+    mediaTypes: {
+      banner: {
+        sizes: [
+          [300, 250],
+          [300, 600],
+        ],
+      },
+    },
     bids: [
-    {
-                bidder: 'bizzclick',
-                params: {
-                      placementId: 'hash',
-                            accountId: 'accountId'
-                }
-            }
-    ]
-  }
-            ];
+      {
+        bidder: "bizzclick",
+        params: {
+          placementId: "hash",
+          accountId: "accountId",
+          host: "host",
+        },
+      },
+    ],
+  },
+  {
+    code: "native_example",
+    // sizes: [[1, 1]],
+    mediaTypes: {
+      native: {
+        title: {
+          required: true,
+          len: 800,
+        },
+        image: {
+          required: true,
+          len: 80,
+        },
+        sponsoredBy: {
+          required: true,
+        },
+        clickUrl: {
+          required: true,
+        },
+        privacyLink: {
+          required: false,
+        },
+        body: {
+          required: true,
+        },
+        icon: {
+          required: true,
+          sizes: [50, 50],
+        },
+      },
+    },
+    bids: [
+      {
+        bidder: "bizzclick",
+        params: {
+          placementId: "hash",
+          accountId: "accountId",
+          host: "host",
+        },
+      },
+    ],
+  },
+  {
+    code: "video1",
+    sizes: [640, 480],
+    mediaTypes: {
+      video: {
+        minduration: 0,
+        maxduration: 999,
+        boxingallowed: 1,
+        skip: 0,
+        mimes: ["application/javascript", "video/mp4"],
+        w: 1920,
+        h: 1080,
+        protocols: [2],
+        linearity: 1,
+        api: [1, 2],
+      },
+    },
+    bids: [
+      {
+        bidder: "bizzclick",
+        params: {
+          placementId: "hash",
+          accountId: "accountId",
+          host: "host",
+        },
+      },
+    ],
+  },
+];
 ```

--- a/modules/bliinkBidAdapter.js
+++ b/modules/bliinkBidAdapter.js
@@ -134,8 +134,8 @@ function canAccessTopWindow() {
 }
 
 /**
-  * domLoading feature is computed on window.top if reachable.
-  */
+ * domLoading feature is computed on window.top if reachable.
+ */
 export function getDomLoadingDuration() {
   let domLoadingDuration = -1;
   let performance;

--- a/modules/blueconicRtdProvider.js
+++ b/modules/blueconicRtdProvider.js
@@ -19,9 +19,9 @@ export const RTD_LOCAL_NAME = 'bcPrebidData';
 export const storage = getStorageManager({moduleType: MODULE_TYPE_RTD, moduleName: SUBMODULE_NAME});
 
 /**
-* Try parsing stringified array of data.
-* @param {String} data
-*/
+ * Try parsing stringified array of data.
+ * @param {String} data
+ */
 function parseJson(data) {
   try {
     return JSON.parse(data);

--- a/modules/brandmetricsRtdProvider.js
+++ b/modules/brandmetricsRtdProvider.js
@@ -72,10 +72,10 @@ function checkConsent (userConsent) {
 }
 
 /**
-* Add event- listeners to hook in to brandmetrics events
-* @param {Object} reqBidsConfigObj
-* @param {function} callback
-*/
+ * Add event- listeners to hook in to brandmetrics events
+ * @param {Object} reqBidsConfigObj
+ * @param {function} callback
+ */
 function processBrandmetricsEvents (reqBidsConfigObj, moduleConfig, callback) {
   const callBidTargeting = (event) => {
     if (event.available && event.conf) {
@@ -139,8 +139,8 @@ function initializeBrandmetrics(scriptId) {
 }
 
 /**
-* Hook in to brandmetrics creative_in_view- event and emit billable- event for creatives measured by brandmetrics.
-*/
+ * Hook in to brandmetrics creative_in_view- event and emit billable- event for creatives measured by brandmetrics.
+ */
 function initializeBillableEvents() {
   if (!billableEventsInitialized) {
     window._brandmetrics.push({

--- a/modules/browsiRtdProvider.js
+++ b/modules/browsiRtdProvider.js
@@ -88,6 +88,7 @@ export function collectData() {
   let predictorData = {
     ...{
       sk: _moduleParams.siteKey,
+      pk: _moduleParams.pubKey,
       sw: (win.screen && win.screen.width) || -1,
       sh: (win.screen && win.screen.height) || -1,
       url: `${doc.location.protocol}//${doc.location.host}${doc.location.pathname}`,
@@ -134,7 +135,6 @@ function getRTD(auc) {
       const adSlot = getSlotByCode(uc);
       const identifier = adSlot ? getMacroId(_browsiData['pmd'], adSlot) : uc;
       const _pd = _bp[identifier];
-      rp[uc] = getKVObject(-1);
       if (!_pd) {
         return rp
       }
@@ -275,7 +275,7 @@ function getPredictionsFromServer(url) {
         if (req.status === 200) {
           try {
             const data = JSON.parse(response);
-            if (data && data.p && data.kn) {
+            if (data) {
               setData({p: data.p, kn: data.kn, pmd: data.pmd, bet: data.bet});
             } else {
               setData({});

--- a/modules/bucksenseBidAdapter.js
+++ b/modules/bucksenseBidAdapter.js
@@ -16,7 +16,7 @@ export const spec = {
    *
    * @param {object} bid The bid to validate.
    * @return boolean True if this is a valid bid, and false otherwise.
-  */
+   */
   isBidRequestValid: function (bid) {
     logInfo(WHO + ' isBidRequestValid() - INPUT bid:', bid);
     if (bid.bidder !== BIDDER_CODE || typeof bid.params === 'undefined') {
@@ -29,10 +29,10 @@ export const spec = {
   },
 
   /**
-    * Make a server request from the list of BidRequests.
-    *
-    * @param {BidRequest[]} validBidRequests A non-empty list of valid bid requests that should be sent to the Server.
-    * @return ServerRequest Info describing the request to the server.
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {BidRequest[]} validBidRequests A non-empty list of valid bid requests that should be sent to the Server.
+   * @return ServerRequest Info describing the request to the server.
    */
   buildRequests: function (validBidRequests, bidderRequest) {
     logInfo(WHO + ' buildRequests() - INPUT validBidRequests:', validBidRequests, 'INPUT bidderRequest:', bidderRequest);
@@ -74,7 +74,7 @@ export const spec = {
    *
    * @param {*} serverResponse A successful response from the server.
    * @return {Bid[]} An array of bids which were nested inside the server.
-  */
+   */
   interpretResponse: function (serverResponse, request) {
     logInfo(WHO + ' interpretResponse() - INPUT serverResponse:', serverResponse, 'INPUT request:', request);
 

--- a/modules/codefuelBidAdapter.js
+++ b/modules/codefuelBidAdapter.js
@@ -10,11 +10,11 @@ export const spec = {
   supportedMediaTypes: [ BANNER ],
   aliases: ['ex'], // short code
   /**
-         * Determines whether or not the given bid request is valid.
-         *
-         * @param {BidRequest} bid The bid params to validate.
-         * @return boolean True if this is a valid bid, and false otherwise.
-         */
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
   isBidRequestValid: function(bid) {
     if (bid.nativeParams) {
       return false;
@@ -22,11 +22,11 @@ export const spec = {
     return !!(bid.params.placementId || (bid.params.member && bid.params.invCode));
   },
   /**
-         * Make a server request from the list of BidRequests.
-         *
-         * @param {validBidRequests[]} - an array of bids
-         * @return ServerRequest Info describing the request to the server.
-         */
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @return ServerRequest Info describing the request to the server.
+   */
   buildRequests: function(validBidRequests, bidderRequest) {
     const page = bidderRequest.refererInfo.page;
     const domain = bidderRequest.refererInfo.domain;
@@ -78,11 +78,11 @@ export const spec = {
     };
   },
   /**
-         * Unpack the response from the server into a list of bids.
-         *
-         * @param {ServerResponse} serverResponse A successful response from the server.
-         * @return {Bid[]} An array of bids which were nested inside the server.
-         */
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
   interpretResponse: (serverResponse, { bids }) => {
     if (!serverResponse.body) {
       return [];
@@ -116,12 +116,12 @@ export const spec = {
   },
 
   /**
-     * Register the user sync pixels which should be dropped after the auction.
-     *
-     * @param {SyncOptions} syncOptions Which user syncs are allowed?
-     * @param {ServerResponse[]} serverResponses List of server's responses.
-     * @return {UserSync[]} The user syncs which should be dropped.
-     */
+   * Register the user sync pixels which should be dropped after the auction.
+   *
+   * @param {SyncOptions} syncOptions Which user syncs are allowed?
+   * @param {ServerResponse[]} serverResponses List of server's responses.
+   * @return {UserSync[]} The user syncs which should be dropped.
+   */
   getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent) {
     return [];
   }

--- a/modules/consentManagementGpp.js
+++ b/modules/consentManagementGpp.js
@@ -70,13 +70,18 @@ export class GPPClient {
    *  - a promise to GPP data.
    */
   static init(mkCmp = cmpClient) {
-    if (this.INST == null) {
-      this.INST = this.ping(mkCmp).catch(e => {
-        this.INST = null;
+    let inst = this.INST;
+    if (!inst) {
+      let err;
+      const reset = () => err && (this.INST = null);
+      inst = this.INST = this.ping(mkCmp).catch(e => {
+        err = true;
+        reset();
         throw e;
       });
+      reset();
     }
-    return this.INST.then(([client, pingData]) => [
+    return inst.then(([client, pingData]) => [
       client,
       client.initialized ? client.refresh() : client.init(pingData)
     ]);

--- a/modules/contxtfulRtdProvider.js
+++ b/modules/contxtfulRtdProvider.js
@@ -1,0 +1,150 @@
+/**
+ * Contxtful Technologies Inc
+ * This RTD module provides receptivity feature that can be accessed using the
+ * getReceptivity() function. The value returned by this function enriches the ad-units
+ * that are passed within the `getTargetingData` functions and GAM.
+ */
+
+import { submodule } from '../src/hook.js';
+import {
+  logInfo,
+  logError,
+  isStr,
+  isEmptyStr,
+  buildUrl,
+} from '../src/utils.js';
+import { loadExternalScript } from '../src/adloader.js';
+
+const MODULE_NAME = 'contxtful';
+const MODULE = `${MODULE_NAME}RtdProvider`;
+
+const CONTXTFUL_RECEPTIVITY_DOMAIN = 'api.receptivity.io';
+
+let initialReceptivity = null;
+let contxtfulModule = null;
+
+/**
+ * Init function used to start sub module
+ * @param { { params: { version: String, customer: String, hostname: String } } } config
+ * @return { Boolean }
+ */
+function init(config) {
+  logInfo(MODULE, 'init', config);
+  initialReceptivity = null;
+  contxtfulModule = null;
+
+  try {
+    const {version, customer, hostname} = extractParameters(config);
+    initCustomer(version, customer, hostname);
+    return true;
+  } catch (error) {
+    logError(MODULE, error);
+    return false;
+  }
+}
+
+/**
+ * Extract required configuration for the sub module.
+ * validate that all required configuration are present and are valid.
+ * Throws an error if any config is missing of invalid.
+ * @param { { params: { version: String, customer: String, hostname: String } } } config
+ * @return { { version: String, customer: String, hostname: String } }
+ * @throws params.{name} should be a non-empty string
+ */
+function extractParameters(config) {
+  const version = config?.params?.version;
+  if (!isStr(version) || isEmptyStr(version)) {
+    throw Error(`${MODULE}: params.version should be a non-empty string`);
+  }
+
+  const customer = config?.params?.customer;
+  if (!isStr(customer) || isEmptyStr(customer)) {
+    throw Error(`${MODULE}: params.customer should be a non-empty string`);
+  }
+
+  const hostname = config?.params?.hostname || CONTXTFUL_RECEPTIVITY_DOMAIN;
+
+  return {version, customer, hostname};
+}
+
+/**
+ * Initialize sub module for a customer.
+ * This will load the external resources for the sub module.
+ * @param { String } version
+ * @param { String } customer
+ * @param { String } hostname
+ */
+function initCustomer(version, customer, hostname) {
+  const CONNECTOR_URL = buildUrl({
+    protocol: 'https',
+    host: hostname,
+    pathname: `/${version}/prebid/${customer}/connector/p.js`,
+  });
+
+  const externalScript = loadExternalScript(CONNECTOR_URL, MODULE_NAME);
+  addExternalScriptEventListener(externalScript);
+}
+
+/**
+ * Add event listener to the script tag for the expected events from the external script.
+ * @param { HTMLScriptElement } script
+ */
+function addExternalScriptEventListener(script) {
+  if (!script) {
+    return;
+  }
+
+  script.addEventListener('initialReceptivity', ({ detail }) => {
+    let receptivityState = detail?.ReceptivityState;
+    if (isStr(receptivityState) && !isEmptyStr(receptivityState)) {
+      initialReceptivity = receptivityState;
+    }
+  });
+
+  script.addEventListener('rxEngineIsReady', ({ detail: api }) => {
+    contxtfulModule = api;
+  });
+}
+
+/**
+ * Return current receptivity.
+ * @return { { ReceptivityState: String } }
+ */
+function getReceptivity() {
+  return {
+    ReceptivityState: contxtfulModule?.GetReceptivity()?.ReceptivityState || initialReceptivity
+  };
+}
+
+/**
+ * Set targeting data for ad server
+ * @param { [String] } adUnits
+ * @param {*} _config
+ * @param {*} _userConsent
+ *  @return {{ code: { ReceptivityState: String } }}
+ */
+function getTargetingData(adUnits, _config, _userConsent) {
+  logInfo(MODULE, 'getTargetingData');
+  if (!adUnits) {
+    return {};
+  }
+
+  const receptivity = getReceptivity();
+  if (!receptivity?.ReceptivityState) {
+    return {};
+  }
+
+  return adUnits.reduce((targets, code) => {
+    targets[code] = receptivity;
+    return targets;
+  }, {});
+}
+
+export const contxtfulSubmodule = {
+  name: MODULE_NAME,
+  init,
+  extractParameters,
+  getTargetingData,
+};
+
+submodule('realTimeData', contxtfulSubmodule);

--- a/modules/contxtfulRtdProvider.md
+++ b/modules/contxtfulRtdProvider.md
@@ -1,0 +1,65 @@
+# Overview
+
+**Module Name:** Contxtful RTD Provider  
+**Module Type:** RTD Provider  
+**Maintainer:** [prebid@contxtful.com](mailto:prebid@contxtful.com)
+
+# Description
+
+The Contxtful RTD module offers a unique feature—Receptivity. Receptivity is an efficiency metric, enabling the qualification of any instant in a session in real time based on attention. The core idea is straightforward: the likelihood of an ad’s success increases when it grabs attention and is presented in the right context at the right time.
+
+To utilize this module, you need to register for an account with [Contxtful](https://contxtful.com). For inquiries, please contact [prebid@contxtful.com](mailto:prebid@contxtful.com).
+
+# Configuration
+
+## Build Instructions
+
+To incorporate this module into your `prebid.js`, compile the module using the following command:
+
+```sh
+gulp build --modules=contxtfulRtdProvider,<other modules...>
+```
+
+## Module Configuration
+
+Configure the `contxtfulRtdProvider` by passing the required settings through the `setConfig` function in `prebid.js`.
+
+```js
+import pbjs from 'prebid.js';
+
+pbjs.setConfig({
+  "realTimeData": {
+    "auctionDelay": 1000,
+    "dataProviders": [
+      {
+        "name": "contxtful",
+        "waitForIt": true,
+        "params": {
+          "version": "<API Version>",
+          "customer": "<Contxtful Customer ID>"
+        }
+      }
+    ]
+  }
+});
+```
+
+### Configuration Parameters
+
+| Name       | Type     | Scope    | Description                               |
+|------------|----------|----------|-------------------------------------------|
+| `version`  | `string` | Required | Specifies the API version of Contxtful.   |
+| `customer` | `string` | Required | Your unique customer identifier.          |
+
+# Usage
+
+The `contxtfulRtdProvider` module loads an external JavaScript file and authenticates with Contxtful APIs. The `getTargetingData` function then adds a `ReceptivityState` to each ad slot, which can have one of two values: `Receptive` or `NonReceptive`.
+
+```json
+{
+  "adUnitCode1": { "ReceptivityState": "Receptive" },
+  "adUnitCode2": { "ReceptivityState": "NonReceptive" }
+}
+```
+
+This module also integrates seamlessly with Google Ad Manager, ensuring that the `ReceptivityState` is available as early as possible in the ad serving process.

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -125,7 +125,8 @@ export const spec = {
     return [];
   },
 
-  /** f
+  /**
+   * f
    * @param {object} bid
    * @return {boolean}
    */
@@ -275,20 +276,26 @@ export const spec = {
     if (isArray(body.ext?.igbid)) {
       const seller = body.ext.seller || FLEDGE_SELLER_DOMAIN;
       const sellerTimeout = body.ext.sellerTimeout || FLEDGE_SELLER_TIMEOUT;
-      const sellerSignals = body.ext.sellerSignals || {};
       body.ext.igbid.forEach((igbid) => {
         const perBuyerSignals = {};
         igbid.igbuyer.forEach(buyerItem => {
           perBuyerSignals[buyerItem.origin] = buyerItem.buyerdata;
         });
         const bidRequest = request.bidRequests.find(b => b.bidId === igbid.impid);
+        const bidId = bidRequest.bidId;
+        let sellerSignals = body.ext.sellerSignals || {};
         if (!sellerSignals.floor && bidRequest.params.bidFloor) {
           sellerSignals.floor = bidRequest.params.bidFloor;
         }
         if (!sellerSignals.sellerCurrency && bidRequest.params.bidFloorCur) {
           sellerSignals.sellerCurrency = bidRequest.params.bidFloorCur;
         }
-        const bidId = bidRequest.bidId;
+        if (body?.ext?.sellerSignalsPerImp !== undefined) {
+          const sellerSignalsPerImp = body.ext.sellerSignalsPerImp[bidId];
+          if (sellerSignalsPerImp !== undefined) {
+            sellerSignals = {...sellerSignals, ...sellerSignalsPerImp};
+          }
+        }
         fledgeAuctionConfigs.push({
           bidId,
           config: {
@@ -607,6 +614,8 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
   };
   request.user = bidderRequest.ortb2?.user || {};
   request.site = bidderRequest.ortb2?.site || {};
+  request.app = bidderRequest.ortb2?.app || {};
+  request.device = bidderRequest.ortb2?.device || {};
   if (bidderRequest && bidderRequest.ceh) {
     request.user.ceh = bidderRequest.ceh;
   }
@@ -681,17 +690,7 @@ function hasValidVideoMediaType(bidRequest) {
     }
   });
 
-  if (isValid) {
-    const videoPlacement = bidRequest.mediaTypes.video.placement || bidRequest.params.video.placement;
-    // We do not support long form for now, also we have to check that context & placement are consistent
-    if (bidRequest.mediaTypes.video.context == 'instream' && videoPlacement === 1) {
-      return true;
-    } else if (bidRequest.mediaTypes.video.context == 'outstream' && videoPlacement !== 1) {
-      return true;
-    }
-  }
-
-  return false;
+  return isValid;
 }
 
 /**

--- a/modules/deepintentBidAdapter.js
+++ b/modules/deepintentBidAdapter.js
@@ -2,6 +2,7 @@ import { generateUUID, deepSetValue, deepAccess, isArray, isInteger, logError, l
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 const BIDDER_CODE = 'deepintent';
+const GVL_ID = 541;
 const BIDDER_ENDPOINT = 'https://prebid.deepintent.com/prebid';
 const USER_SYNC_URL = 'https://cdn.deepintent.com/syncpixel.html';
 const DI_M_V = '1.0.0';
@@ -32,6 +33,7 @@ export const ORTB_VIDEO_PARAMS = {
 };
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: GVL_ID,
   supportedMediaTypes: [BANNER, VIDEO],
   aliases: [],
 

--- a/modules/deltaprojectsBidAdapter.js
+++ b/modules/deltaprojectsBidAdapter.js
@@ -16,7 +16,7 @@ export const BIDDER_CODE = 'deltaprojects';
 export const BIDDER_ENDPOINT_URL = 'https://d5p.de17a.com/dogfight/prebid';
 export const USERSYNC_URL = 'https://userservice.de17a.com/getuid/prebid';
 
-/** -- isBidRequestValid --**/
+/** -- isBidRequestValid -- */
 function isBidRequestValid(bid) {
   if (!bid) return false;
 
@@ -32,9 +32,9 @@ function isBidRequestValid(bid) {
   return true;
 }
 
-/** -- Build requests --**/
+/** -- Build requests -- */
 function buildRequests(validBidRequests, bidderRequest) {
-  /** == shared ==**/
+  /** == shared == */
   // -- build id
   const id = bidderRequest.bidderRequestId;
 
@@ -146,7 +146,7 @@ function buildImpressionBanner(bid, bannerMediaType) {
   };
 }
 
-/** -- Interpret response --**/
+/** -- Interpret response -- */
 function interpretResponse(serverResponse) {
   if (!serverResponse.body) {
     logWarn('Response body is invalid, return !!');
@@ -189,7 +189,7 @@ function interpretResponse(serverResponse) {
   return bidResponses;
 }
 
-/** -- On Bid Won -- **/
+/** -- On Bid Won -- */
 function onBidWon(bid) {
   let cpm = bid.cpm;
   if (bid.currency && bid.currency !== bid.originalCurrency && typeof bid.getCpmInNewCurrency === 'function') {
@@ -200,7 +200,7 @@ function onBidWon(bid) {
   bid.ad = bid.ad.replace(wonPriceMacroPatten, wonPrice);
 }
 
-/** -- Get user syncs --**/
+/** -- Get user syncs -- */
 function getUserSyncs(syncOptions, serverResponses, gdprConsent) {
   const syncs = []
 
@@ -223,7 +223,7 @@ function getUserSyncs(syncOptions, serverResponses, gdprConsent) {
   return syncs;
 }
 
-/** -- Get bid floor --**/
+/** -- Get bid floor -- */
 export function getBidFloor(bid, mediaType, size, currency) {
   if (isFn(bid.getFloor)) {
     const bidFloorCurrency = currency || 'USD';
@@ -234,7 +234,7 @@ export function getBidFloor(bid, mediaType, size, currency) {
   }
 }
 
-/** -- Helper methods --**/
+/** -- Helper methods -- */
 function setOnAny(collection, key) {
   for (let i = 0, result; i < collection.length; i++) {
     result = deepAccess(collection[i], key);

--- a/modules/discoveryBidAdapter.js
+++ b/modules/discoveryBidAdapter.js
@@ -6,7 +6,7 @@ import { BANNER, NATIVE } from '../src/mediaTypes.js';
 const BIDDER_CODE = 'discovery';
 const ENDPOINT_URL = 'https://rtb-jp.mediago.io/api/bid?tn=';
 const TIME_TO_LIVE = 500;
-const storage = getStorageManager({bidderCode: BIDDER_CODE});
+export const storage = getStorageManager({bidderCode: BIDDER_CODE});
 let globals = {};
 let itemMaps = {};
 const MEDIATYPE = [BANNER, NATIVE];
@@ -14,6 +14,9 @@ const MEDIATYPE = [BANNER, NATIVE];
 /* ----- _ss_pp_id:start ------ */
 const COOKIE_KEY_SSPPID = '_ss_pp_id';
 const COOKIE_KEY_MGUID = '__mguid_';
+const COOKIE_KEY_PMGUID = '__pmguid_';
+const COOKIE_RETENTION_TIME = 365 * 24 * 60 * 60 * 1000; // 1 year
+const COOKY_SYNC_IFRAME_URL = 'https://asset.popin.cc/js/cookieSync.html';
 
 const NATIVERET = {
   id: 'id',
@@ -55,24 +58,81 @@ const NATIVERET = {
 };
 
 /**
- * 获取用户id
+ * get page title
+ * @returns {string}
+ */
+
+export function getPageTitle(win = window) {
+  try {
+    const ogTitle = win.top.document.querySelector('meta[property="og:title"]')
+    return win.top.document.title || (ogTitle && ogTitle.content) || '';
+  } catch (e) {
+    const ogTitle = document.querySelector('meta[property="og:title"]')
+    return document.title || (ogTitle && ogTitle.content) || '';
+  }
+}
+
+/**
+ * get page description
+ * @returns {string}
+ */
+export function getPageDescription(win = window) {
+  let element;
+
+  try {
+    element = win.top.document.querySelector('meta[name="description"]') ||
+      win.top.document.querySelector('meta[property="og:description"]')
+  } catch (e) {
+    element = document.querySelector('meta[name="description"]') ||
+      document.querySelector('meta[property="og:description"]')
+  }
+
+  return (element && element.content) || '';
+}
+
+/**
+ * get page keywords
+ * @returns {string}
+ */
+export function getPageKeywords(win = window) {
+  let element;
+
+  try {
+    element = win.top.document.querySelector('meta[name="keywords"]');
+  } catch (e) {
+    element = document.querySelector('meta[name="keywords"]');
+  }
+
+  return (element && element.content) || '';
+}
+
+/**
+ * get connection downlink
+ * @returns {number}
+ */
+export function getConnectionDownLink(win = window) {
+  const nav = win.navigator || {};
+  return nav && nav.connection && nav.connection.downlink >= 0 ? nav.connection.downlink.toString() : undefined;
+}
+
+/**
+ * get pmg uid
+ * 获取并生成用户的id
  * @return {string}
  */
-const getUserID = () => {
-  let idd = storage.getCookie(COOKIE_KEY_SSPPID);
-  let idm = storage.getCookie(COOKIE_KEY_MGUID);
+export const getPmgUID = () => {
+  if (!storage.cookiesAreEnabled()) return;
 
-  if (idd && !idm) {
-    idm = idd;
-  } else if (idm && !idd) {
-    idd = idm;
-  } else if (!idd && !idm) {
-    const uuid = utils.generateUUID();
-    storage.setCookie(COOKIE_KEY_MGUID, uuid);
-    storage.setCookie(COOKIE_KEY_SSPPID, uuid);
-    return uuid;
+  let pmgUid = storage.getCookie(COOKIE_KEY_PMGUID);
+  if (!pmgUid) {
+    pmgUid = utils.generateUUID();
+    const date = new Date();
+    date.setTime(date.getTime() + COOKIE_RETENTION_TIME);
+    try {
+      storage.setCookie(COOKIE_KEY_PMGUID, pmgUid, date.toUTCString());
+    } catch (e) {}
   }
-  return idd;
+  return pmgUid;
 };
 
 /* ----- _ss_pp_id:end ------ */
@@ -361,6 +421,10 @@ function getParam(validBidRequests, bidderRequest) {
   const page = utils.deepAccess(bidderRequest, 'refererInfo.page');
   const referer = utils.deepAccess(bidderRequest, 'refererInfo.ref');
   const firstPartyData = bidderRequest.ortb2;
+  const topWindow = window.top;
+  const title = getPageTitle();
+  const desc = getPageDescription();
+  const keywords = getPageKeywords();
 
   if (items && items.length) {
     let c = {
@@ -381,9 +445,22 @@ function getParam(validBidRequests, bidderRequest) {
       ext: {
         eids,
         firstPartyData,
+        ssppid: storage.getCookie(COOKIE_KEY_SSPPID) || undefined,
+        pmguid: getPmgUID(),
+        page: {
+          title: title ? title.slice(0, 100) : undefined,
+          desc: desc ? desc.slice(0, 300) : undefined,
+          keywords: keywords ? keywords.slice(0, 100) : undefined,
+          hLen: topWindow.history?.length || undefined,
+        },
+        device: {
+          nbw: getConnectionDownLink(),
+          hc: topWindow.navigator?.hardwareConcurrency || undefined,
+          dm: topWindow.navigator?.deviceMemory || undefined,
+        }
       },
       user: {
-        buyeruid: getUserID(),
+        buyeruid: storage.getCookie(COOKIE_KEY_MGUID) || undefined,
         id: sharedid || pubcid,
       },
       tmax: timeout,
@@ -545,6 +622,31 @@ export const spec = {
     }
 
     return bidResponses;
+  },
+
+  getUserSyncs: function (syncOptions, serverResponse, gdprConsent, uspConsent, gppConsent) {
+    const origin = encodeURIComponent(location.origin || `https://${location.host}`);
+    let syncParamUrl = `dm=${origin}`;
+
+    if (gdprConsent && gdprConsent.consentString) {
+      if (typeof gdprConsent.gdprApplies === 'boolean') {
+        syncParamUrl += `&gdpr=${Number(gdprConsent.gdprApplies)}&gdpr_consent=${gdprConsent.consentString}`;
+      } else {
+        syncParamUrl += `&gdpr=0&gdpr_consent=${gdprConsent.consentString}`;
+      }
+    }
+    if (uspConsent && uspConsent.consentString) {
+      syncParamUrl += `&ccpa_consent=${uspConsent.consentString}`;
+    }
+
+    if (syncOptions.iframeEnabled) {
+      return [
+        {
+          type: 'iframe',
+          url: `${COOKY_SYNC_IFRAME_URL}?${syncParamUrl}`
+        }
+      ];
+    }
   },
 
   /**

--- a/modules/dsp_genieeBidAdapter.js
+++ b/modules/dsp_genieeBidAdapter.js
@@ -1,0 +1,123 @@
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER } from '../src/mediaTypes.js';
+import { ortbConverter } from '../libraries/ortbConverter/converter.js';
+import { deepAccess, deepSetValue } from '../src/utils.js';
+import { config } from '../src/config.js';
+const BIDDER_CODE = 'dsp_geniee';
+const ENDPOINT_URL = 'https://rt.gsspat.jp/prebid_auction';
+const ENDPOINT_URL_UNCOMFORTABLE = 'https://rt.gsspat.jp/prebid_uncomfortable';
+const ENDPOINT_USERSYNC = 'https://rt.gsspat.jp/prebid_cs';
+const VALID_CURRENCIES = ['USD', 'JPY'];
+const converter = ortbConverter({
+  context: { ttl: 300, netRevenue: true },
+  // set optional parameters
+  imp(buildImp, bidRequest, context) {
+    const imp = buildImp(bidRequest, context);
+    deepSetValue(imp, 'ext', bidRequest.params);
+    return imp;
+  }
+});
+
+function USPConsent(consent) {
+  return typeof consent === 'string' && consent[0] === '1' && consent.toUpperCase()[2] === 'Y';
+}
+
+function invalidCurrency(currency) {
+  return typeof currency === 'string' && VALID_CURRENCIES.indexOf(currency.toUpperCase()) === -1;
+}
+
+function hasTest(imp) {
+  if (typeof imp !== 'object') {
+    return false;
+  }
+  for (let i = 0; i < imp.length; i++) {
+    if (deepAccess(imp[i], 'ext.test') === 1) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [BANNER],
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} - The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: function (_) {
+    return true;
+  },
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @param {bidderRequest} - the master bidRequest object
+   * @return ServerRequest Info describing the request to the server.
+   */
+  buildRequests: function (validBidRequests, bidderRequest) {
+    if (deepAccess(bidderRequest, 'gdprConsent.gdprApplies') || // gdpr
+            USPConsent(bidderRequest.uspConsent) || // usp
+            config.getConfig('coppa') || // coppa
+            invalidCurrency(config.getConfig('currency.adServerCurrency')) // currency validation
+    ) {
+      return {
+        method: 'GET',
+        url: ENDPOINT_URL_UNCOMFORTABLE
+      };
+    }
+
+    const payload = converter.toORTB({ validBidRequests, bidderRequest });
+
+    if (hasTest(deepAccess(payload, 'imp'))) {
+      deepSetValue(payload, 'test', 1);
+    }
+
+    deepSetValue(payload, 'at', 1); // first price auction only
+
+    return {
+      method: 'POST',
+      url: ENDPOINT_URL,
+      data: payload
+    };
+  },
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @param {BidRequest} bidRequest - the master bidRequest object
+   * @return {bids} - An array of bids which were nested inside the server.
+   */
+  interpretResponse: function (serverResponse, bidRequest) {
+    if (!serverResponse.body) { // empty response (no bids)
+      return [];
+    }
+    const bids = converter.fromORTB({ response: serverResponse.body, request: bidRequest.data }).bids;
+    return bids;
+  },
+
+  /**
+   * Register the user sync pixels which should be dropped after the auction.
+   *
+   * @param {SyncOptions} syncOptions Which user syncs are allowed?
+   * @param {ServerResponse[]} serverResponses List of server's responses.
+   * @return {UserSync[]} The user syncs which should be dropped.
+   */
+  getUserSyncs: function (syncOptions, serverResponses, gdprConsent, uspConsent) {
+    const syncs = [];
+    // gdpr & usp
+    if (deepAccess(gdprConsent, 'gdprApplies') || USPConsent(uspConsent)) {
+      return syncs;
+    }
+    if (syncOptions.pixelEnabled) {
+      syncs.push({
+        type: 'image',
+        url: ENDPOINT_USERSYNC
+      });
+    }
+    return syncs;
+  }
+};
+registerBidder(spec);

--- a/modules/dsp_genieeBidAdapter.md
+++ b/modules/dsp_genieeBidAdapter.md
@@ -1,0 +1,39 @@
+# Overview
+
+```markdown
+Module Name:  Geniee Bid Adapter
+Module Type:  Bidder Adapter
+Maintainer:   dsp_back@geniee.co.jp
+```
+
+# Description
+This is [Geniee](https://geniee.co.jp) Bidder Adapter for Prebid.js.
+
+Please contact us before using the adapter.
+
+We will provide ads when satisfy the following conditions:
+
+- There are a certain number bid requests by zone
+- The request is a Banner ad
+- Payment is possible in Japanese yen or US dollars
+- The request is not for GDPR or COPPA users
+
+Thus, even if the following test, it will be no bids if the request does not reach a certain requests.
+
+# Test AdUnits
+```javascript
+var adUnits={
+    code: 'geniee-test-ad',
+    bids: [{
+        bidder: 'dsp_geniee',
+        params: {
+            test: 1,
+        }
+    }],
+    mediaTypes: {
+        banner: {
+            sizes: [[300, 250]]
+        }
+    }
+};
+```

--- a/modules/dxkultureBidAdapter.js
+++ b/modules/dxkultureBidAdapter.js
@@ -1,5 +1,6 @@
 import {
   logInfo,
+  logWarn,
   logError,
   logMessage,
   deepAccess,
@@ -8,13 +9,14 @@ import {
 } from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
+import { Renderer } from '../src/Renderer.js';
 import {ortbConverter} from '../libraries/ortbConverter/converter.js'
 
 const BIDDER_CODE = 'dxkulture';
 const DEFAULT_BID_TTL = 300;
 const DEFAULT_NET_REVENUE = true;
 const DEFAULT_CURRENCY = 'USD';
-const SYNC_URL = 'https://ads.kulture.media/usync';
+const DEFAULT_OUTSTREAM_RENDERER_URL = 'https://cdn.dxkulture.com/players/dxOutstreamPlayer.js';
 
 const converter = ortbConverter({
   context: {
@@ -55,18 +57,12 @@ const converter = ortbConverter({
   },
   bidResponse(buildBidResponse, bid, context) {
     let resMediaType;
+    const {bidRequest} = context;
+
     if (bid.adm?.trim().startsWith('<VAST')) {
       resMediaType = VIDEO;
     } else {
       resMediaType = BANNER;
-    }
-
-    const isADomainPresent = bid.adomain && bid.adomain.length;
-
-    if (isADomainPresent) {
-      context.meta = {
-        advertiserDomains: bid.adomain
-      };
     }
 
     context.mediaType = resMediaType;
@@ -78,6 +74,10 @@ const converter = ortbConverter({
 
     const bidResponse = buildBidResponse(bid, context);
 
+    if (resMediaType === VIDEO && bidRequest.mediaTypes.video.context === 'outstream') {
+      bidResponse.renderer = outstreamRenderer(bidResponse);
+    }
+
     return bidResponse;
   }
 });
@@ -86,7 +86,7 @@ export const spec = {
   code: BIDDER_CODE,
   VERSION: '1.0.0',
   supportedMediaTypes: [BANNER, VIDEO],
-  ENDPOINT: 'https://ads.kulture.media/pbjs',
+  ENDPOINT: 'https://ads.dxkulture.com/pbjs',
 
   /**
    * Determines whether or not the given bid request is valid.
@@ -138,33 +138,90 @@ export const spec = {
 
   getUserSyncs: function (syncOptions, serverResponses, gdprConsent, uspConsent) {
     logInfo('dxkulture.getUserSyncs', 'syncOptions', syncOptions, 'serverResponses', serverResponses);
-
     let syncs = [];
 
     if (!syncOptions.iframeEnabled && !syncOptions.pixelEnabled) {
       return syncs;
     }
 
-    if (syncOptions.iframeEnabled || syncOptions.pixelEnabled) {
-      let pixelType = syncOptions.iframeEnabled ? 'iframe' : 'image';
-      let queryParamStrings = [];
-      let syncUrl = SYNC_URL;
-      if (gdprConsent) {
-        queryParamStrings.push('gdpr=' + (gdprConsent.gdprApplies ? 1 : 0));
-        queryParamStrings.push('gdpr_consent=' + encodeURIComponent(gdprConsent.consentString || ''));
-      }
-      if (uspConsent) {
-        queryParamStrings.push('us_privacy=' + encodeURIComponent(uspConsent));
-      }
+    serverResponses.forEach(resp => {
+      const userSync = deepAccess(resp, 'body.ext.usersync');
+      if (userSync) {
+        let syncDetails = [];
+        Object.keys(userSync).forEach(key => {
+          const value = userSync[key];
+          if (value.syncs && value.syncs.length) {
+            syncDetails = syncDetails.concat(value.syncs);
+          }
+        });
+        syncDetails.forEach(syncDetails => {
+          let queryParamStrings = [];
+          let syncUrl = syncDetails.url;
 
-      return [{
-        type: pixelType,
-        url: `${syncUrl}${queryParamStrings.length > 0 ? '?' + queryParamStrings.join('&') : ''}`
-      }];
-    }
-  }
+          if (syncDetails.type === 'iframe') {
+            if (gdprConsent) {
+              queryParamStrings.push('gdpr=' + (gdprConsent.gdprApplies ? 1 : 0));
+              queryParamStrings.push('gdpr_consent=' + encodeURIComponent(gdprConsent.consentString || ''));
+            }
+            if (uspConsent) {
+              queryParamStrings.push('us_privacy=' + encodeURIComponent(uspConsent));
+            }
+            syncUrl = `${syncDetails.url}${queryParamStrings.length > 0 ? '?' + queryParamStrings.join('&') : ''}`
+          }
+
+          syncs.push({
+            type: syncDetails.type === 'iframe' ? 'iframe' : 'image',
+            url: syncUrl
+          });
+        });
+
+        if (syncOptions.iframeEnabled) {
+          syncs = syncs.filter(s => s.type == 'iframe');
+        } else if (syncOptions.pixelEnabled) {
+          syncs = syncs.filter(s => s.type == 'image');
+        }
+      }
+    });
+    logInfo('dxkulture.getUserSyncs result=%o', syncs);
+    return syncs;
+  },
 
 };
+
+function outstreamRenderer(bid) {
+  const rendererConfig = {
+    width: bid.width,
+    height: bid.height,
+    vastTimeout: 5000,
+    maxAllowedVastTagRedirects: 3,
+    allowVpaid: false,
+    autoPlay: true,
+    preload: true,
+    mute: false
+  }
+
+  const renderer = Renderer.install({
+    id: bid.adId,
+    url: DEFAULT_OUTSTREAM_RENDERER_URL,
+    config: rendererConfig,
+    loaded: false,
+    targetId: bid.adUnitCode,
+    adUnitCode: bid.adUnitCode
+  });
+
+  try {
+    renderer.setRender(function (bid) {
+      bid.renderer.push(() => {
+        const { id, config } = bid.renderer;
+        window.dxOutstreamPlayer(bid, id, config);
+      });
+    });
+  } catch (err) {
+    logWarn('dxkulture: Prebid Error calling setRender on renderer', err);
+  }
+
+  return renderer;
+}
 
 /* =======================================
  * Util Functions

--- a/modules/euidIdSystem.js
+++ b/modules/euidIdSystem.js
@@ -12,7 +12,7 @@ import {MODULE_TYPE_UID} from '../src/activities/modules.js';
 
 // RE below lint exception: UID2 and EUID are separate modules, but the protocol is the same and shared code makes sense here.
 // eslint-disable-next-line prebid/validate-imports
-import { Uid2GetId, Uid2CodeVersion } from './uid2IdSystem_shared.js';
+import { Uid2GetId, Uid2CodeVersion, extractIdentityFromParams } from './uid2IdSystem_shared.js';
 
 const MODULE_NAME = 'euid';
 const MODULE_REVISION = Uid2CodeVersion;
@@ -99,6 +99,14 @@ export const euidIdSubmodule = {
       internalStorage: ADVERTISING_COOKIE
     };
 
+    if (FEATURES.UID2_CSTG) {
+      mappedConfig.cstg = {
+        serverPublicKey: config?.params?.serverPublicKey,
+        subscriptionId: config?.params?.subscriptionId,
+        ...extractIdentityFromParams(config?.params ?? {})
+      }
+    }
+    _logInfo(`EUID configuration loaded and mapped.`, mappedConfig);
     const result = Uid2GetId(mappedConfig, storage, _logInfo, _logWarn);
     _logInfo(`EUID getId returned`, result);
     return result;

--- a/modules/euidIdSystem.md
+++ b/modules/euidIdSystem.md
@@ -1,8 +1,58 @@
 ## EUID User ID Submodule
 
-EUID requires initial tokens to be generated server-side. The EUID module handles storing, providing, and optionally refreshing them. The module can operate in one of two different modes: *Client Refresh* mode or *Server Only* mode.
+The EUID module handles storing, providing, and optionally refreshing tokens. While initial tokens traditionally required server-side generation, the introduction of the *Client-Side Token Generation (CSTG)* mode offers publishers the flexibility to generate EUID tokens directly from the module, eliminating this need. Publishers can choose to operate the module in one of three distinct modes: *Client Refresh* mode, *Server Only* mode and *Client-Side Token Generation* mode.
 
 *Server Only* mode was originally referred to as *legacy mode*, but it is a popular mode for new integrations where publishers prefer to handle token refresh server-side.
+
+*Client-Side Token Generation* mode is included in EUID module by default. However, it's important to note that this mode is created and made available recently. For publishers who do not intend to use it, you have the option to instruct the build to exclude the code related to this feature:
+
+```
+    $ gulp build --modules=uid2IdSystem --disable UID2_CSTG
+```
+If you do plan to use Client-Side Token Generation (CSTG) mode, please consult the EUID Team first as they will provide required configuration values for you to use (see the Client-Side Token Generation (CSTG) mode section below for details)
+
+**This mode is created and made available recently. Please consult EUID Team first as they will provide required configuration values for you to use.**
+
+For publishers seeking a purely client-side integration without the complexities of server-side involvement, the CSTG mode is highly recommended. This mode requires the provision of a public key, subscription ID and [directly identifying information (DII)](https://unifiedid.com/docs/ref-info/glossary-uid#gl-dii) - either emails or phone numbers. In the CSTG mode, the module takes on the responsibility of encrypting the DII, generating the EUID token, and handling token refreshes when necessary.
+
+To configure the module to use this mode, you must:
+1. Set `parmas.serverPublicKey`  and `params.subscriptionId` (please reach out to the UID2 team to obtain these values)
+2. Provide **ONLY ONE DII** by setting **ONLY ONE** of `params.email`/`params.phone`/`params.emailHash`/`params.phoneHash`
+
+Below is a table that provides guidance on when to use each directly identifying information (DII) parameter, along with information on whether normalization and hashing are required by the publisher for each parameter.
+
+| DII param        | When to use it                                        | Normalization required by publisher? | Hashing required by publisher? |
+|------------------|-------------------------------------------------------|--------------------------------------|--------------------------------|
+| params.email     | When you have users' email address                    | No                                   | No                             |
+| params.phone     | When you have user's phone number                     | Yes                                  | No                             |
+| params.emailHash | When you have user's hashed, normalized email address | Yes                                  | Yes                            |
+| params.phoneHash | When you have user's hashed, normalized phone number  | Yes                                  | Yes                            |
+
+
+*Note that setting params.email will normalize email addresses, but params.phone requires phone numbers to be normalized.*
+
+Refer to [Normalization and Encoding](#normalization-and-encoding) for details on email address normalization, SHA-256 hashing and Base64 encoding.
+
+### CSTG example
+
+Configuration:
+```
+pbjs.setConfig({
+    userSync: {
+        userIds: [{
+            name: 'euid',
+            params: {
+               serverPublicKey: '...server public key...',
+               subscriptionId: '...subcription id...',
+               email: 'user@email.com',
+               //phone: '+0000000',
+               //emailHash: '...email hash...',
+               //phoneHash: '...phone hash ...'
+            }
+        }]
+    }
+});
+```
 
 ## Client Refresh mode
 

--- a/modules/fledgeForGpt.js
+++ b/modules/fledgeForGpt.js
@@ -20,8 +20,8 @@ export let isEnabled = false;
 config.getConfig('fledgeForGpt', config => init(config.fledgeForGpt));
 
 /**
-  * Module init.
-  */
+ * Module init.
+ */
 export function init(cfg) {
   if (cfg && cfg.enabled === true) {
     if (!isEnabled) {

--- a/modules/flippBidAdapter.js
+++ b/modules/flippBidAdapter.js
@@ -3,7 +3,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
 import {getStorageManager} from '../src/storageManager.js';
 
-const NETWORK_ID = 11090;
+const NETWORK_ID = 10922;
 const AD_TYPES = [4309, 641];
 const DTX_TYPES = [5061];
 const TARGET_NAME = 'inline';

--- a/modules/freewheel-sspBidAdapter.js
+++ b/modules/freewheel-sspBidAdapter.js
@@ -183,8 +183,8 @@ function getCampaignId(xmlNode) {
 }
 
 /**
-* returns the top most accessible window
-*/
+ * returns the top most accessible window
+ */
 function getTopMostWindow() {
   var res = window;
 
@@ -319,21 +319,21 @@ export const spec = {
   supportedMediaTypes: [BANNER, VIDEO],
   aliases: ['stickyadstv', 'freewheelssp'], //  aliases for freewheel-ssp
   /**
-  * Determines whether or not the given bid request is valid.
-  *
-  * @param {object} bid The bid to validate.
-  * @return boolean True if this is a valid bid, and false otherwise.
-  */
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {object} bid The bid to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
   isBidRequestValid: function(bid) {
     return !!(bid.params.zoneId);
   },
 
   /**
-  * Make a server request from the list of BidRequests.
-  *
-  * @param {BidRequest[]} bidRequests A non-empty list of bid requests which should be sent to the Server.
-  * @return ServerRequest Info describing the request to the server.
-  */
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {BidRequest[]} bidRequests A non-empty list of bid requests which should be sent to the Server.
+   * @return ServerRequest Info describing the request to the server.
+   */
   buildRequests: function(bidRequests, bidderRequest) {
     // var currency = config.getConfig(currency);
 
@@ -474,12 +474,12 @@ export const spec = {
   },
 
   /**
-  * Unpack the response from the server into a list of bids.
-  *
-  * @param {*} serverResponse A successful response from the server.
-  * @param {object} request: the built request object containing the initial bidRequest.
-  * @return {Bid[]} An array of bids which were nested inside the server.
-  */
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {*} serverResponse A successful response from the server.
+   * @param {object} request: the built request object containing the initial bidRequest.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
   interpretResponse: function(serverResponse, request) {
     var bidrequest = request.bidRequest;
     var playerSize = [];

--- a/modules/geoedgeRtdProvider.js
+++ b/modules/geoedgeRtdProvider.js
@@ -17,11 +17,12 @@
 
 import { submodule } from '../src/hook.js';
 import { ajax } from '../src/ajax.js';
-import { generateUUID, insertElement, isEmpty, logError } from '../src/utils.js';
+import { generateUUID, createInvisibleIframe, insertElement, isEmpty, logError } from '../src/utils.js';
 import * as events from '../src/events.js';
 import CONSTANTS from '../src/constants.json';
 import { loadExternalScript } from '../src/adloader.js';
 import { auctionManager } from '../src/auctionManager.js';
+import { getRefererInfo } from '../src/refererDetection.js';
 
 /** @type {string} */
 const SUBMODULE_NAME = 'geoedge';
@@ -69,17 +70,38 @@ export function setWrapper(responseText) {
   wrapper = responseText;
 }
 
+export function getInitialParams(key) {
+  let refererInfo = getRefererInfo();
+  let params = {
+    wver: 'pbjs',
+    wtype: 'pbjs-module',
+    key,
+    meta: {
+      topUrl: refererInfo.page
+    },
+    site: refererInfo.domain,
+    pimp: PV_ID,
+    fsRan: true,
+    frameApi: true
+  };
+  return params;
+}
+
+export function markAsLoaded() {
+  preloaded = true;
+}
+
 /**
  * preloads the client
-  * @param {string} key
+ * @param {string} key
  */
 export function preloadClient(key) {
-  let link = document.createElement('link');
-  link.rel = 'preload';
-  link.as = 'script';
-  link.href = getClientUrl(key);
-  link.onload = () => { preloaded = true };
-  insertElement(link);
+  let iframe = createInvisibleIframe();
+  iframe.id = 'grumiFrame';
+  insertElement(iframe);
+  iframe.contentWindow.grumi = getInitialParams(key);
+  let url = getClientUrl(key);
+  loadExternalScript(url, SUBMODULE_NAME, markAsLoaded, iframe.contentDocument);
 }
 
 /**
@@ -103,7 +125,7 @@ export function wrapHtml(wrapper, html) {
  * @param {string} key
  * @return {Object}
  */
-function getMacros(bid, key) {
+export function getMacros(bid, key) {
   return {
     '${key}': key,
     '%%ADUNIT%%': bid.adUnitCode,
@@ -116,7 +138,9 @@ function getMacros(bid, key) {
     '%_hbadomains': bid.meta && bid.meta.advertiserDomains,
     '%%PATTERN:hb_pb%%': bid.pbHg,
     '%%SITE%%': location.hostname,
-    '%_pimp%': PV_ID
+    '%_pimp%': PV_ID,
+    '%_hbCpm!': bid.cpm,
+    '%_hbCurrency!': bid.currency
   };
 }
 
@@ -250,9 +274,9 @@ function init(config, userConsent) {
 /** @type {RtdSubmodule} */
 export const geoedgeSubmodule = {
   /**
-     * used to link submodule with realTimeData
-     * @type {string}
-     */
+   * used to link submodule with realTimeData
+   * @type {string}
+   */
   name: SUBMODULE_NAME,
   init,
   onBidResponseEvent: conditionallyWrap

--- a/modules/geolocationRtdProvider.js
+++ b/modules/geolocationRtdProvider.js
@@ -4,6 +4,7 @@ import { ACTIVITY_TRANSMIT_PRECISE_GEO } from '../src/activities/activities.js';
 import { MODULE_TYPE_RTD } from '../src/activities/modules.js';
 import { isActivityAllowed } from '../src/activities/rules.js';
 import { activityParams } from '../src/activities/activityParams.js';
+import {VENDORLESS_GVLID} from '../src/consentHandler.js';
 
 let permissionsAvailable = true;
 let geolocation;
@@ -54,6 +55,7 @@ function init(moduleConfig) {
 }
 export const geolocationSubmodule = {
   name: 'geolocation',
+  gvlid: VENDORLESS_GVLID,
   getBidRequestData: getGeolocationData,
   init: init,
 };

--- a/modules/getintentBidAdapter.js
+++ b/modules/getintentBidAdapter.js
@@ -38,7 +38,7 @@ export const spec = {
    *
    * @param {BidRequest} bid The bid to validate.
    * @return {boolean} True if this is a valid bid, and false otherwise.
-   * */
+   */
   isBidRequestValid: function(bid) {
     return !!(bid && bid.params && bid.params.pid && bid.params.tid);
   },
@@ -108,7 +108,7 @@ function buildUrl(bid) {
  *
  * @param {BidRequest} bidRequest.
  * @return {object} GI bid request.
- * */
+ */
 function buildGiBidRequest(bidRequest) {
   let giBidRequest = {
     bid_id: bidRequest.bidId,
@@ -191,7 +191,7 @@ function addOptional(params, request, props) {
 /**
  * @param {String} s The string representing a size (e.g. "300x250").
  * @return {Number[]} An array with two elements: [width, height] (e.g.: [300, 250]).
- * */
+ */
 function parseSize(s) {
   return s.split('x').map(Number);
 }
@@ -200,7 +200,7 @@ function parseSize(s) {
  * @param {Array} sizes An array of sizes/numbers to be joined into single string.
  *                      May be an array (e.g. [300, 250]) or array of arrays (e.g. [[300, 250], [640, 480]].
  * @return {String} The string with sizes, e.g. array of sizes [[50, 50], [80, 80]] becomes "50x50,80x80" string.
- * */
+ */
 function produceSize (sizes) {
   function sizeToStr(s) {
     if (Array.isArray(s) && s.length === 2 && isInteger(s[0]) && isInteger(s[1])) {

--- a/modules/gjirafaBidAdapter.js
+++ b/modules/gjirafaBidAdapter.js
@@ -116,11 +116,11 @@ export const spec = {
 };
 
 /**
-* Generate size param for bid request using sizes array
-*
-* @param {Array} sizes Possible sizes for the ad unit.
-* @return {string} Processed sizes param to be used for the bid request.
-*/
+ * Generate size param for bid request using sizes array
+ *
+ * @param {Array} sizes Possible sizes for the ad unit.
+ * @return {string} Processed sizes param to be used for the bid request.
+ */
 function generateSizeParam(sizes) {
   return sizes.map(size => size.join(DIMENSION_SEPARATOR)).join(SIZE_SEPARATOR);
 }

--- a/modules/goldfishAdsRtdProvider.js
+++ b/modules/goldfishAdsRtdProvider.js
@@ -74,9 +74,9 @@ const getTargetingDataFromApi = (key) => {
 /**
  * @returns {{
  *    name: 'golfishads.com',
-  *   ext: { segtax: 4},
-  *   segment: string[]
-  * } | null }
+ *   ext: { segtax: 4},
+ *   segment: string[]
+ * } | null }
  */
 export const getStorageData = () => {
   const now = new Date();
@@ -140,9 +140,9 @@ const init = (config, userConsent) => {
  *
  * @param {{
  *  name: string,
-*  ext: { segtax: 4},
-*  segment: {id: string}[]
-* } | null } userData
+ *  ext: { segtax: 4},
+ *  segment: {id: string}[]
+ * } | null } userData
  * @param {*} reqBidsConfigObj
  * @returns
  */

--- a/modules/gravitoIdSystem.js
+++ b/modules/gravitoIdSystem.js
@@ -16,16 +16,16 @@ export const cookieKey = 'gravitompId';
 
 export const gravitoIdSystemSubmodule = {
   /**
-  * used to link submodule with config
-  * @type {string}
-  */
+   * used to link submodule with config
+   * @type {string}
+   */
   name: MODULE_NAME,
 
   /**
-  * performs action to obtain id
-  * @function
-  * @returns { {id: {gravitompId: string}} | undefined }
-  */
+   * performs action to obtain id
+   * @function
+   * @returns { {id: {gravitompId: string}} | undefined }
+   */
   getId: function() {
     const newId = storage.getCookie(cookieKey);
     if (!newId) {
@@ -38,11 +38,11 @@ export const gravitoIdSystemSubmodule = {
   },
 
   /**
-  * decode the stored id value for passing to bid requests
-  * @function
-  * @param { {gravitompId: string} } value
-  * @returns { {gravitompId: {string} } | undefined }
-  */
+   * decode the stored id value for passing to bid requests
+   * @function
+   * @param { {gravitompId: string} } value
+   * @returns { {gravitompId: {string} } | undefined }
+   */
   decode: function(value) {
     if (value && typeof value === 'object') {
       var result = {};

--- a/modules/greenbidsAnalyticsAdapter.js
+++ b/modules/greenbidsAnalyticsAdapter.js
@@ -2,18 +2,20 @@ import {ajax} from '../src/ajax.js';
 import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
 import CONSTANTS from '../src/constants.json';
 import adapterManager from '../src/adapterManager.js';
-import {deepClone, logError, logInfo} from '../src/utils.js';
+import {deepClone, generateUUID, logError, logInfo, logWarn} from '../src/utils.js';
 
 const analyticsType = 'endpoint';
 
-export const ANALYTICS_VERSION = '1.0.0';
+export const ANALYTICS_VERSION = '2.0.0';
 
 const ANALYTICS_SERVER = 'https://a.greenbids.ai';
 
 const {
   EVENTS: {
+    AUCTION_INIT,
     AUCTION_END,
     BID_TIMEOUT,
+    BILLABLE_EVENT,
   }
 } = CONSTANTS;
 
@@ -25,28 +27,53 @@ export const BIDDER_STATUS = {
 
 const analyticsOptions = {};
 
-export const parseBidderCode = function (bid) {
-  let bidderCode = bid.bidderCode || bid.bidder;
-  return bidderCode.toLowerCase();
-};
+export const isSampled = function(greenbidsId, samplingRate) {
+  if (samplingRate < 0 || samplingRate > 1) {
+    logWarn('Sampling rate must be between 0 and 1');
+    return true;
+  }
+  const hashInt = parseInt(greenbidsId.slice(-4), 16);
+
+  return hashInt < samplingRate * (0xFFFF + 1);
+}
 
 export const greenbidsAnalyticsAdapter = Object.assign(adapter({ANALYTICS_SERVER, analyticsType}), {
 
   cachedAuctions: {},
 
   initConfig(config) {
+    analyticsOptions.options = deepClone(config.options);
     /**
      * Required option: pbuid
      * @type {boolean}
      */
-    analyticsOptions.options = deepClone(config.options);
-    if (typeof config.options.pbuid !== 'string' || config.options.pbuid.length < 1) {
+    if (typeof analyticsOptions.options.pbuid !== 'string' || analyticsOptions.options.pbuid.length < 1) {
       logError('"options.pbuid" is required.');
       return false;
     }
 
+    /**
+     *  Deprecate use of integerated 'sampling' config
+     *  replace by greenbidsSampling
+     */
+    if (typeof analyticsOptions.options.sampling === 'number') {
+      logWarn('"options.sampling" is deprecated, please use "greenbidsSampling" instead.');
+      analyticsOptions.options.greenbidsSampling = analyticsOptions.options.sampling;
+      // Set sampling to null to prevent prebid analytics integrated sampling to happen
+      analyticsOptions.options.sampling = null;
+    }
+
+    /**
+     *  Discourage unsampled analytics
+     */
+    if (typeof analyticsOptions.options.greenbidsSampling !== 'number' || analyticsOptions.options.greenbidsSampling >= 1) {
+      logWarn('"options.greenbidsSampling" is not set or >=1, using this analytics module unsampled is discouraged.');
+      analyticsOptions.options.greenbidsSampling = 1;
+    }
+
     analyticsOptions.pbuid = config.options.pbuid
     analyticsOptions.server = ANALYTICS_SERVER;
+
     return true;
   },
   sendEventMessage(endPoint, data) {
@@ -57,13 +84,16 @@ export const greenbidsAnalyticsAdapter = Object.assign(adapter({ANALYTICS_SERVER
     });
   },
   createCommonMessage(auctionId) {
+    const cachedAuction = this.getCachedAuction(auctionId);
     return {
       version: ANALYTICS_VERSION,
       auctionId: auctionId,
       referrer: window.location.href,
-      sampling: analyticsOptions.options.sampling,
+      sampling: analyticsOptions.options.greenbidsSampling,
       prebid: '$prebid.version$',
+      greenbidsId: cachedAuction.greenbidsId,
       pbuid: analyticsOptions.pbuid,
+      billingId: cachedAuction.billingId,
       adUnits: [],
     };
   },
@@ -96,21 +126,22 @@ export const greenbidsAnalyticsAdapter = Object.assign(adapter({ANALYTICS_SERVER
       }
     }
   },
-  createBidMessage(auctionEndArgs, timeoutBids) {
-    logInfo(auctionEndArgs)
+  createBidMessage(auctionEndArgs) {
     const {auctionId, timestamp, auctionEnd, adUnits, bidsReceived, noBids} = auctionEndArgs;
+    const cachedAuction = this.getCachedAuction(auctionId);
     const message = this.createCommonMessage(auctionId);
+    const timeoutBids = cachedAuction.timeoutBids || [];
 
     message.auctionElapsed = (auctionEnd - timestamp);
 
     adUnits.forEach((adUnit) => {
-      const adUnitCode = adUnit.code.toLowerCase();
+      const adUnitCode = adUnit.code?.toLowerCase() || 'unknown_adunit_code';
       message.adUnits.push({
         code: adUnitCode,
         mediaTypes: {
-          ...(adUnit.mediaTypes.banner !== undefined) && {banner: adUnit.mediaTypes.banner},
-          ...(adUnit.mediaTypes.video !== undefined) && {video: adUnit.mediaTypes.video},
-          ...(adUnit.mediaTypes.native !== undefined) && {native: adUnit.mediaTypes.native}
+          ...(adUnit.mediaTypes?.banner !== undefined) && {banner: adUnit.mediaTypes.banner},
+          ...(adUnit.mediaTypes?.video !== undefined) && {video: adUnit.mediaTypes.video},
+          ...(adUnit.mediaTypes?.native !== undefined) && {native: adUnit.mediaTypes.native}
         },
         ortb2Imp: adUnit.ortb2Imp || {},
         bidders: [],
@@ -130,13 +161,26 @@ export const greenbidsAnalyticsAdapter = Object.assign(adapter({ANALYTICS_SERVER
   getCachedAuction(auctionId) {
     this.cachedAuctions[auctionId] = this.cachedAuctions[auctionId] || {
       timeoutBids: [],
+      greenbidsId: null,
+      billingId: null,
+      isSampled: true,
     };
     return this.cachedAuctions[auctionId];
+  },
+  handleAuctionInit(auctionInitArgs) {
+    const cachedAuction = this.getCachedAuction(auctionInitArgs.auctionId);
+    try {
+      cachedAuction.greenbidsId = auctionInitArgs.adUnits[0].ortb2Imp.ext.greenbids.greenbidsId;
+    } catch (e) {
+      logInfo("Couldn't find Greenbids RTD info, assuming analytics only");
+      cachedAuction.greenbidsId = generateUUID();
+    }
+    cachedAuction.isSampled = isSampled(cachedAuction.greenbidsId, analyticsOptions.options.greenbidsSampling);
   },
   handleAuctionEnd(auctionEndArgs) {
     const cachedAuction = this.getCachedAuction(auctionEndArgs.auctionId);
     this.sendEventMessage('/',
-      this.createBidMessage(auctionEndArgs, cachedAuction.timeoutBids)
+      this.createBidMessage(auctionEndArgs, cachedAuction)
     );
   },
   handleBidTimeout(timeoutBids) {
@@ -145,14 +189,34 @@ export const greenbidsAnalyticsAdapter = Object.assign(adapter({ANALYTICS_SERVER
       cachedAuction.timeoutBids.push(bid);
     });
   },
+  handleBillable(billableArgs) {
+    const cachedAuction = this.getCachedAuction(billableArgs.auctionId);
+    /* Filter Greenbids Billable Events only */
+    if (billableArgs.vendor === 'greenbidsRtdProvider') {
+      cachedAuction.billingId = billableArgs.billingId || 'unknown_billing_id';
+    }
+  },
   track({eventType, args}) {
-    switch (eventType) {
-      case BID_TIMEOUT:
-        this.handleBidTimeout(args);
-        break;
-      case AUCTION_END:
-        this.handleAuctionEnd(args);
-        break;
+    try {
+      if (eventType === AUCTION_INIT) {
+        this.handleAuctionInit(args);
+      }
+
+      if (this.getCachedAuction(args?.auctionId)?.isSampled ?? true) {
+        switch (eventType) {
+          case BID_TIMEOUT:
+            this.handleBidTimeout(args);
+            break;
+          case AUCTION_END:
+            this.handleAuctionEnd(args);
+            break;
+          case BILLABLE_EVENT:
+            this.handleBillable(args);
+            break;
+        }
+      }
+    } catch (e) {
+      logWarn('There was an error handling event ' + eventType);
     }
   },
   getAnalyticsOptions() {

--- a/modules/greenbidsAnalyticsAdapter.md
+++ b/modules/greenbidsAnalyticsAdapter.md
@@ -1,23 +1,24 @@
-# Overview
+#### Registration
 
-```
-Module Name: Greenbids Analytics Adapter
-Module Type: Analytics Adapter
-Maintainer: jb@greenbids.ai
-```
+The Greenbids Analytics adapter requires setup and approval from the
+Greenbids team. Please reach out to our team for more information [greenbids.ai](https://greenbids.ai).
 
-# Description
+#### Analytics Options
 
-Analytics adapter for Greenbids
+{: .table .table-bordered .table-striped }
+| Name         | Scope              | Description                                                                                                                 | Example                                                                             | Type             |
+|-------------|---------|--------------------|-----------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|------------------|
+| pbuid | required  | The Greenbids Publisher ID | greenbids-publisher-1  | string |
+| greenbidsSampling | optional  | sampling factor [0-1] (a value of 0.1 will filter 90% of the traffic) | 1.0  | float |
 
-# Test Parameters
+### Example Configuration
 
-```
-{
-  provider: 'greenbids',
-  options: {
-    pbuid: "PBUID_FROM_GREENBIDS"
-    sampling: 1.0
-  }
-}
+```javascript
+    pbjs.enableAnalytics({
+        provider: 'greenbids',
+        options: {
+            pbuid: "greenbids-publisher-1" // please contact Greenbids to get a pbuid for yourself
+            greenbidsSampling: 1.0
+        }
+    });
 ```

--- a/modules/greenbidsRtdProvider.md
+++ b/modules/greenbidsRtdProvider.md
@@ -2,6 +2,7 @@
 
 ```
 Module Name: Greenbids RTD Provider
+Module Version: 2.0.0
 Module Type: RTD Provider
 Maintainer: jb@greenbids.ai
 ```
@@ -21,7 +22,6 @@ This module is configured as part of the `realTimeData.dataProviders` object.
 | `waitForIt `     | required (mandatory true value) | Tells prebid auction to wait for the result of this module | `'true'`   | `boolean` |
 | `params`      | required |  | | `Object` |
 | `params.pbuid`      | required | The client site id provided by Greenbids. | `'TEST_FROM_GREENBIDS'` | `string` |
-| `params.targetTPR`      | optional (default 0.95) | Target True positive rate for the throttling model | `0.99` | `[0-1]` |
 | `params.timeout`      | optional (default 200) | Maximum amount of milliseconds allowed for module to finish working (has to be <= to the realTimeData.auctionDelay property) | `200` | `number` |
 
 #### Example

--- a/modules/growthCodeRtdProvider.js
+++ b/modules/growthCodeRtdProvider.js
@@ -81,8 +81,8 @@ function callServer(configParams, items, expiresAt, userConsent) {
     url = tryAppendQueryString(url, 'pid', configParams.pid);
     url = tryAppendQueryString(url, 'u', window.location.href);
     url = tryAppendQueryString(url, 'gcid', gcid);
-    if ((userConsent !== null) && (userConsent.gdpr !== null) && (userConsent.gdpr.consentData.getTCData.tcString)) {
-      url = tryAppendQueryString(url, 'tcf', userConsent.gdpr.consentData.getTCData.tcString)
+    if ((userConsent !== null) && (userConsent.gdpr !== null) && (userConsent.gdpr.consentString)) {
+      url = tryAppendQueryString(url, 'tcf', userConsent.gdpr.consentString)
     }
 
     ajax.ajaxBuilder()(url, {

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -345,15 +345,15 @@ function buildRequests(validBidRequests, bidderRequest) {
     // ADTS-134 Retrieve ID envelopes
     for (const eid in eids) data[eid] = eids[eid];
 
-    // ADJS-1024 & ADSS-1297 & ADTS-175
-    gpid && (data.gpid = gpid);
-
     if (mediaTypes.banner) {
       sizes = mediaTypes.banner.sizes;
     } else if (mediaTypes.video) {
       sizes = mediaTypes.video.playerSize;
       data = _getVidParams(mediaTypes.video);
     }
+
+    // ADJS-1024 & ADSS-1297 & ADTS-175
+    gpid && (data.gpid = gpid);
 
     if (pageViewId) {
       data.pv = pageViewId;

--- a/modules/hadronIdSystem.js
+++ b/modules/hadronIdSystem.js
@@ -9,8 +9,11 @@ import {ajax} from '../src/ajax.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {submodule} from '../src/hook.js';
 import {isFn, isStr, isPlainObject, logError, logInfo} from '../src/utils.js';
+import { config } from '../src/config.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
+import { gdprDataHandler, uspDataHandler, gppDataHandler } from '../src/adapterManager.js';
 
+const LOG_PREFIX = '[hadronIdSystem]';
 const HADRONID_LOCAL_NAME = 'auHadronId';
 const MODULE_NAME = 'hadronId';
 const AU_GVLID = 561;
@@ -41,6 +44,8 @@ function paramOrDefault(param, defaultVal, arg) {
 const urlAddParams = (url, params) => {
   return url + (url.indexOf('?') > -1 ? '&' : '?') + params
 }
+
+const isDebug = config.getConfig('debug') || false;
 
 /** @type {Submodule} */
 export const hadronIdSubmodule = {
@@ -88,7 +93,7 @@ export const hadronIdSubmodule = {
             } catch (error) {
               logError(error);
             }
-            logInfo(`Response from backend is ${responseObj}`);
+            logInfo(LOG_PREFIX, `Response from backend is ${response}`, responseObj);
             hadronId = responseObj['hadronId'];
             storage.setDataInLocalStorage(HADRONID_LOCAL_NAME, hadronId);
             responseObj = {id: {hadronId}};
@@ -100,13 +105,34 @@ export const hadronIdSubmodule = {
           callback();
         }
       };
-      logInfo('HadronId not found in storage, calling backend...');
-      const url = urlAddParams(
+      let url = urlAddParams(
         // config.params.url and config.params.urlArg are not documented
         // since their use is for debugging purposes only
         paramOrDefault(config.params.url, DEFAULT_HADRON_URL_ENDPOINT, config.params.urlArg),
-        `partner_id=${partnerId}&_it=prebid`
+        `partner_id=${partnerId}&_it=prebid&t=1&src=id` // src=id => the backend was called from getId
       );
+      if (isDebug) {
+        url += '&debug=1'
+      }
+      const gdprConsent = gdprDataHandler.getConsentData()
+      if (gdprConsent) {
+        url += `${gdprConsent.consentString ? '&gdprString=' + encodeURIComponent(gdprConsent.consentString) : ''}`;
+        url += `&gdpr=${gdprConsent.gdprApplies === true ? 1 : 0}`;
+      }
+
+      const usPrivacyString = uspDataHandler.getConsentData();
+      if (usPrivacyString) {
+        url += `&us_privacy=${encodeURIComponent(usPrivacyString)}`;
+      }
+
+      const gppConsent = gppDataHandler.getConsentData();
+      if (gppConsent) {
+        url += `${gppConsent.gppString ? '&gpp=' + encodeURIComponent(gppConsent.gppString) : ''}`;
+        url += `${gppConsent.applicableSections ? '&gpp_sid=' + encodeURIComponent(gppConsent.applicableSections) : ''}`;
+      }
+
+      logInfo(LOG_PREFIX, `hadronId not found in storage, calling home (${url})`);
+
       ajax(url, callbacks, undefined, {method: 'GET'});
     };
     return {callback: resp};

--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -19,7 +19,7 @@ import {ajax} from '../src/ajax.js';
 import {submodule} from '../src/hook.js';
 import {getRefererInfo} from '../src/refererDetection.js';
 import {getStorageManager} from '../src/storageManager.js';
-import {uspDataHandler} from '../src/adapterManager.js';
+import {uspDataHandler, gppDataHandler} from '../src/adapterManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
 
 const MODULE_NAME = 'id5Id';
@@ -118,7 +118,7 @@ export const id5IdSubmodule = {
     }
 
     const resp = function (cbFunction) {
-      new IdFetchFlow(submoduleConfig, consentData, cacheIdObj, uspDataHandler.getConsentData()).execute()
+      new IdFetchFlow(submoduleConfig, consentData, cacheIdObj, uspDataHandler.getConsentData(), gppDataHandler.getConsentData()).execute()
         .then(response => {
           cbFunction(response)
         })
@@ -170,11 +170,12 @@ export const id5IdSubmodule = {
 };
 
 class IdFetchFlow {
-  constructor(submoduleConfig, gdprConsentData, cacheIdObj, usPrivacyData) {
+  constructor(submoduleConfig, gdprConsentData, cacheIdObj, usPrivacyData, gppData) {
     this.submoduleConfig = submoduleConfig
     this.gdprConsentData = gdprConsentData
     this.cacheIdObj = cacheIdObj
     this.usPrivacyData = usPrivacyData
+    this.gppData = gppData
   }
 
   execute() {
@@ -285,6 +286,11 @@ class IdFetchFlow {
     if (this.usPrivacyData !== undefined && !isEmpty(this.usPrivacyData) && !isEmptyStr(this.usPrivacyData)) {
       data.us_privacy = this.usPrivacyData;
     }
+    if (this.gppData) {
+      data.gpp_string = this.gppData.gppString;
+      data.gpp_sid = this.gppData.applicableSections;
+    }
+
     if (signature !== undefined && !isEmptyStr(signature)) {
       data.s = signature;
     }

--- a/modules/idWardRtdProvider.js
+++ b/modules/idWardRtdProvider.js
@@ -28,9 +28,9 @@ function addRealTimeData(ortb2, rtd) {
 }
 
 /**
-  * Try parsing stringified array of segment IDs.
-  * @param {String} data
-  */
+ * Try parsing stringified array of segment IDs.
+ * @param {String} data
+ */
 function tryParse(data) {
   try {
     return JSON.parse(data);
@@ -41,12 +41,12 @@ function tryParse(data) {
 }
 
 /**
-  * Real-time data retrieval from ID Ward
-  * @param {Object} reqBidsConfigObj
-  * @param {function} onDone
-  * @param {Object} rtdConfig
-  * @param {Object} userConsent
-  */
+ * Real-time data retrieval from ID Ward
+ * @param {Object} reqBidsConfigObj
+ * @param {function} onDone
+ * @param {Object} rtdConfig
+ * @param {Object} userConsent
+ */
 export function getRealTimeData(reqBidsConfigObj, onDone, rtdConfig, userConsent) {
   if (rtdConfig && isPlainObject(rtdConfig.params)) {
     const jsonData = storage.getDataFromLocalStorage(rtdConfig.params.cohortStorageKey)
@@ -85,11 +85,11 @@ export function getRealTimeData(reqBidsConfigObj, onDone, rtdConfig, userConsent
 }
 
 /**
-  * Module init
-  * @param {Object} provider
-  * @param {Object} userConsent
-  * @return {boolean}
-  */
+ * Module init
+ * @param {Object} provider
+ * @param {Object} userConsent
+ * @return {boolean}
+ */
 function init(provider, userConsent) {
   return true;
 }

--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -54,7 +54,6 @@ export const identityLinkSubmodule = {
     }
     const hasGdpr = (consentData && typeof consentData.gdprApplies === 'boolean' && consentData.gdprApplies) ? 1 : 0;
     const gdprConsentString = hasGdpr ? consentData.consentString : '';
-    const tcfPolicyV2 = utils.deepAccess(consentData, 'vendorData.tcfPolicyVersion') === 2;
     // use protocol relative urls for http or https
     if (hasGdpr && (!gdprConsentString || gdprConsentString === '')) {
       utils.logInfo('identityLink: Consent string is required to call envelope API.');
@@ -64,7 +63,7 @@ export const identityLinkSubmodule = {
     const gppString = gppData && gppData.gppString ? gppData.gppString : false;
     const gppSectionId = gppData && gppData.gppString && gppData.applicableSections.length > 0 && gppData.applicableSections[0] !== -1 ? gppData.applicableSections[0] : false;
     const hasGpp = gppString && gppSectionId;
-    const url = `https://api.rlcdn.com/api/identity/envelope?pid=${configParams.pid}${hasGdpr ? (tcfPolicyV2 ? '&ct=4&cv=' : '&ct=1&cv=') + gdprConsentString : ''}${hasGpp ? '&gpp=' + gppString + '&gpp_sid=' + gppSectionId : ''}`;
+    const url = `https://api.rlcdn.com/api/identity/envelope?pid=${configParams.pid}${hasGdpr ? '&ct=4&cv=' + gdprConsentString : ''}${hasGpp ? '&gpp=' + gppString + '&gpp_sid=' + gppSectionId : ''}`;
     let resp;
     resp = function (callback) {
       // Check ats during callback so it has a chance to initialise.

--- a/modules/imRtdProvider.js
+++ b/modules/imRtdProvider.js
@@ -50,8 +50,8 @@ function getSegments(segments, moduleConfig) {
 }
 
 /**
-* @param {string} bidderName
-*/
+ * @param {string} bidderName
+ */
 export function getBidderFunction(bidderName) {
   const biddersFunction = {
     pubmatic: function (bid, data, moduleConfig) {

--- a/modules/impactifyBidAdapter.js
+++ b/modules/impactifyBidAdapter.js
@@ -360,7 +360,7 @@ export const spec = {
   /**
    * Register bidder specific code, which will execute if a bid from this bidder won the auction
    * @param {Bid} The bid that won the auction
-  */
+   */
   onBidWon: function (bid) {
     ajax(`${LOGGER_URI}/prebid/won`, null, JSON.stringify(bid), {
       method: 'POST',
@@ -373,7 +373,7 @@ export const spec = {
   /**
    * Register bidder specific code, which will execute if bidder timed out after an auction
    * @param {data} Containing timeout specific data
-  */
+   */
   onTimeout: function (data) {
     ajax(`${LOGGER_URI}/prebid/timeout`, null, JSON.stringify(data[0]), {
       method: 'POST',

--- a/modules/incrxBidAdapter.js
+++ b/modules/incrxBidAdapter.js
@@ -12,22 +12,22 @@ export const spec = {
   supportedMediaTypes: [BANNER],
 
   /**
-  * Determines whether or not the given bid request is valid.
-  *
-  * @param {BidRequest} bid The bid params to validate.
-  * @return boolean True if this is a valid bid, and false otherwise.
-  */
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
   isBidRequestValid: function (bid) {
     return !!(bid.params.placementId);
   },
 
   /**
-  * Make a server request from the list of BidRequests.
-  *
-  * @param validBidRequests
-  * @param bidderRequest
-  * @return Array Info describing the request to the server.
-  */
+   * Make a server request from the list of BidRequests.
+   *
+   * @param validBidRequests
+   * @param bidderRequest
+   * @return Array Info describing the request to the server.
+   */
   buildRequests: function (validBidRequests, bidderRequest) {
     return validBidRequests.map(bidRequest => {
       const sizes = parseSizesInput(bidRequest.params.size || bidRequest.sizes);
@@ -53,11 +53,11 @@ export const spec = {
   },
 
   /**
-  * Unpack the response from the server into a list of bids.
-  *
-  * @param {ServerResponse} serverResponse A successful response from the server.
-  * @return {Bid[]} An array of bids which were nested inside the server.
-  */
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
   interpretResponse: function (serverResponse) {
     const response = serverResponse.body;
     const bids = [];

--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -68,17 +68,42 @@ function buildBanner(bidRequest) {
 }
 
 function buildVideo(bidRequest) {
-  const w = deepAccess(bidRequest, 'mediaTypes.video.w');
-  const h = deepAccess(bidRequest, 'mediaTypes.video.h');
+  let w = deepAccess(bidRequest, 'mediaTypes.video.w');
+  let h = deepAccess(bidRequest, 'mediaTypes.video.h');
   const mimes = deepAccess(bidRequest, 'mediaTypes.video.mimes');
   const placement = deepAccess(bidRequest, 'mediaTypes.video.placement') || 3;
+  const plcmt = deepAccess(bidRequest, 'mediaTypes.video.plcmt') || undefined;
+  const playerSize = deepAccess(bidRequest, 'mediaTypes.video.playerSize');
 
-  return {
+  if (!w && playerSize) {
+    if (Array.isArray(playerSize[0])) {
+      w = parseInt(playerSize[0][0], 10);
+    } else if (typeof playerSize[0] === 'number' && !isNaN(playerSize[0])) {
+      w = parseInt(playerSize[0], 10);
+    }
+  }
+  if (!h && playerSize) {
+    if (Array.isArray(playerSize[0])) {
+      h = parseInt(playerSize[0][1], 10);
+    } else if (typeof playerSize[1] === 'number' && !isNaN(playerSize[1])) {
+      h = parseInt(playerSize[1], 10);
+    }
+  }
+
+  let videoObj = {
     placement,
     mimes,
     w,
     h,
   }
+
+  if (plcmt) {
+    videoObj = {
+      ...videoObj,
+      plcmt
+    }
+  }
+  return videoObj
 }
 
 function buildImpression(bidRequest) {
@@ -235,7 +260,11 @@ function buildBid(bid, bidderRequest) {
     meta.advertiserDomains = bid.adomain
   }
 
-  return {
+  let mediaType = 'banner';
+  if (bid.adm && bid.adm.includes('<VAST')) {
+    mediaType = 'video';
+  }
+  let bidResponse = {
     requestId: bid.impid,
     creativeId: bid.crid,
     cpm: bid.price,
@@ -244,11 +273,22 @@ function buildBid(bid, bidderRequest) {
     ttl: bid.exp || config.getConfig('insticator.bidTTL') || BID_TTL,
     width: bid.w,
     height: bid.h,
-    mediaType: 'banner',
+    mediaType: mediaType,
     ad: bid.adm,
     adUnitCode: originalBid.adUnitCode,
     ...(Object.keys(meta).length > 0 ? {meta} : {})
   };
+
+  if (mediaType === 'video') {
+    bidResponse.vastXml = bid.adm;
+  }
+
+  // Inticator bid adaptor only returns `vastXml` for video bids. No VastUrl or videoCache.
+  if (!bidResponse.vastUrl && bidResponse.vastXml) {
+    bidResponse.vastUrl = 'data:text/xml;charset=utf-8;base64,' + window.btoa(bidResponse.vastXml.replace(/\\"/g, '"'));
+  }
+
+  return bidResponse;
 }
 
 function buildBidSet(seatbid, bidderRequest) {
@@ -315,9 +355,26 @@ function validateVideo(bid) {
     return true;
   }
 
+  let w = deepAccess(bid, 'mediaTypes.video.w');
+  let h = deepAccess(bid, 'mediaTypes.video.h');
+  const playerSize = deepAccess(bid, 'mediaTypes.video.playerSize');
+  if (!w && playerSize) {
+    if (Array.isArray(playerSize[0])) {
+      w = parseInt(playerSize[0][0], 10);
+    } else if (typeof playerSize[0] === 'number' && !isNaN(playerSize[0])) {
+      w = parseInt(playerSize[0], 10);
+    }
+  }
+  if (!h && playerSize) {
+    if (Array.isArray(playerSize[0])) {
+      h = parseInt(playerSize[0][1], 10);
+    } else if (typeof playerSize[1] === 'number' && !isNaN(playerSize[1])) {
+      h = parseInt(playerSize[1], 10);
+    }
+  }
   const videoSize = [
-    deepAccess(bid, 'mediaTypes.video.w'),
-    deepAccess(bid, 'mediaTypes.video.h'),
+    w,
+    h,
   ];
 
   if (
@@ -338,6 +395,13 @@ function validateVideo(bid) {
 
   if (typeof placement !== 'undefined' && typeof placement !== 'number') {
     logError('insticator: video placement is not a number');
+    return false;
+  }
+
+  const plcmt = deepAccess(bid, 'mediaTypes.video.plcmt');
+
+  if (typeof plcmt !== 'undefined' && typeof plcmt !== 'number') {
+    logError('insticator: video plcmt is not a number');
     return false;
   }
 

--- a/modules/integr8BidAdapter.js
+++ b/modules/integr8BidAdapter.js
@@ -128,11 +128,11 @@ export const spec = {
 };
 
 /**
-* Generate size param for bid request using sizes array
-*
-* @param {Array} sizes Possible sizes for the ad unit.
-* @return {string} Processed sizes param to be used for the bid request.
-*/
+ * Generate size param for bid request using sizes array
+ *
+ * @param {Array} sizes Possible sizes for the ad unit.
+ * @return {string} Processed sizes param to be used for the bid request.
+ */
 function generateSizeParam(sizes) {
   return sizes.map(size => size.join(DIMENSION_SEPARATOR)).join(SIZE_SEPARATOR);
 }

--- a/modules/invibesBidAdapter.js
+++ b/modules/invibesBidAdapter.js
@@ -9,7 +9,7 @@ const CONSTANTS = {
   SYNC_ENDPOINT: 'https://k.r66net.com/GetUserSync',
   TIME_TO_LIVE: 300,
   DEFAULT_CURRENCY: 'EUR',
-  PREBID_VERSION: 10,
+  PREBID_VERSION: 11,
   METHOD: 'GET',
   INVIBES_VENDOR_ID: 436,
   USERID_PROVIDERS: ['pubcid', 'pubProvidedId', 'uid2', 'zeotapIdPlus', 'id5id'],
@@ -49,13 +49,35 @@ registerBidder(spec);
 // some state info is required: cookie info, unique user visit id
 const topWin = getTopMostWindow();
 let invibes = topWin.invibes = topWin.invibes || {};
-invibes.purposes = invibes.purposes || [false, false, false, false, false, false, false, false, false, false];
-invibes.legitimateInterests = invibes.legitimateInterests || [false, false, false, false, false, false, false, false, false, false];
+invibes.purposes = invibes.purposes || [false, false, false, false, false, false, false, false, false, false, false];
+invibes.legitimateInterests = invibes.legitimateInterests || [false, false, false, false, false, false, false, false, false, false, false];
 invibes.placementBids = invibes.placementBids || [];
 invibes.pushedCids = invibes.pushedCids || {};
 let preventPageViewEvent = false;
+let isInfiniteScrollPage = false;
+let isPlacementRefresh = false;
 let _customUserSync;
 let _disableUserSyncs;
+
+function updateInfiniteScrollFlag() {
+  const { scrollHeight } = document.documentElement;
+
+  if (invibes.originalURL === undefined) {
+    invibes.originalURL = window.location.href;
+    return;
+  }
+
+  if (invibes.originalScrollHeight === undefined) {
+    invibes.originalScrollHeight = scrollHeight;
+    return;
+  }
+
+  const currentURL = window.location.href;
+
+  if (scrollHeight > invibes.originalScrollHeight && invibes.originalURL !== currentURL) {
+    isInfiniteScrollPage = true;
+  }
+}
 
 function isBidRequestValid(bid) {
   if (typeof bid.params !== 'object') {
@@ -87,10 +109,24 @@ function buildRequest(bidRequests, bidderRequest) {
   const _placementIds = [];
   const _adUnitCodes = [];
   let _customEndpoint, _userId, _domainId;
-  let _ivAuctionStart = bidderRequest.auctionStart || Date.now();
+  let _ivAuctionStart = Date.now();
+  window.invibes = window.invibes || {};
+  window.invibes.placementIds = window.invibes.placementIds || [];
+
+  if (isInfiniteScrollPage == false) {
+    updateInfiniteScrollFlag();
+  }
 
   bidRequests.forEach(function (bidRequest) {
     bidRequest.startTime = new Date().getTime();
+
+    if (window.invibes.placementIds.includes(bidRequest.params.placementId)) {
+      isPlacementRefresh = true;
+    }
+
+    window.invibes.placementIds.push(bidRequest.params.placementId);
+
+    _placementIds.push(bidRequest.params.placementId);
     _placementIds.push(bidRequest.params.placementId);
     _adUnitCodes.push(bidRequest.adUnitCode);
     _domainId = _domainId || bidRequest.params.domainId;
@@ -138,6 +174,8 @@ function buildRequest(bidRequests, bidderRequest) {
     tc: invibes.gdpr_consent,
     isLocalStorageEnabled: storage.hasLocalStorage(),
     preventPageViewEvent: preventPageViewEvent,
+    isPlacementRefresh: isPlacementRefresh,
+    isInfiniteScrollPage: isInfiniteScrollPage,
   };
 
   let lid = readFromLocalStorage('ivbsdid');
@@ -368,7 +406,9 @@ function addMeta(bidModelMeta) {
 }
 
 function generateRandomId() {
-  return (Math.round(Math.random() * 1e12)).toString(36).substring(0, 10);
+  return '10000000100040008000100000000000'.replace(/[018]/g, c =>
+    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+  );
 }
 
 function getDocumentLocation(bidderRequest) {
@@ -568,7 +608,7 @@ function readGdprConsent(gdprConsent) {
     }
 
     let legitimateInterests = getLegitimateInterests(gdprConsent.vendorData);
-    tryCopyValueToArray(legitimateInterests, invibes.legitimateInterests, 10);
+    tryCopyValueToArray(legitimateInterests, invibes.legitimateInterests, purposesLength);
 
     let invibesVendorId = CONSTANTS.INVIBES_VENDOR_ID.toString(10);
     let vendorConsents = getVendorConsents(gdprConsent.vendorData);
@@ -621,6 +661,10 @@ function tryCopyValueToArray(value, target, length) {
 
 function getPurposeConsentsCounter(vendorData) {
   if (vendorData.purpose && vendorData.purpose.consents) {
+    if (vendorData.tcfPolicyVersion >= 4) {
+      return 11;
+    }
+
     return 10;
   }
 

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -535,7 +535,7 @@ function isValidSize(size) {
  * Determines whether or not the given size object is an element of the size
  * array.
  *
- * @param  {array}  sizeArray The size array.
+ * @param  {Array}  sizeArray The size array.
  * @param  {object} size      The size object.
  * @return {boolean}          True if the size object is an element of the size array, and false
  *                            otherwise.
@@ -590,7 +590,7 @@ function checkVideoParams(mediaTypeVideoRef, paramsVideoRef) {
  * Get One size from Size Array
  * [[250,350]] -> [250, 350]
  * [250, 350]  -> [250, 350]
- * @param {array} sizes array of sizes
+ * @param {Array} sizes array of sizes
  */
 function getFirstSize(sizes = []) {
   if (isValidSize(sizes)) {
@@ -607,7 +607,7 @@ function getFirstSize(sizes = []) {
  *
  * @param  {number}  bidFloor    The bidFloor parameter inside bid request config.
  * @param  {number}  bidFloorCur The bidFloorCur parameter inside bid request config.
- * @return {bool}                True if this is a valid bidFloor parameters format, and false
+ * @return {boolean}                True if this is a valid bidFloor parameters format, and false
  *                               otherwise.
  */
 function isValidBidFloorParams(bidFloor, bidFloorCur) {
@@ -630,7 +630,7 @@ function nativeMediaTypeValid(bid) {
  * Get bid request object with the associated id.
  *
  * @param  {*}      id          Id of the impression.
- * @param  {array}  impressions List of impressions sent in the request.
+ * @param  {Array}  impressions List of impressions sent in the request.
  * @return {object}             The impression with the associated id.
  */
 function getBidRequest(id, impressions, validBidRequests) {
@@ -648,7 +648,7 @@ function getBidRequest(id, impressions, validBidRequests) {
 /**
  * From the userIdAsEids array, filter for the ones our adserver can use, and modify them
  * for our purposes, e.g. add rtiPartner
- * @param {array} allEids userIdAsEids passed in by prebid
+ * @param {Array} allEids userIdAsEids passed in by prebid
  * @return {object} contains toSend (eids to send to the adserver) and seenSources (used to filter
  *                  identity info from IX Library)
  */
@@ -676,11 +676,11 @@ function getEidInfo(allEids) {
 /**
  * Builds a request object to be sent to the ad server based on bid requests.
  *
- * @param  {array}  validBidRequests A list of valid bid request config objects.
+ * @param  {Array}  validBidRequests A list of valid bid request config objects.
  * @param  {object} bidderRequest    An object containing other info like gdprConsent.
  * @param  {object} impressions      An object containing a list of impression objects describing the bids for each transaction
- * @param  {array}  version          Endpoint version denoting banner, video or native.
- * @return {array}                   List of objects describing the request to the server.
+ * @param  {Array}  version          Endpoint version denoting banner, video or native.
+ * @return {Array}                   List of objects describing the request to the server.
  *
  */
 function buildRequest(validBidRequests, bidderRequest, impressions, version) {
@@ -789,8 +789,8 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
 /**
  * addRTI adds RTI info of the partner to retrieved user IDs from prebid ID module.
  *
- * @param {array} userEids userEids info retrieved from prebid
- * @param {array} eidInfo eidInfo info from prebid
+ * @param {Array} userEids userEids info retrieved from prebid
+ * @param {Array} eidInfo eidInfo info from prebid
  */
 function addRTI(userEids, eidInfo) {
   let identityInfo = window.headertag.getIdentityInfo();
@@ -809,7 +809,7 @@ function addRTI(userEids, eidInfo) {
 
 /**
  * createRequest creates the base request object
- * @param  {array}  validBidRequests A list of valid bid request config objects.
+ * @param  {Array}  validBidRequests A list of valid bid request config objects.
  * @return {object}                  Object describing the request to the server.
  */
 function createRequest(validBidRequests) {
@@ -849,9 +849,9 @@ function addRequestedFeatureToggles(r, requestedFeatureToggles) {
  *
  * @param  {object} r                Base reuqest object.
  * @param  {object} bidderRequest    An object containing other info like gdprConsent.
- * @param  {array}  impressions      A list of impressions to be added to the request.
- * @param  {array}  validBidRequests A list of valid bid request config objects.
- * @param  {array}  userEids         User ID info retrieved from Prebid ID module.
+ * @param  {Array}  impressions      A list of impressions to be added to the request.
+ * @param  {Array}  validBidRequests A list of valid bid request config objects.
+ * @param  {Array}  userEids         User ID info retrieved from Prebid ID module.
  * @return {object}                  Enriched object describing the request to the server.
  */
 function enrichRequest(r, bidderRequest, impressions, validBidRequests, userEids) {
@@ -958,10 +958,10 @@ function applyRegulations(r, bidderRequest) {
 /**
  * addImpressions adds impressions to request object
  *
- * @param  {array}  impressions        List of impressions to be added to the request.
- * @param  {array}  impKeys            List of impression keys.
+ * @param  {Array}  impressions        List of impressions to be added to the request.
+ * @param  {Array}  impKeys            List of impression keys.
  * @param  {object} r                  Reuqest object.
- * @param  {int}    adUnitIndex        Index of the current add unit
+ * @param  {number}    adUnitIndex        Index of the current add unit
  * @return {object}                    Reqyest object with added impressions describing the request to the server.
  */
 function addImpressions(impressions, impKeys, r, adUnitIndex) {
@@ -1113,7 +1113,7 @@ This function retrieves the page URL and appends first party data query paramete
 to it without adding duplicate query parameters. Returns original referer URL if no IX FPD exists.
 @param {Object} bidderRequest - The bidder request object containing information about the bid and the page.
 @returns {string} - The modified page URL with first party data query parameters appended.
-*/
+ */
 function getIxFirstPartyDataPageUrl (bidderRequest) {
   // Parse additional runtime configs.
   const bidderCode = (bidderRequest && bidderRequest.bidderCode) || 'ix';
@@ -1143,7 +1143,7 @@ This function appends the provided query parameters to the given URL without add
 @param {string} url - The base URL to which query parameters will be appended.
 @param {Object} params - An object containing key-value pairs of query parameters to append.
 @returns {string} - The modified URL with the provided query parameters appended.
-*/
+ */
 function appendIXQueryParams(bidderRequest, url, params) {
   let urlObj;
   try {
@@ -1228,10 +1228,10 @@ function addAdUnitFPD(imp, bid) {
 /**
  * addIdentifiersInfo adds indentifier info to ixDaig.
  *
- * @param  {array}  impressions        List of impressions to be added to the request.
+ * @param  {Array}  impressions        List of impressions to be added to the request.
  * @param  {object} r                  Reuqest object.
- * @param  {array}  impKeys            List of impression keys.
- * @param  {int}    adUnitIndex        Index of the current add unit
+ * @param  {Array}  impKeys            List of impression keys.
+ * @param  {number}    adUnitIndex        Index of the current add unit
  * @param  {object} payload            Request payload object.
  * @param  {string} baseUrl            Base exchagne URL.
  * @return {object}                    Reqyest object with added indentigfier info to ixDiag.
@@ -1254,7 +1254,7 @@ function addIdentifiersInfo(impressions, r, impKeys, adUnitIndex, payload, baseU
 /**
  * Return an object of user IDs stored by Prebid User ID module
  *
- * @returns {array} ID providers that are present in userIds
+ * @returns {Array} ID providers that are present in userIds
  */
 function _getUserIds(bidRequest) {
   const userIds = bidRequest.userId || {};
@@ -1265,8 +1265,8 @@ function _getUserIds(bidRequest) {
 /**
  * Calculates IX diagnostics values and packages them into an object
  *
- * @param {array} validBidRequests - The valid bid requests from prebid
- * @param {bool} fledgeEnabled - Flag indicating if protected audience (fledge) is enabled
+ * @param {Array} validBidRequests - The valid bid requests from prebid
+ * @param {boolean} fledgeEnabled - Flag indicating if protected audience (fledge) is enabled
  * @return {Object} IX diag values for ad units
  */
 function buildIXDiag(validBidRequests, fledgeEnabled) {
@@ -1327,8 +1327,8 @@ function buildIXDiag(validBidRequests, fledgeEnabled) {
 
 /**
  *
- * @param  {array}   bannerSizeList list of banner sizes
- * @param  {array}   bannerSize the size to be removed
+ * @param  {Array}   bannerSizeList list of banner sizes
+ * @param  {Array}   bannerSize the size to be removed
  * @return {boolean} true if successfully removed, false if not found
  */
 
@@ -1487,7 +1487,7 @@ function updateMissingSizes(validBidRequest, missingBannerSizes, imp) {
 /**
  * @param  {object} bid      ValidBidRequest object, used to adjust floor
  * @param  {object} imp      Impression object to be modified
- * @param  {array}  newSize  The new size to be applied
+ * @param  {Array}  newSize  The new size to be applied
  * @return {object} newImp   Updated impression object
  */
 function createMissingBannerImp(bid, imp, newSize) {
@@ -1786,7 +1786,7 @@ export const spec = {
   /**
    * Make a server request from the list of BidRequests.
    *
-   * @param  {array}  validBidRequests A list of valid bid request config objects.
+   * @param  {Array}  validBidRequests A list of valid bid request config objects.
    * @param  {object} bidderRequest    A object contains bids and other info like gdprConsent.
    * @return {object}                  Info describing the request to the server.
    */
@@ -1874,7 +1874,7 @@ export const spec = {
    *
    * @param  {object} serverResponse A successful response from the server.
    * @param  {object} bidderRequest  The bid request sent to the server.
-   * @return {array}                 An array of bids which were nested inside the server.
+   * @return {Array}                 An array of bids which were nested inside the server.
    */
   interpretResponse: function (serverResponse, bidderRequest) {
     const bids = [];
@@ -1966,8 +1966,8 @@ export const spec = {
   /**
    * Determine which user syncs should occur
    * @param {object} syncOptions
-   * @param {array} serverResponses
-   * @returns {array} User sync pixels
+   * @param {Array} serverResponses
+   * @returns {Array} User sync pixels
    */
   getUserSyncs: function (syncOptions, serverResponses) {
     const syncs = [];
@@ -2008,11 +2008,11 @@ export const spec = {
 };
 
 /**
-   * Build img user sync url
-   * @param {int} syncsPerBidder number of syncs Per Bidder
-   * @param {int} index index to pass
-   * @returns {string} img user sync url
-   */
+ * Build img user sync url
+ * @param {number} syncsPerBidder number of syncs Per Bidder
+ * @param {number} index index to pass
+ * @returns {string} img user sync url
+ */
 function buildImgSyncUrl(syncsPerBidder, index) {
   let consentString = '';
   let gdprApplies = '0';
@@ -2029,7 +2029,7 @@ function buildImgSyncUrl(syncsPerBidder, index) {
 
 /**
  * Combines all imps into a single object
- * @param {array} imps array of imps
+ * @param {Array} imps array of imps
  * @returns object
  */
 export function combineImps(imps) {

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -26,16 +26,16 @@ let resumeBidRequest;
 /** @type {RtdSubmodule} */
 export const jwplayerSubmodule = {
   /**
-     * used to link submodule with realTimeData
-     * @type {string}
-     */
+   * used to link submodule with realTimeData
+   * @type {string}
+   */
   name: SUBMODULE_NAME,
   /**
-     * add targeting data to bids and signal completion to realTimeData module
-     * @function
-     * @param {Obj} bidReqConfig
-     * @param {function} onDone
-     */
+   * add targeting data to bids and signal completion to realTimeData module
+   * @function
+   * @param {Obj} bidReqConfig
+   * @param {function} onDone
+   */
   getBidRequestData: enrichBidRequest,
   init
 };

--- a/modules/lemmaDigitalBidAdapter.js
+++ b/modules/lemmaDigitalBidAdapter.js
@@ -26,7 +26,7 @@ export var spec = {
    *
    * @param {BidRequest} bid The bid params to validate.
    * @return boolean True if this is a valid bid, and false otherwise.
-   **/
+   */
   isBidRequestValid: (bid) => {
     if (!bid || !bid.params) {
       utils.logError(LOG_WARN_PREFIX, 'nil/empty bid object');
@@ -51,11 +51,11 @@ export var spec = {
   },
 
   /**
-  * Make a server request from the list of BidRequests.
-  *
-  * @param {validBidRequests[]} - an array of bids
-  * @return ServerRequest Info describing the request to the server.
-  **/
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @return ServerRequest Info describing the request to the server.
+   */
   buildRequests: (validBidRequests, bidderRequest) => {
     if (validBidRequests.length === 0) {
       return;
@@ -79,11 +79,11 @@ export var spec = {
   },
 
   /**
-  * Unpack the response from the server into a list of bids.
-  *
-  * @param {ServerResponse} response A successful response from the server.
-  * @return {Bid[]} An array of bids which were nested inside the server.
-  **/
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} response A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
   interpretResponse: (response, request) => {
     return spec._parseRTBResponse(request, response.body);
   },
@@ -93,7 +93,7 @@ export var spec = {
    * @param {SyncOptions} syncOptions Which user syncs are allowed?
    * @param {ServerResponse[]} serverResponses List of server's responses.
    * @return {UserSync[]} The user syncs which should be dropped.
-   **/
+   */
   getUserSyncs: (syncOptions, serverResponses) => {
     let syncurl = USER_SYNC + 'pid=' + pubId;
     if (syncOptions.iframeEnabled) {
@@ -115,7 +115,7 @@ export var spec = {
 
   /**
    * parse object
-   **/
+   */
   _parseJSON: function (rawPayload) {
     try {
       if (rawPayload) {
@@ -155,7 +155,7 @@ export var spec = {
 
   /**
    * create IAB standard OpenRTB bid request
-   **/
+   */
   _createoRTBRequest: (bidRequests, conf) => {
     var oRTBObject = {};
     try {
@@ -202,7 +202,7 @@ export var spec = {
 
   /**
    * create impression array objects
-   **/
+   */
   _getImpressionArray: (request) => {
     var impArray = [];
     var map = request.map(bid => spec._getImpressionObject(bid));
@@ -218,7 +218,7 @@ export var spec = {
 
   /**
    * create impression (single) object
-   **/
+   */
   _getImpressionObject: (bid) => {
     var impression = {};
     var bObj;
@@ -277,8 +277,8 @@ export var spec = {
   },
 
   /**
-  * set bid floor
-  **/
+   * set bid floor
+   */
   _setFloor: (impObj, bid) => {
     let bidFloor = -1;
     // get lowest floor from floorModule
@@ -304,8 +304,8 @@ export var spec = {
   },
 
   /**
-  * parse Open RTB response
-  **/
+   * parse Open RTB response
+   */
   _parseRTBResponse: (request, response) => {
     var bidResponses = [];
     try {
@@ -358,8 +358,8 @@ export var spec = {
   },
 
   /**
-  * get bid request api end point url
-  **/
+   * get bid request api end point url
+   */
   _endPointURL: (request) => {
     var params = request && request[0].params ? request[0].params : null;
     if (params) {
@@ -371,8 +371,8 @@ export var spec = {
   },
 
   /**
-  * get domain name from url
-  **/
+   * get domain name from url
+   */
   _getDomain: (url) => {
     var a = document.createElement('a');
     a.setAttribute('href', url);
@@ -380,8 +380,8 @@ export var spec = {
   },
 
   /**
-  * create the site object
-  **/
+   * create the site object
+   */
   _getSiteObject: (request, conf) => {
     var params = request && request.params ? request.params : null;
     if (params) {
@@ -406,8 +406,8 @@ export var spec = {
   },
 
   /**
-  * create the app object
-  **/
+   * create the app object
+   */
   _getAppObject: (request) => {
     var params = request && request.params ? request.params : null;
     if (params) {
@@ -432,8 +432,8 @@ export var spec = {
   },
 
   /**
-  * create the device object
-  **/
+   * create the device object
+   */
   _getDeviceObject: (request) => {
     var params = request && request.params ? request.params : null;
     if (params) {
@@ -481,8 +481,8 @@ export var spec = {
   },
 
   /**
-  * get request ad sizes
-  **/
+   * get request ad sizes
+   */
   _getSizes: (request) => {
     if (request && request.sizes && utils.isArray(request.sizes[0]) && request.sizes[0].length > 0) {
       return request.sizes[0];
@@ -491,8 +491,8 @@ export var spec = {
   },
 
   /**
-  * create the banner object
-  **/
+   * create the banner object
+   */
   _getBannerRequest: (bid) => {
     var bObj;
     var adFormat = [];
@@ -531,8 +531,8 @@ export var spec = {
   },
 
   /**
-  * create the video object
-  **/
+   * create the video object
+   */
   _getVideoRequest: (bid) => {
     var vObj;
     if (utils.deepAccess(bid, 'mediaTypes.video')) {
@@ -554,8 +554,8 @@ export var spec = {
   },
 
   /**
-  * check media type
-  **/
+   * check media type
+   */
   _checkMediaType: (adm, newBid) => {
     // Create a regex here to check the strings
     var videoRegex = new RegExp(/VAST.*version/);

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -115,6 +115,7 @@ function initializeLiveConnect(configParams) {
   }
 
   liveConnectConfig.wrapperName = 'prebid';
+  liveConnectConfig.trackerVersion = '$prebid.version$';
   liveConnectConfig.identityResolutionConfig = identityResolutionConfig;
   liveConnectConfig.identifiersToResolve = configParams.identifiersToResolve || [];
   liveConnectConfig.fireEventDelay = configParams.fireEventDelay;
@@ -156,7 +157,7 @@ function tryFireEvent() {
 
 /** @type {Submodule} */
 export const liveIntentIdSubmodule = {
-  moduleMode: process.env.LiveConnectMode,
+  moduleMode: '$$LIVE_INTENT_MODULE_MODE$$',
   /**
    * used to link submodule with config
    * @type {string}
@@ -221,6 +222,10 @@ export const liveIntentIdSubmodule = {
 
       if (value.pubmatic) {
         result.pubmatic = { 'id': value.pubmatic, ext: { provider: LI_PROVIDER_DOMAIN } }
+      }
+
+      if (value.sovrn) {
+        result.sovrn = { 'id': value.sovrn, ext: { provider: LI_PROVIDER_DOMAIN } }
       }
 
       return result
@@ -326,7 +331,7 @@ export const liveIntentIdSubmodule = {
       }
     },
     'openx': {
-      source: 'openx.com',
+      source: 'openx.net',
       atype: 3,
       getValue: function(data) {
         return data.id;
@@ -339,6 +344,18 @@ export const liveIntentIdSubmodule = {
     },
     'pubmatic': {
       source: 'pubmatic.com',
+      atype: 3,
+      getValue: function(data) {
+        return data.id;
+      },
+      getUidExt: function(data) {
+        if (data.ext) {
+          return data.ext;
+        }
+      }
+    },
+    'sovrn': {
+      source: 'liveintent.sovrn.com',
       atype: 3,
       getValue: function(data) {
         return data.id;

--- a/modules/malltvBidAdapter.js
+++ b/modules/malltvBidAdapter.js
@@ -124,11 +124,11 @@ export const spec = {
 };
 
 /**
-* Generate size param for bid request using sizes array
-*
-* @param {Array} sizes Possible sizes for the ad unit.
-* @return {string} Processed sizes param to be used for the bid request.
-*/
+ * Generate size param for bid request using sizes array
+ *
+ * @param {Array} sizes Possible sizes for the ad unit.
+ * @return {string} Processed sizes param to be used for the bid request.
+ */
 function generateSizeParam(sizes) {
   return sizes.map(size => size.join(DIMENSION_SEPARATOR)).join(SIZE_SEPARATOR);
 }

--- a/modules/mediafilterRtdProvider.js
+++ b/modules/mediafilterRtdProvider.js
@@ -16,9 +16,9 @@ import { loadExternalScript } from '../src/adloader.js';
 import * as events from '../src/events.js';
 import CONSTANTS from '../src/constants.json';
 
-/** @const {string} MEDIAFILTER_EVENT_TYPE - The event type for Media Filter. */
+/** The event type for Media Filter. */
 export const MEDIAFILTER_EVENT_TYPE = 'com.mediatrust.pbjs.';
-/** @const {string} MEDIAFILTER_BASE_URL - The base URL for Media Filter scripts. */
+/** The base URL for Media Filter scripts. */
 export const MEDIAFILTER_BASE_URL = 'https://scripts.webcontentassessor.com/scripts/';
 
 export const MediaFilter = {

--- a/modules/mediagoBidAdapter.js
+++ b/modules/mediagoBidAdapter.js
@@ -10,17 +10,21 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 
 const BIDDER_CODE = 'mediago';
 // const PROTOCOL = window.document.location.protocol;
-const ENDPOINT_URL =
-  // ((PROTOCOL === 'https:') ? 'https' : 'http') +
-  'https://rtb-us.mediago.io/api/bid?tn=';
+const ENDPOINT_URL = 'https://gbid.mediago.io/api/bid?tn=';
+const COOKY_SYNC_URL = 'https://gtrace.mediago.io/ju/cs/eplist';
+const COOKY_SYNC_IFRAME_URL = 'https://cdn.mediago.io/js/cookieSync.html';
+
 const TIME_TO_LIVE = 500;
+const GVLID = 1020;
 // const ENDPOINT_URL = '/api/bid?tn=';
-const storage = getStorageManager({bidderCode: BIDDER_CODE});
+const storage = getStorageManager({ bidderCode: BIDDER_CODE });
 let globals = {};
 let itemMaps = {};
 
 /* ----- mguid:start ------ */
 const COOKIE_KEY_MGUID = '__mguid_';
+const STORE_MAX_AGE = 1000 * 60 * 60 * 24 * 365;
+let reqTimes = 0;
 
 /**
  * 获取用户id
@@ -31,7 +35,7 @@ const getUserID = () => {
 
   if (i === null) {
     const uuid = utils.generateUUID();
-    storage.setCookie(COOKIE_KEY_MGUID, uuid);
+    storage.setCookie(COOKIE_KEY_MGUID, uuid, STORE_MAX_AGE);
     return uuid;
   }
   return i;
@@ -72,7 +76,7 @@ function isMobileAndTablet() {
         '.+mobile|avantgo|bada/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)',
         '|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone',
         '|p(ixi|re)/|plucker|pocket|psp|series(4|6)0|symbian|treo|up.(browser|link)|vodafone|wap',
-        '|windows ce|xda|xiino|android|ipad|playbook|silk',
+        '|windows ce|xda|xiino|android|ipad|playbook|silk'
       ].join(''),
       'i'
     );
@@ -96,7 +100,7 @@ function isMobileAndTablet() {
         '|tim-|t-mo|to(pl|sh)|ts(70|m-|m3|m5)|tx-9|up(.b|g1|si)|utst|',
         'v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|-v)',
         '|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas-',
-        '|your|zeto|zte-',
+        '|your|zeto|zte-'
       ].join(''),
       'i'
     );
@@ -138,7 +142,7 @@ function getBidFloor(bid) {
     const bidFloor = bid.getFloor({
       currency: 'USD',
       mediaType: '*',
-      size: '*',
+      size: '*'
     });
     return bidFloor.floor;
   } catch (_) {
@@ -156,11 +160,7 @@ function transformSizes(requestSizes) {
   let sizes = [];
   let sizeObj = {};
 
-  if (
-    utils.isArray(requestSizes) &&
-    requestSizes.length === 2 &&
-    !utils.isArray(requestSizes[0])
-  ) {
+  if (utils.isArray(requestSizes) && requestSizes.length === 2 && !utils.isArray(requestSizes[0])) {
     sizeObj.width = parseInt(requestSizes[0], 10);
     sizeObj.height = parseInt(requestSizes[1], 10);
     sizes.push(sizeObj);
@@ -187,7 +187,7 @@ const mediagoAdSize = [
   { w: 160, h: 600 },
   { w: 320, h: 180 },
   { w: 320, h: 100 },
-  { w: 336, h: 280 },
+  { w: 336, h: 280 }
 ];
 
 /**
@@ -207,17 +207,13 @@ function getItems(validBidRequests, bidderRequest) {
 
     // 确认尺寸是否符合我们要求
     for (let size of sizes) {
-      matchSize = mediagoAdSize.find(
-        (item) => size.width === item.w && size.height === item.h
-      );
+      matchSize = mediagoAdSize.find(item => size.width === item.w && size.height === item.h);
       if (matchSize) {
         break;
       }
     }
     if (!matchSize) {
-      matchSize = sizes[0]
-        ? { h: sizes[0].height || 0, w: sizes[0].width || 0 }
-        : { h: 0, w: 0 };
+      matchSize = sizes[0] ? { h: sizes[0].height || 0, w: sizes[0].width || 0 } : { h: 0, w: 0 };
     }
 
     const bidFloor = getBidFloor(req);
@@ -225,6 +221,18 @@ function getItems(validBidRequests, bidderRequest) {
       utils.deepAccess(req, 'ortb2Imp.ext.gpid') ||
       utils.deepAccess(req, 'ortb2Imp.ext.data.pbadslot') ||
       utils.deepAccess(req, 'params.placementId', 0);
+
+    const gdprConsent = {};
+    if (bidderRequest && bidderRequest.gdprConsent) {
+      gdprConsent.consent = bidderRequest.gdprConsent.consentString;
+      gdprConsent.gdpr = bidderRequest.gdprConsent.gdprApplies ? 1 : 0;
+      // if (bidderRequest.gdprConsent.addtlConsent && bidderRequest.gdprConsent.addtlConsent.indexOf('~') !== -1) {
+      //   let ac = bidderRequest.gdprConsent.addtlConsent;
+      //   // pull only the ids from the string (after the ~) and convert them to an array of ints
+      //   let acStr = ac.substring(ac.indexOf('~') + 1);
+      //   gdpr_consent.addtl_consent = acStr.split('.').map(id => parseInt(id, 10));
+      // }
+    }
 
     // if (mediaTypes.native) {}
     // banner广告类型
@@ -237,23 +245,42 @@ function getItems(validBidRequests, bidderRequest) {
           h: matchSize.h,
           w: matchSize.w,
           pos: 1,
-          format: sizes,
+          format: sizes
         },
         ext: {
+          adUnitCode: req.adUnitCode,
+          referrer: getReferrer(req, bidderRequest),
           ortb2Imp: utils.deepAccess(req, 'ortb2Imp'), // 传入完整对象，分析日志数据
           gpid: gpid, // 加入后无法返回广告
+          adslot: utils.deepAccess(req, 'ortb2Imp.ext.data.adserver.adslot', '', ''),
+          ...gdprConsent // gdpr
         },
-        tagid: req.params && req.params.tagid,
+        tagid: req.params && req.params.tagid
       };
       itemMaps[id] = {
         req,
-        ret,
+        ret
       };
     }
 
     return ret;
   });
   return items;
+}
+
+/**
+ * @param {BidRequest} bidRequest
+ * @param bidderRequest
+ * @returns {string}
+ */
+function getReferrer(bidRequest = {}, bidderRequest = {}) {
+  let pageUrl;
+  if (bidRequest.params && bidRequest.params.referrer) {
+    pageUrl = bidRequest.params.referrer;
+  } else {
+    pageUrl = utils.deepAccess(bidderRequest, 'refererInfo.page');
+  }
+  return pageUrl;
 }
 
 /**
@@ -268,7 +295,14 @@ function getParam(validBidRequests, bidderRequest) {
   const sharedid =
     utils.deepAccess(validBidRequests[0], 'userId.sharedid.id') ||
     utils.deepAccess(validBidRequests[0], 'userId.pubcid');
-  const eids = validBidRequests[0].userIdAsEids || validBidRequests[0].userId;
+
+  const bidsUserIdAsEids = validBidRequests[0].userIdAsEids;
+  const bidsUserid = validBidRequests[0].userId;
+  const eids = bidsUserIdAsEids || bidsUserid;
+  const ppuid = bidsUserid && bidsUserid.pubProvidedId;
+  const content = utils.deepAccess(bidderRequest, 'ortb2.site.content');
+  const cat = utils.deepAccess(bidderRequest, 'ortb2.site.cat');
+  reqTimes += 1;
 
   let isMobile = isMobileAndTablet() ? 1 : 0;
   // input test status by Publisher. more frequently for test true req
@@ -276,8 +310,7 @@ function getParam(validBidRequests, bidderRequest) {
   let auctionId = getProperty(bidderRequest, 'auctionId');
   let items = getItems(validBidRequests, bidderRequest);
 
-  const domain =
-    utils.deepAccess(bidderRequest, 'refererInfo.domain') || document.domain;
+  const domain = utils.deepAccess(bidderRequest, 'refererInfo.domain') || document.domain;
   const location = utils.deepAccess(bidderRequest, 'refererInfo.location');
   const page = utils.deepAccess(bidderRequest, 'refererInfo.page');
   const referer = utils.deepAccess(bidderRequest, 'refererInfo.ref');
@@ -301,15 +334,21 @@ function getParam(validBidRequests, bidderRequest) {
         // ua: 'Mozilla/5.0 (Linux; Android 12; SM-G970U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Mobile Safari/537.36',
         os: navigator.platform || '',
         ua: navigator.userAgent,
-        language: /en/.test(navigator.language) ? 'en' : navigator.language,
+        language: /en/.test(navigator.language) ? 'en' : navigator.language
       },
       ext: {
         eids,
+        bidsUserIdAsEids,
+        bidsUserid,
+        ppuid,
         firstPartyData,
+        content,
+        cat,
+        reqTimes
       },
       user: {
         buyeruid: getUserID(),
-        id: sharedid || pubcid,
+        id: sharedid || pubcid
       },
       eids,
       site: {
@@ -322,11 +361,11 @@ function getParam(validBidRequests, bidderRequest) {
         publisher: {
           // todo
           id: domain,
-          name: domain,
-        },
+          name: domain
+        }
       },
       imp: items,
-      tmax: timeout,
+      tmax: timeout
     };
     return c;
   } else {
@@ -336,6 +375,7 @@ function getParam(validBidRequests, bidderRequest) {
 
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: GVLID,
   // aliases: ['ex'], // short code
   /**
    * Determines whether or not the given bid request is valid.
@@ -367,7 +407,7 @@ export const spec = {
     return {
       method: 'POST',
       url: ENDPOINT_URL + globals['token'],
-      data: payloadString,
+      data: payloadString
     };
   },
 
@@ -398,7 +438,7 @@ export const spec = {
           ttl: TIME_TO_LIVE,
           // referrer: REFERER,
           ad: getProperty(bid, 'adm'),
-          nurl: getProperty(bid, 'nurl'),
+          nurl: getProperty(bid, 'nurl')
           //   adserverTargeting: {
           //     granularityMultiplier: 0.1,
           //     priceGranularity: 'pbHg',
@@ -413,6 +453,38 @@ export const spec = {
     }
 
     return bidResponses;
+  },
+
+  getUserSyncs: function (syncOptions, serverResponse, gdprConsent, uspConsent, gppConsent) {
+    const origin = encodeURIComponent(location.origin || `https://${location.host}`);
+    let syncParamUrl = `dm=${origin}`;
+
+    if (gdprConsent && gdprConsent.consentString) {
+      if (typeof gdprConsent.gdprApplies === 'boolean') {
+        syncParamUrl += `&gdpr=${Number(gdprConsent.gdprApplies)}&gdpr_consent=${gdprConsent.consentString}`;
+      } else {
+        syncParamUrl += `&gdpr=0&gdpr_consent=${gdprConsent.consentString}`;
+      }
+    }
+    if (uspConsent && uspConsent.consentString) {
+      syncParamUrl += `&ccpa_consent=${uspConsent.consentString}`;
+    }
+
+    if (syncOptions.iframeEnabled) {
+      return [
+        {
+          type: 'iframe',
+          url: `${COOKY_SYNC_IFRAME_URL}?${syncParamUrl}`
+        }
+      ];
+    } else {
+      return [
+        {
+          type: 'image',
+          url: `${COOKY_SYNC_URL}?${syncParamUrl}`
+        }
+      ];
+    }
   },
 
   /**
@@ -434,7 +506,7 @@ export const spec = {
     if (bid['nurl']) {
       utils.triggerPixel(bid['nurl']);
     }
-  },
+  }
 
   /**
    * Register bidder specific code, which will execute when the adserver targeting has been set for a bid from this bidder

--- a/modules/mediasquareBidAdapter.js
+++ b/modules/mediasquareBidAdapter.js
@@ -20,20 +20,20 @@ export const spec = {
   aliases: ['msq'], // short code
   supportedMediaTypes: [BANNER, NATIVE, VIDEO],
   /**
-         * Determines whether or not the given bid request is valid.
-         *
-         * @param {BidRequest} bid The bid params to validate.
-         * @return boolean True if this is a valid bid, and false otherwise.
-         */
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
   isBidRequestValid: function(bid) {
     return !!(bid.params.owner && bid.params.code);
   },
   /**
-         * Make a server request from the list of BidRequests.
-         *
-         * @param {validBidRequests[]} - an array of bids
-         * @return ServerRequest Info describing the request to the server.
-         */
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @return ServerRequest Info describing the request to the server.
+   */
   buildRequests: function(validBidRequests, bidderRequest) {
     // convert Native ORTB definition to old-style prebid native definition
     validBidRequests = convertOrtbRequestToProprietaryNative(validBidRequests);
@@ -96,11 +96,11 @@ export const spec = {
     };
   },
   /**
-         * Unpack the response from the server into a list of bids.
-         *
-         * @param {ServerResponse} serverResponse A successful response from the server.
-         * @return {Bid[]} An array of bids which were nested inside the server.
-         */
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
   interpretResponse: function(serverResponse, bidRequest) {
     const serverBody = serverResponse.body;
     // const headerValue = serverResponse.headers.get('some-response-header');
@@ -148,12 +148,12 @@ export const spec = {
   },
 
   /**
-     * Register the user sync pixels which should be dropped after the auction.
-     *
-     * @param {SyncOptions} syncOptions Which user syncs are allowed?
-     * @param {ServerResponse[]} serverResponses List of server's responses.
-     * @return {UserSync[]} The user syncs which should be dropped.
-     */
+   * Register the user sync pixels which should be dropped after the auction.
+   *
+   * @param {SyncOptions} syncOptions Which user syncs are allowed?
+   * @param {ServerResponse[]} serverResponses List of server's responses.
+   * @return {UserSync[]} The user syncs which should be dropped.
+   */
   getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent) {
     if (typeof serverResponses === 'object' && serverResponses != null && serverResponses.length > 0 && serverResponses[0].hasOwnProperty('body') &&
         serverResponses[0].body.hasOwnProperty('cookies') && typeof serverResponses[0].body.cookies === 'object') {
@@ -164,9 +164,9 @@ export const spec = {
   },
 
   /**
-     * Register bidder specific code, which will execute if a bid from this bidder won the auction
-     * @param {Bid} The bid that won the auction
-     */
+   * Register bidder specific code, which will execute if a bid from this bidder won the auction
+   * @param {Bid} The bid that won the auction
+   */
   onBidWon: function(bid) {
     // fires a pixel to confirm a winning bid
     if (bid.hasOwnProperty('mediaType') && bid.mediaType == 'video') {

--- a/modules/merkleIdSystem.js
+++ b/modules/merkleIdSystem.js
@@ -87,17 +87,17 @@ function generateId(configParams, configStorage) {
 /** @type {Submodule} */
 export const merkleIdSubmodule = {
   /**
-     * used to link submodule with config
-     * @type {string}
-     */
+   * used to link submodule with config
+   * @type {string}
+   */
   name: MODULE_NAME,
 
   /**
-     * decode the stored id value for passing to bid requests
-     * @function
-     * @param {string} value
-     * @returns {{eids:arrayofields}}
-     */
+   * decode the stored id value for passing to bid requests
+   * @function
+   * @param {string} value
+   * @returns {{eids:arrayofields}}
+   */
   decode(value) {
     // Legacy support for a single id
     const id = (value && value.pam_id && typeof value.pam_id.id === 'string') ? value.pam_id : undefined;
@@ -115,12 +115,12 @@ export const merkleIdSubmodule = {
   },
 
   /**
-     * performs action to obtain id and return a value in the callback's response argument
-     * @function
-     * @param {SubmoduleConfig} [config]
-     * @param {ConsentData} [consentData]
-     * @returns {IdResponse|undefined}
-     */
+   * performs action to obtain id and return a value in the callback's response argument
+   * @function
+   * @param {SubmoduleConfig} [config]
+   * @param {ConsentData} [consentData]
+   * @returns {IdResponse|undefined}
+   */
   getId(config, consentData) {
     logInfo('User ID - merkleId generating id');
 

--- a/modules/mgidXBidAdapter.js
+++ b/modules/mgidXBidAdapter.js
@@ -166,9 +166,14 @@ export const spec = {
       placements,
       coppa: config.getConfig('coppa') === true ? 1 : 0,
       ccpa: bidderRequest.uspConsent || undefined,
-      gdpr: bidderRequest.gdprConsent || undefined,
       tmax: config.getConfig('bidderTimeout')
     };
+
+    if (bidderRequest.gdprConsent) {
+      request.gdpr = {
+        consentString: bidderRequest.gdprConsent.consentString
+      };
+    }
 
     const len = validBidRequests.length;
     for (let i = 0; i < len; i++) {

--- a/modules/minutemediaBidAdapter.js
+++ b/modules/minutemediaBidAdapter.js
@@ -19,7 +19,7 @@ const SUPPORTED_AD_TYPES = [BANNER, VIDEO];
 const BIDDER_CODE = 'minutemedia';
 const ADAPTER_VERSION = '6.0.0';
 const TTL = 360;
-const CURRENCY = 'USD';
+const DEFAULT_CURRENCY = 'USD';
 const SELLER_ENDPOINT = 'https://hb.minutemedia-prebid.com/';
 const MODES = {
   PRODUCTION: 'hb-mm-multi',
@@ -72,7 +72,7 @@ export const spec = {
         const bidResponse = {
           requestId: adUnit.requestId,
           cpm: adUnit.cpm,
-          currency: adUnit.currency || CURRENCY,
+          currency: adUnit.currency || DEFAULT_CURRENCY,
           width: adUnit.width,
           height: adUnit.height,
           ttl: adUnit.ttl || TTL,
@@ -141,16 +141,16 @@ registerBidder(spec);
  * @param bid {bid}
  * @returns {Number}
  */
-function getFloor(bid, mediaType) {
+function getFloor(bid, mediaType, currency) {
   if (!isFn(bid.getFloor)) {
     return 0;
   }
   let floorResult = bid.getFloor({
-    currency: CURRENCY,
+    currency: currency,
     mediaType: mediaType,
     size: '*'
   });
-  return floorResult.currency === CURRENCY && floorResult.floor ? floorResult.floor : 0;
+  return floorResult.currency === currency && floorResult.floor ? floorResult.floor : 0;
 }
 
 /**
@@ -286,6 +286,7 @@ function generateBidParameters(bid, bidderRequest) {
   const {params} = bid;
   const mediaType = isBanner(bid) ? BANNER : VIDEO;
   const sizesArray = getSizesArray(bid, mediaType);
+  const currency = params.currency || config.getConfig('currency.adServerCurrency') || DEFAULT_CURRENCY;
 
   // fix floor price in case of NAN
   if (isNaN(params.floorPrice)) {
@@ -296,12 +297,13 @@ function generateBidParameters(bid, bidderRequest) {
     mediaType,
     adUnitCode: getBidIdParameter('adUnitCode', bid),
     sizes: sizesArray,
-    floorPrice: Math.max(getFloor(bid, mediaType), params.floorPrice),
+    currency: currency,
+    floorPrice: Math.max(getFloor(bid, mediaType, currency), params.floorPrice),
     bidId: getBidIdParameter('bidId', bid),
     loop: getBidIdParameter('bidderRequestsCount', bid),
     bidderRequestId: getBidIdParameter('bidderRequestId', bid),
     transactionId: bid.ortb2Imp?.ext?.tid || '',
-    coppa: 0
+    coppa: 0,
   };
 
   const pos = deepAccess(bid, `mediaTypes.${mediaType}.pos`);

--- a/modules/minutemediaBidAdapter.md
+++ b/modules/minutemediaBidAdapter.md
@@ -24,6 +24,7 @@ The adapter supports Video(instream) & Banner.
 | `floorPrice` | optional | Number |  Minimum price in USD. Misuse of this parameter can impact revenue | 2.00
 | `placementId` | optional | String |  A unique placement identifier  | "12345678"
 | `testMode` | optional | Boolean |  This activates the test mode  | false
+| `currency` | optional | String | 3 letters currency | "EUR"
 
 # Test Parameters
 ```javascript

--- a/modules/missenaBidAdapter.js
+++ b/modules/missenaBidAdapter.js
@@ -59,9 +59,11 @@ export const spec = {
   buildRequests: function (validBidRequests, bidderRequest) {
     const capKey = `missena.missena.capper.remove-bubble.${validBidRequests[0]?.params.apiKey}`;
     const capping = safeJSONParse(storage.getDataFromLocalStorage(capKey));
+    const referer = bidderRequest?.refererInfo?.topmostLocation;
     if (
       typeof capping?.expiry === 'number' &&
-      new Date().getTime() < capping?.expiry
+      new Date().getTime() < capping?.expiry &&
+      (!capping?.referer || capping?.referer == referer)
     ) {
       logInfo('Missena - Capped');
       return [];

--- a/modules/multibid/index.js
+++ b/modules/multibid/index.js
@@ -45,10 +45,10 @@ config.getConfig(MODULE_NAME, conf => {
 });
 
 /**
-   * @summary validates multibid configuration entries
-   * @param {Object[]} multibid - example [{bidder: 'bidderA', maxbids: 2, prefix: 'bidA'}, {bidder: 'bidderB', maxbids: 2}]
-   * @return {Boolean}
-*/
+ * @summary validates multibid configuration entries
+ * @param {Object[]} multibid - example [{bidder: 'bidderA', maxbids: 2, prefix: 'bidA'}, {bidder: 'bidderB', maxbids: 2}]
+ * @return {Boolean}
+ */
 export function validateMultibid(conf) {
   let check = true;
   let duplicate = conf.filter(entry => {
@@ -77,10 +77,10 @@ export function validateMultibid(conf) {
 }
 
 /**
-   * @summary addBidderRequests before hook
-   * @param {Function} fn reference to original function (used by hook logic)
-   * @param {Object[]} array containing copy of each bidderRequest object
-*/
+ * @summary addBidderRequests before hook
+ * @param {Function} fn reference to original function (used by hook logic)
+ * @param {Object[]} array containing copy of each bidderRequest object
+ */
 export function adjustBidderRequestsHook(fn, bidderRequests) {
   bidderRequests.map(bidRequest => {
     // Loop through bidderRequests and check if bidderCode exists in multiconfig
@@ -95,11 +95,11 @@ export function adjustBidderRequestsHook(fn, bidderRequests) {
 }
 
 /**
-   * @summary addBidResponse before hook
-   * @param {Function} fn reference to original function (used by hook logic)
-   * @param {String} ad unit code for bid
-   * @param {Object} bid object
-*/
+ * @summary addBidResponse before hook
+ * @param {Function} fn reference to original function (used by hook logic)
+ * @param {String} ad unit code for bid
+ * @param {Object} bid object
+ */
 export const addBidResponseHook = timedBidResponseHook('multibid', function addBidResponseHook(fn, adUnitCode, bid, reject) {
   let floor = deepAccess(bid, 'floorData.floorValue');
 
@@ -146,9 +146,9 @@ export const addBidResponseHook = timedBidResponseHook('multibid', function addB
 });
 
 /**
-* A descending sort function that will sort the list of objects based on the following:
-*  - bids without dynamic aliases are sorted before bids with dynamic aliases
-*/
+ * A descending sort function that will sort the list of objects based on the following:
+ *  - bids without dynamic aliases are sorted before bids with dynamic aliases
+ */
 export function sortByMultibid(a, b) {
   if (a.bidder !== a.bidderCode && b.bidder === b.bidderCode) {
     return 1;
@@ -162,13 +162,13 @@ export function sortByMultibid(a, b) {
 }
 
 /**
-   * @summary getHighestCpmBidsFromBidPool before hook
-   * @param {Function} fn reference to original function (used by hook logic)
-   * @param {Object[]} array of objects containing all bids from bid pool
-   * @param {Function} function to reduce to only highest cpm value for each bidderCode
-   * @param {Number} adUnit bidder targeting limit, default set to 0
-   * @param {Boolean} default set to false, this hook modifies targeting and sets to true
-*/
+ * @summary getHighestCpmBidsFromBidPool before hook
+ * @param {Function} fn reference to original function (used by hook logic)
+ * @param {Object[]} array of objects containing all bids from bid pool
+ * @param {Function} function to reduce to only highest cpm value for each bidderCode
+ * @param {Number} adUnit bidder targeting limit, default set to 0
+ * @param {Boolean} default set to false, this hook modifies targeting and sets to true
+ */
 export function targetBidPoolHook(fn, bidsReceived, highestCpmCallback, adUnitBidLimit = 0, hasModified = false) {
   if (!config.getConfig('multibid')) resetMultiConfig();
   if (hasMultibid) {
@@ -216,18 +216,18 @@ export function targetBidPoolHook(fn, bidsReceived, highestCpmCallback, adUnitBi
 }
 
 /**
-* Resets globally stored multibid configuration
-*/
+ * Resets globally stored multibid configuration
+ */
 export const resetMultiConfig = () => { hasMultibid = false; multiConfig = {}; };
 
 /**
-* Resets globally stored multibid ad unit bids
-*/
+ * Resets globally stored multibid ad unit bids
+ */
 export const resetMultibidUnits = () => multibidUnits = {};
 
 /**
-* Set up hooks on init
-*/
+ * Set up hooks on init
+ */
 function init() {
   // TODO: does this reset logic make sense - what about simultaneous auctions?
   events.on(CONSTANTS.EVENTS.AUCTION_INIT, resetMultibidUnits);

--- a/modules/mwOpenLinkIdSystem.js
+++ b/modules/mwOpenLinkIdSystem.js
@@ -112,27 +112,27 @@ export { writeCookie };
 /** @type {Submodule} */
 export const mwOpenLinkIdSubModule = {
   /**
-     * used to link submodule with config
-     * @type {string}
-     */
+   * used to link submodule with config
+   * @type {string}
+   */
   name: 'mwOpenLinkId',
   /**
-     * decode the stored id value for passing to bid requests
-     * @function
-     * @param {MwOlId} mwOlId
-     * @return {(Object|undefined}
-     */
+   * decode the stored id value for passing to bid requests
+   * @function
+   * @param {MwOlId} mwOlId
+   * @return {(Object|undefined}
+   */
   decode(mwOlId) {
     const id = mwOlId && isPlainObject(mwOlId) ? mwOlId.eid : undefined;
     return id ? { 'mwOpenLinkId': id } : undefined;
   },
 
   /**
-     * performs action to obtain id and return a value in the callback's response argument
-     * @function
-     * @param {SubmoduleParams} [submoduleParams]
-     * @returns {id:MwOlId | undefined}
-     */
+   * performs action to obtain id and return a value in the callback's response argument
+   * @function
+   * @param {SubmoduleParams} [submoduleParams]
+   * @returns {id:MwOlId | undefined}
+   */
   getId(submoduleConfig) {
     const submoduleConfigParams = (submoduleConfig && submoduleConfig.params) || {};
     if (!isValidConfig(submoduleConfigParams)) return undefined;

--- a/modules/mygaruIdSystem.js
+++ b/modules/mygaruIdSystem.js
@@ -1,0 +1,98 @@
+/**
+ * This module adds MyGaru Real Time User Sync to the User ID module
+ * The {@link module:modules/userId} module is required
+ * @module modules/mygaruIdSystem
+ * @requires module:modules/userId
+ */
+
+import { ajax } from '../src/ajax.js';
+import { submodule } from '../src/hook.js';
+
+const bidderCode = 'mygaruId';
+const syncUrl = 'https://ident.mygaru.com/v2/id';
+
+export function buildUrl(opts) {
+  const queryPairs = [];
+  for (let key in opts) {
+    if (opts[key] !== undefined) {
+      queryPairs.push(`${key}=${encodeURIComponent(opts[key])}`);
+    }
+  }
+  return `${syncUrl}?${queryPairs.join('&')}`;
+}
+
+function requestRemoteIdAsync(url) {
+  return new Promise((resolve) => {
+    ajax(
+      url,
+      {
+        success: response => {
+          try {
+            const jsonResponse = JSON.parse(response);
+            const { iuid } = jsonResponse;
+            resolve(iuid);
+          } catch (e) {
+            resolve();
+          }
+        },
+        error: () => {
+          resolve();
+        },
+      },
+      undefined,
+      {
+        method: 'GET',
+        contentType: 'application/json'
+      }
+    );
+  });
+}
+
+/** @type {Submodule} */
+export const mygaruIdSubmodule = {
+  /**
+   * used to link submodule with config
+   * @type {string}
+   */
+  name: bidderCode,
+  /**
+   * decode the stored id value for passing to bid requests
+   * @function
+   * @returns {{id: string} | null}
+   */
+  decode(id) {
+    return id;
+  },
+  /**
+   * get the MyGaru Id from local storages and initiate a new user sync
+   * @function
+   * @param {SubmoduleConfig} [config]
+   * @param {ConsentData} [consentData]
+   * @returns {{id: string | undefined}}
+   */
+  getId(config, consentData) {
+    const gdprApplies = consentData && typeof consentData.gdprApplies === 'boolean' && consentData.gdprApplies ? 1 : 0;
+    const gdprConsentString = gdprApplies ? consentData.consentString : undefined;
+    const url = buildUrl({
+      gdprApplies,
+      gdprConsentString
+    });
+
+    return {
+      url,
+      callback: function (done) {
+        return requestRemoteIdAsync(url).then((id) => {
+          done({ mygaruId: id });
+        })
+      }
+    }
+  },
+  eids: {
+    'mygaruId': {
+      source: 'mygaru.com',
+      atype: 1
+    },
+  }
+};
+
+submodule('userId', mygaruIdSubmodule);

--- a/modules/mygaruIdSystem.md
+++ b/modules/mygaruIdSystem.md
@@ -1,0 +1,24 @@
+## Mygaru User ID Submodule
+
+MyGaru provides single use tokens as a UserId for SSPs and DSP that consume  telecom DMP data.  
+
+## Building Prebid with Mygaru ID Support
+
+First, make sure to add submodule to your Prebid.js package with:
+
+```
+gulp build --modules=userId,mygaruIdSystem
+```
+Params configuration is not required. 
+Also mygaru is async, in order to get ids for initial ad auctions you need to add auctionDelay param to userSync config.
+
+```javascript
+pbjs.setConfig({
+    userSync: {
+        auctionDelay: 100,
+        userIds: [{
+            name: 'mygaruId',
+        }]
+    }
+});
+```

--- a/modules/naveggIdSystem.js
+++ b/modules/naveggIdSystem.js
@@ -74,16 +74,16 @@ function readnavIDFromCookie() {
 /** @type {Submodule} */
 export const naveggIdSubmodule = {
   /**
-  * used to link submodule with config
-  * @type {string}
-  */
+   * used to link submodule with config
+   * @type {string}
+   */
   name: MODULE_NAME,
   /**
-  * decode the stored id value for passing to bid requests
-  * @function
-  * @param { Object | string | undefined } value
-  * @return { Object | string | undefined }
-  */
+   * decode the stored id value for passing to bid requests
+   * @function
+   * @param { Object | string | undefined } value
+   * @return { Object | string | undefined }
+   */
   decode(value) {
     const naveggIdVal = value ? isStr(value) ? value : isPlainObject(value) ? value.id : undefined : undefined;
     return naveggIdVal ? {
@@ -91,11 +91,11 @@ export const naveggIdSubmodule = {
     } : undefined;
   },
   /**
-  * performs action to obtain id and return a value in the callback's response argument
-  * @function
-  * @param {SubmoduleConfig} config
-  * @return {{id: string | undefined } | undefined}
-  */
+   * performs action to obtain id and return a value in the callback's response argument
+   * @function
+   * @param {SubmoduleConfig} config
+   * @return {{id: string | undefined } | undefined}
+   */
   getId() {
     const naveggIdString = readnaveggIdFromLocalStorage() || readnaveggIDFromCookie() || getNaveggIdFromApi() || readoldnaveggIDFromCookie() || readnvgIDFromCookie() || readnavIDFromCookie();
 

--- a/modules/neuwoRtdProvider.js
+++ b/modules/neuwoRtdProvider.js
@@ -71,7 +71,7 @@ export function addFragment(base, path, addition) {
 /**
  * Concatenate a base array and an array within an object
  * non-array bases will be arrays, non-arrays at object key will be discarded
- * @param {array} base base array to add to
+ * @param {Array} base base array to add to
  * @param {object} source object to get an array from
  * @param {string} key dot-notated path to array within object
  * @returns base + source[key] if that's an array

--- a/modules/nobidBidAdapter.js
+++ b/modules/nobidBidAdapter.js
@@ -367,21 +367,21 @@ export const spec = {
   ],
   supportedMediaTypes: [BANNER, VIDEO],
   /**
- * Determines whether or not the given bid request is valid.
- *
- * @param {BidRequest} bid The bid params to validate.
- * @return boolean True if this is a valid bid, and false otherwise.
- */
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
   isBidRequestValid: function(bid) {
     log('isBidRequestValid', bid);
     return !!bid.params.siteId;
   },
   /**
- * Make a server request from the list of BidRequests.
- *
- * @param {validBidRequests[]} - an array of bids
- * @return ServerRequest Info describing the request to the server.
- */
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @return ServerRequest Info describing the request to the server.
+   */
   buildRequests: function(validBidRequests, bidderRequest) {
     function resolveEndpoint() {
       var ret = 'https://ads.servenobid.com/';
@@ -421,11 +421,11 @@ export const spec = {
     };
   },
   /**
-     * Unpack the response from the server into a list of bids.
-     *
-     * @param {ServerResponse} serverResponse A successful response from the server.
-     * @return {Bid[]} An array of bids which were nested inside the server.
-     */
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
   interpretResponse: function(serverResponse, bidRequest) {
     log('interpretResponse -> serverResponse', serverResponse);
     log('interpretResponse -> bidRequest', bidRequest);
@@ -433,12 +433,12 @@ export const spec = {
   },
 
   /**
-     * Register the user sync pixels which should be dropped after the auction.
-     *
-     * @param {SyncOptions} syncOptions Which user syncs are allowed?
-     * @param {ServerResponse[]} serverResponses List of server's responses.
-     * @return {UserSync[]} The user syncs which should be dropped.
-     */
+   * Register the user sync pixels which should be dropped after the auction.
+   *
+   * @param {SyncOptions} syncOptions Which user syncs are allowed?
+   * @param {ServerResponse[]} serverResponses List of server's responses.
+   * @return {UserSync[]} The user syncs which should be dropped.
+   */
   getUserSyncs: function(syncOptions, serverResponses, gdprConsent, usPrivacy, gppConsent) {
     if (syncOptions.iframeEnabled) {
       let params = '';
@@ -483,9 +483,9 @@ export const spec = {
   },
 
   /**
-     * Register bidder specific code, which will execute if bidder timed out after an auction
-     * @param {data} Containing timeout specific data
-     */
+   * Register bidder specific code, which will execute if bidder timed out after an auction
+   * @param {data} Containing timeout specific data
+   */
   onTimeout: function(data) {
     window.nobid.timeoutTotal++;
     log('Timeout total: ' + window.nobid.timeoutTotal, data);

--- a/modules/novatiqIdSystem.js
+++ b/modules/novatiqIdSystem.js
@@ -17,9 +17,9 @@ const MODULE_NAME = 'novatiq';
 export const novatiqIdSubmodule = {
 
   /**
- * used to link submodule with config
- * @type {string}
- */
+   * used to link submodule with config
+   * @type {string}
+   */
   name: MODULE_NAME,
   /**
    * used to specify vendor id
@@ -28,10 +28,10 @@ export const novatiqIdSubmodule = {
   gvlid: 1119,
 
   /**
- * decode the stored id value for passing to bid requests
- * @function
- * @returns {novatiq: {snowflake: string}}
- */
+   * decode the stored id value for passing to bid requests
+   * @function
+   * @returns {novatiq: {snowflake: string}}
+   */
   decode(novatiqId, config) {
     let responseObj = {
       novatiq: {
@@ -52,11 +52,11 @@ export const novatiqIdSubmodule = {
   },
 
   /**
- * performs action to obtain id and return a value in the callback's response argument
- * @function
- * @param {SubmoduleConfig} config
- * @returns {id: string}
- */
+   * performs action to obtain id and return a value in the callback's response argument
+   * @function
+   * @param {SubmoduleConfig} config
+   * @returns {id: string}
+   */
   getId(config) {
     const configParams = config.params || {};
     const urlParams = this.getUrlParams(configParams);

--- a/modules/oneKeyIdSystem.js
+++ b/modules/oneKeyIdSystem.js
@@ -47,27 +47,27 @@ const getIdsAndPreferences = (callback) => {
 /** @type {Submodule} */
 export const oneKeyIdSubmodule = {
   /**
-    * used to link submodule with config
-    * @type {string}
-    */
+   * used to link submodule with config
+   * @type {string}
+   */
   name: 'oneKeyData',
   /**
-    * decode the stored data value for passing to bid requests
-    * @function decode
-    * @param {(Object|string)} value
-    * @returns {(Object|undefined)}
-    */
+   * decode the stored data value for passing to bid requests
+   * @function decode
+   * @param {(Object|string)} value
+   * @returns {(Object|undefined)}
+   */
   decode(data) {
     return { oneKeyData: data };
   },
   /**
-    * performs action to obtain id and return a value in the callback's response argument
-    * @function
-    * @param {SubmoduleConfig} [config]
-    * @param {ConsentData} [consentData]
-    * @param {(Object|undefined)} cacheIdObj
-    * @returns {IdResponse|undefined}
-    */
+   * performs action to obtain id and return a value in the callback's response argument
+   * @function
+   * @param {SubmoduleConfig} [config]
+   * @param {ConsentData} [consentData]
+   * @param {(Object|undefined)} cacheIdObj
+   * @returns {IdResponse|undefined}
+   */
   getId(config) {
     return {
       callback: getIdsAndPreferences

--- a/modules/operaadsIdSystem.js
+++ b/modules/operaadsIdSystem.js
@@ -50,33 +50,33 @@ function asyncRequest(url, cb) {
 
 export const operaIdSubmodule = {
   /**
-     * used to link submodule with config
-     * @type {string}
-     */
+   * used to link submodule with config
+   * @type {string}
+   */
   name: MODULE_NAME,
 
   /**
-     * @type {string}
-     */
+   * @type {string}
+   */
   version,
 
   /**
-     * decode the stored id value for passing to bid requests
-     * @function
-     * @param {string} id
-     * @returns {{'operaId': string}}
-     */
+   * decode the stored id value for passing to bid requests
+   * @function
+   * @param {string} id
+   * @returns {{'operaId': string}}
+   */
   decode: (id) =>
     id != null && id.length > 0
       ? { [ID_KEY]: id }
       : undefined,
 
   /**
-     * performs action to obtain id and return a value in the callback's response argument
-     * @function
-     * @param {SubmoduleConfig} [config]
-     * @returns {IdResponse|undefined}
-     */
+   * performs action to obtain id and return a value in the callback's response argument
+   * @function
+   * @param {SubmoduleConfig} [config]
+   * @returns {IdResponse|undefined}
+   */
   getId(config, consentData) {
     logMessage(`${MODULE_NAME}: start synchronizing opera uid`);
     const params = (config && config.params) || {};

--- a/modules/optidigitalBidAdapter.js
+++ b/modules/optidigitalBidAdapter.js
@@ -15,11 +15,11 @@ export const spec = {
   gvlid: GVL_ID,
   supportedMediaTypes: [BANNER],
   /**
-     * Determines whether or not the given bid request is valid.
-     *
-     * @param {BidRequest} bid The bid params to validate.
-     * @return boolean True if this is a valid bid, and false otherwise.
-     */
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
   isBidRequestValid: function(bid) {
     let isValid = false;
     if (typeof bid.params !== 'undefined' && bid.params.placementId && bid.params.publisherId) {
@@ -29,11 +29,11 @@ export const spec = {
     return isValid;
   },
   /**
-     * Make a server request from the list of BidRequests.
-     *
-     * @param {validBidRequests[]} - an array of bids
-     * @return ServerRequest Info describing the request to the server.
-     */
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @return ServerRequest Info describing the request to the server.
+   */
   buildRequests: function(validBidRequests, bidderRequest) {
     if (!validBidRequests || validBidRequests.length === 0 || !bidderRequest || !bidderRequest.bids) {
       return [];
@@ -105,11 +105,11 @@ export const spec = {
     };
   },
   /**
-     * Unpack the response from the server into a list of bids.
-     *
-     * @param {ServerResponse} serverResponse A successful response from the server.
-     * @return {Bid[]} An array of bids which were nested inside the server.
-     */
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
   interpretResponse: function(serverResponse, bidRequest) {
     const bidResponses = [];
     serverResponse = serverResponse.body;
@@ -138,12 +138,12 @@ export const spec = {
   },
 
   /**
-     * Register the user sync pixels which should be dropped after the auction.
-     *
-     * @param {SyncOptions} syncOptions Which user syncs are allowed?
-     * @param {ServerResponse[]} serverResponses List of server's responses.
-     * @return {UserSync[]} The user syncs which should be dropped.
-     */
+   * Register the user sync pixels which should be dropped after the auction.
+   *
+   * @param {SyncOptions} syncOptions Which user syncs are allowed?
+   * @param {ServerResponse[]} serverResponses List of server's responses.
+   * @return {UserSync[]} The user syncs which should be dropped.
+   */
   getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent) {
     let syncurl = '';
     if (!isSynced) {

--- a/modules/optimeraRtdProvider.js
+++ b/modules/optimeraRtdProvider.js
@@ -30,7 +30,8 @@ let _moduleParams = {};
  * Default Optimera Key Name
  * This can default to hb_deal_optimera for publishers
  * who used the previous Optimera Bidder Adapter.
- * @type {string} */
+ * @type {string}
+ */
 export let optimeraKeyName = 'hb_deal_optimera';
 
 /**

--- a/modules/optimonAnalyticsAdapter.js
+++ b/modules/optimonAnalyticsAdapter.js
@@ -1,12 +1,12 @@
 /**
-*
-*********************************************************
-*
-* Optimon.io Prebid Analytics Adapter
-*
-*********************************************************
-*
-*/
+ *
+ *********************************************************
+ *
+ * Optimon.io Prebid Analytics Adapter
+ *
+ *********************************************************
+ *
+ */
 
 import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
 import adapterManager from '../src/adapterManager.js';

--- a/modules/pairIdSystem.js
+++ b/modules/pairIdSystem.js
@@ -27,29 +27,29 @@ function pairIdFromCookie(key) {
 /** @type {Submodule} */
 export const pairIdSubmodule = {
   /**
-  * used to link submodule with config
-  * @type {string}
-  */
+   * used to link submodule with config
+   * @type {string}
+   */
   name: MODULE_NAME,
   /**
-  * used to specify vendor id
-  * @type {number}
-  */
+   * used to specify vendor id
+   * @type {number}
+   */
   gvlid: 755,
   /**
-  * decode the stored id value for passing to bid requests
-  * @function
-  * @param { string | undefined } value
-  * @returns {{pairId:string} | undefined }
-  */
+   * decode the stored id value for passing to bid requests
+   * @function
+   * @param { string | undefined } value
+   * @returns {{pairId:string} | undefined }
+   */
   decode(value) {
     return value && Array.isArray(value) ? {'pairId': value} : undefined
   },
   /**
-  * performs action to obtain id and return a value in the callback's response argument
-  * @function
-  * @returns {id: string | undefined }
-  */
+   * performs action to obtain id and return a value in the callback's response argument
+   * @function
+   * @returns {id: string | undefined }
+   */
   getId(config) {
     const pairIdsString = pairIdFromLocalStorage(PAIR_ID_KEY) || pairIdFromCookie(PAIR_ID_KEY)
     let ids = []

--- a/modules/pangleBidAdapter.js
+++ b/modules/pangleBidAdapter.js
@@ -18,6 +18,11 @@ const DEFAULT_CURRENCY = 'USD';
 const DEFAULT_NET_REVENUE = true;
 const PANGLE_COOKIE = '_pangle_id';
 const COOKIE_EXP = 86400 * 1000 * 365 * 1; // 1 year
+const MEDIA_TYPES = {
+  Banner: 1,
+  Video: 2
+};
+
 export const storage = getStorageManager({ moduleType: MODULE_TYPE_RTD, moduleName: BIDDER_CODE })
 
 export function isValidUuid(uuid) {
@@ -104,12 +109,20 @@ const converter = ortbConverter({
     currency: DEFAULT_CURRENCY,
   },
   bidResponse(buildBidResponse, bid, context) {
-    const bidResponse = buildBidResponse(bid, context);
     const { bidRequest } = context;
-    if (bidRequest.mediaTypes.video?.context === 'outstream') {
-      const renderer = Renderer.install({id: bid.bidId, url: OUTSTREAM_RENDERER_URL, adUnitCode: bid.adUnitCode});
-      renderer.setRender(renderOutstream);
-      bidResponse.renderer = renderer;
+    let bidResponse;
+    if (bid.mtype === MEDIA_TYPES.Video) {
+      context.mediaType = VIDEO;
+      bidResponse = buildBidResponse(bid, context);
+      if (bidRequest.mediaTypes.video?.context === 'outstream') {
+        const renderer = Renderer.install({id: bid.bidId, url: OUTSTREAM_RENDERER_URL, adUnitCode: bid.adUnitCode});
+        renderer.setRender(renderOutstream);
+        bidResponse.renderer = renderer;
+      }
+    }
+    if (bid.mtype === MEDIA_TYPES.Banner) {
+      context.mediaType = BANNER;
+      bidResponse = buildBidResponse(bid, context);
     }
     return bidResponse;
   },

--- a/modules/pgamsspBidAdapter.js
+++ b/modules/pgamsspBidAdapter.js
@@ -35,8 +35,13 @@ function getPlacementReqData(bid) {
   const placement = {
     bidId,
     schain,
-    bidfloor
+    bidfloor,
+    eids: []
   };
+
+  if (bid.userId) {
+    getUserId(placement.eids, bid.userId.uid2 && bid.userId.uid2.id, 'uidapi.com');
+  }
 
   if (placementId) {
     placement.placementId = placementId;
@@ -89,6 +94,18 @@ function getBidFloor(bid) {
   } catch (err) {
     logError(err);
     return 0;
+  }
+}
+function getUserId(eids, id, source, uidExt) {
+  if (id) {
+    var uid = { id };
+    if (uidExt) {
+      uid.ext = uidExt;
+    }
+    eids.push({
+      source,
+      uids: [ uid ]
+    });
   }
 }
 

--- a/modules/pilotxBidAdapter.js
+++ b/modules/pilotxBidAdapter.js
@@ -6,11 +6,11 @@ export const spec = {
   supportedMediaTypes: ['banner', 'video'],
   aliases: ['pilotx'], // short code
   /**
-         * Determines whether or not the given bid request is valid.
-         *
-         * @param {BidRequest} bid The bid params to validate.
-         * @return boolean True if this is a valid bid, and false otherwise.
-         */
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
   isBidRequestValid: function (bid) {
     let sizesCheck = !!bid.sizes
     let paramSizesCheck = !!bid.params.sizes
@@ -35,11 +35,11 @@ export const spec = {
     return !!(bid.params.placementId);
   },
   /**
-         * Make a server request from the list of BidRequests.
-         *
-         * @param {validBidRequests[]} - an array of bids
-         * @return ServerRequest Info describing the request to the server.
-         */
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @return ServerRequest Info describing the request to the server.
+   */
   buildRequests: function (validBidRequests, bidderRequest) {
     let payloadItems = {};
     validBidRequests.forEach(bidRequest => {
@@ -84,11 +84,11 @@ export const spec = {
     };
   },
   /**
-         * Unpack the response from the server into a list of bids.
-         *
-         * @param {ServerResponse} serverResponse A successful response from the server.
-         * @return {Bid[]} An array of bids which were nested inside the server.
-         */
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
   interpretResponse: function (serverResponse, bidRequest) {
     const serverBody = serverResponse.body;
     const bidResponses = [];

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -207,7 +207,7 @@ getConfig('s2sConfig', ({s2sConfig}) => setS2sConfig(s2sConfig));
 
 /**
  * resets the _synced variable back to false, primiarily used for testing purposes
-*/
+ */
 export function resetSyncedStatus() {
   _syncCount = 0;
 }
@@ -593,7 +593,7 @@ function shouldEmitNonbids(s2sConfig, response) {
 /**
  * Global setter that sets eids permissions for bidders
  * This setter is to be used by userId module when included
- * @param {array} newEidPermissions
+ * @param {Array} newEidPermissions
  */
 function setEidPermissions(newEidPermissions) {
   eidPermissions = newEidPermissions;

--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -51,12 +51,12 @@ export let allowedFields = [SYN_FIELD, 'gptSlot', 'adUnitCode', 'size', 'domain'
 
 /**
  * @summary This is a flag to indicate if a AJAX call is processing for a floors request
-*/
+ */
 let fetching = false;
 
 /**
  * @summary so we only register for our hooks once
-*/
+ */
 let addedFloorsHook = false;
 
 /**
@@ -332,13 +332,29 @@ export function getFloorDataFromAdUnits(adUnits) {
   }, {});
 }
 
+function getNoFloorSignalBidersArray(floorData) {
+  const { data, enforcement } = floorData
+  // The data.noFloorSignalBidders higher priority then the enforcment
+  if (data?.noFloorSignalBidders?.length > 0) {
+    return data.noFloorSignalBidders
+  } else if (enforcement?.noFloorSignalBidders?.length > 0) {
+    return enforcement.noFloorSignalBidders
+  }
+  return []
+}
+
 /**
  * @summary This function takes the adUnits for the auction and update them accordingly as well as returns the rules hashmap for the auction
  */
 export function updateAdUnitsForAuction(adUnits, floorData, auctionId) {
+  const noFloorSignalBiddersArray = getNoFloorSignalBidersArray(floorData)
+
   adUnits.forEach((adUnit) => {
     adUnit.bids.forEach(bid => {
-      if (floorData.skipped) {
+      // check if the bidder is in the no signal list
+      const isNoFloorSignaled = noFloorSignalBiddersArray.some(bidderName => bidderName === bid.bidder)
+      if (floorData.skipped || isNoFloorSignaled) {
+        isNoFloorSignaled && logInfo(`noFloorSignal to ${bid.bidder}`)
         delete bid.getFloor;
       } else {
         bid.getFloor = getFloor;
@@ -346,8 +362,9 @@ export function updateAdUnitsForAuction(adUnits, floorData, auctionId) {
       // information for bid and analytics adapters
       bid.auctionId = auctionId;
       bid.floorData = {
+        noFloorSignaled: isNoFloorSignaled,
         skipped: floorData.skipped,
-        skipRate: floorData.skipRate,
+        skipRate: deepAccess(floorData, 'data.skipRate') ?? floorData.skipRate,
         floorMin: floorData.floorMin,
         modelVersion: deepAccess(floorData, 'data.modelVersion'),
         modelWeight: deepAccess(floorData, 'data.modelWeight'),
@@ -396,7 +413,7 @@ export function createFloorsDataForAuction(adUnits, auctionId) {
     resolvedFloorsData.skipped = true;
   } else {
     // determine the skip rate now
-    const auctionSkipRate = getParameterByName('pbjs_skipRate') || resolvedFloorsData.skipRate;
+    const auctionSkipRate = getParameterByName('pbjs_skipRate') || (deepAccess(resolvedFloorsData, 'data.skipRate') ?? resolvedFloorsData.skipRate);
     const isSkipped = Math.random() * 100 < parseFloat(auctionSkipRate);
     resolvedFloorsData.skipped = isSkipped;
   }
@@ -663,7 +680,8 @@ export function handleSetFloorsConfig(config) {
       'enforceJS', enforceJS => enforceJS !== false, // defaults to true
       'enforcePBS', enforcePBS => enforcePBS === true, // defaults to false
       'floorDeals', floorDeals => floorDeals === true, // defaults to false
-      'bidAdjustment', bidAdjustment => bidAdjustment !== false, // defaults to true
+      'bidAdjustment', bidAdjustment => bidAdjustment !== false, // defaults to true,
+      'noFloorSignalBidders', noFloorSignalBidders => noFloorSignalBidders || []
     ]),
     'additionalSchemaFields', additionalSchemaFields => typeof additionalSchemaFields === 'object' && Object.keys(additionalSchemaFields).length > 0 ? addFieldOverrides(additionalSchemaFields) : undefined,
     'data', data => (data && parseFloorData(data, 'setConfig')) || undefined

--- a/modules/prismaBidAdapter.js
+++ b/modules/prismaBidAdapter.js
@@ -44,20 +44,20 @@ export const spec = {
   aliases: ['prismadirect'], // short code
   supportedMediaTypes: [BANNER, VIDEO],
   /**
-         * Determines whether or not the given bid request is valid.
-         *
-         * @param {BidRequest} bid The bid params to validate.
-         * @return boolean True if this is a valid bid, and false otherwise.
-         */
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
   isBidRequestValid: function(bid) {
     return !!(bid.params.account && bid.params.tagId);
   },
   /**
-         * Make a server request from the list of BidRequests.
-         *
-         * @param {validBidRequests[]} - an array of bids
-         * @return ServerRequest Info describing the request to the server.
-         */
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @return ServerRequest Info describing the request to the server.
+   */
   buildRequests: function(validBidRequests, bidderRequest) {
     const adUnits = [];
     const test = config.getConfig('debug') ? 1 : 0;
@@ -109,11 +109,11 @@ export const spec = {
     };
   },
   /**
-         * Unpack the response from the server into a list of bids.
-         *
-         * @param {ServerResponse} serverResponse A successful response from the server.
-         * @return {Bid[]} An array of bids which were nested inside the server.
-         */
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
   interpretResponse: function(serverResponse, bidRequest) {
     const serverBody = serverResponse.body;
     const bidResponses = [];
@@ -163,12 +163,12 @@ export const spec = {
   },
 
   /**
-     * Register the user sync pixels which should be dropped after the auction.
-     *
-     * @param {SyncOptions} syncOptions Which user syncs are allowed?
-     * @param {ServerResponse[]} serverResponses List of server's responses.
-     * @return {UserSync[]} The user syncs which should be dropped.
-     */
+   * Register the user sync pixels which should be dropped after the auction.
+   *
+   * @param {SyncOptions} syncOptions Which user syncs are allowed?
+   * @param {ServerResponse[]} serverResponses List of server's responses.
+   * @return {UserSync[]} The user syncs which should be dropped.
+   */
   getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent) {
     if (typeof serverResponses === 'object' && serverResponses != null && serverResponses.length > 0 && serverResponses[0].hasOwnProperty('body') &&
         serverResponses[0].body.hasOwnProperty('cookies') && typeof serverResponses[0].body.cookies === 'object') {
@@ -179,9 +179,9 @@ export const spec = {
   },
 
   /**
-     * Register bidder specific code, which will execute if a bid from this bidder won the auction
-     * @param {Bid} The bid that won the auction
-     */
+   * Register bidder specific code, which will execute if a bid from this bidder won the auction
+   * @param {Bid} The bid that won the auction
+   */
   onBidWon: function(bid) {
     // fires a pixel to confirm a winning bid
     const params = { type: 'prebid', mediatype: 'banner' };

--- a/modules/pubmaticAnalyticsAdapter.js
+++ b/modules/pubmaticAnalyticsAdapter.js
@@ -1,4 +1,4 @@
-import {_each, isArray, isStr, logError, logWarn, pick} from '../src/utils.js';
+import {_each, isArray, isStr, logError, logWarn, pick, generateUUID} from '../src/utils.js';
 import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
 import adapterManager from '../src/adapterManager.js';
 import CONSTANTS from '../src/constants.json';
@@ -9,6 +9,7 @@ import {getGptSlotInfoForAdUnitCode} from '../libraries/gptUtils/gptUtils.js';
 
 /// /////////// CONSTANTS //////////////
 const ADAPTER_CODE = 'pubmatic';
+const VENDOR_OPENWRAP = 'openwrap';
 const SEND_TIMEOUT = 2000;
 const END_POINT_HOST = 'https://t.pubmatic.com/';
 const END_POINT_BID_LOGGER = END_POINT_HOST + 'wl?';
@@ -258,12 +259,27 @@ function isS2SBidder(bidder) {
   return (s2sBidders.indexOf(bidder) > -1) ? 1 : 0
 }
 
+function isOWPubmaticBid(adapterName) {
+  let s2sConf = config.getConfig('s2sConfig');
+  let s2sConfArray = isArray(s2sConf) ? s2sConf : [s2sConf];
+  return s2sConfArray.some(conf => {
+    if (adapterName === ADAPTER_CODE && conf.defaultVendor === VENDOR_OPENWRAP &&
+      conf.bidders.indexOf(ADAPTER_CODE) > -1) {
+      return true;
+    }
+  })
+}
+
 function gatherPartnerBidsForAdUnitForLogger(adUnit, adUnitId, highestBid) {
   highestBid = (highestBid && highestBid.length > 0) ? highestBid[0] : null;
   return Object.keys(adUnit.bids).reduce(function(partnerBids, bidId) {
     adUnit.bids[bidId].forEach(function(bid) {
+      let adapterName = getAdapterNameForAlias(bid.adapterCode || bid.bidder);
+      if (isOWPubmaticBid(adapterName) && isS2SBidder(bid.bidder)) {
+        return;
+      }
       partnerBids.push({
-        'pn': getAdapterNameForAlias(bid.adapterCode || bid.bidder),
+        'pn': adapterName,
         'bc': bid.bidderCode || bid.bidder,
         'bidid': bid.bidId || bidId,
         'db': bid.bidResponse ? 0 : 1,
@@ -286,7 +302,7 @@ function gatherPartnerBidsForAdUnitForLogger(adUnit, adUnitId, highestBid) {
         'ocpm': bid.bidResponse ? (bid.bidResponse.originalCpm || 0) : 0,
         'ocry': bid.bidResponse ? (bid.bidResponse.originalCurrency || CURRENCY_USD) : CURRENCY_USD,
         'piid': bid.bidResponse ? (bid.bidResponse.partnerImpId || EMPTY_STRING) : EMPTY_STRING,
-        'frv': (bid.bidResponse ? (bid.bidResponse.floorData ? bid.bidResponse.floorData.floorRuleValue : undefined) : undefined),
+        'frv': bid.bidResponse ? bid.bidResponse.floorData?.floorRuleValue : undefined,
         'md': bid.bidResponse ? getMetadata(bid.bidResponse.meta) : undefined
       });
     });
@@ -337,11 +353,11 @@ function executeBidsLoggerCall(e, highestCpmBids) {
   let auctionId = e.auctionId;
   let referrer = config.getConfig('pageUrl') || cache.auctions[auctionId].referer || '';
   let auctionCache = cache.auctions[auctionId];
-  let floorData = auctionCache.floorData;
+  let wiid = auctionCache?.wiid || auctionId;
+  let floorData = auctionCache?.floorData;
+  let floorFetchStatus = getFloorFetchStatus(auctionCache?.floorData);
   let outputObj = { s: [] };
   let pixelURL = END_POINT_BID_LOGGER;
-  // will return true if floor data is present.
-  let fetchStatus = getFloorFetchStatus(auctionCache.floorData);
 
   if (!auctionCache) {
     return;
@@ -353,7 +369,7 @@ function executeBidsLoggerCall(e, highestCpmBids) {
 
   pixelURL += 'pubid=' + publisherId;
   outputObj['pubid'] = '' + publisherId;
-  outputObj['iid'] = '' + auctionId;
+  outputObj['iid'] = '' + wiid;
   outputObj['to'] = '' + auctionCache.timeout;
   outputObj['purl'] = referrer;
   outputObj['orig'] = getDomainFromUrl(referrer);
@@ -364,7 +380,7 @@ function executeBidsLoggerCall(e, highestCpmBids) {
   outputObj['tgid'] = getTgId();
   outputObj['pbv'] = getGlobal()?.version || '-1';
 
-  if (floorData && fetchStatus) {
+  if (floorData && floorFetchStatus) {
     outputObj['fmv'] = floorData.floorRequestData ? floorData.floorRequestData.modelVersion || undefined : undefined;
     outputObj['ft'] = floorData.floorResponseData ? (floorData.floorResponseData.enforcements.enforceJS == false ? 0 : 1) : undefined;
   }
@@ -379,8 +395,25 @@ function executeBidsLoggerCall(e, highestCpmBids) {
       'mt': getAdUnitAdFormats(origAdUnit),
       'sz': getSizesForAdUnit(adUnit, adUnitId),
       'ps': gatherPartnerBidsForAdUnitForLogger(adUnit, adUnitId, highestCpmBids.filter(bid => bid.adUnitCode === adUnitId)),
-      'fskp': (floorData && fetchStatus) ? (floorData.floorRequestData ? (floorData.floorRequestData.skipped == false ? 0 : 1) : undefined) : undefined,
+      'fskp': floorData && floorFetchStatus ? (floorData.floorRequestData ? (floorData.floorRequestData.skipped == false ? 0 : 1) : undefined) : undefined,
+      'sid': generateUUID()
     };
+    if (floorData?.floorRequestData) {
+      const { location, fetchStatus, floorProvider } = floorData?.floorRequestData;
+      slotObject.ffs = {
+        [CONSTANTS.FLOOR_VALUES.SUCCESS]: 1,
+        [CONSTANTS.FLOOR_VALUES.ERROR]: 2,
+        [CONSTANTS.FLOOR_VALUES.TIMEOUT]: 4,
+        undefined: 0
+      }[fetchStatus];
+      slotObject.fsrc = {
+        [CONSTANTS.FLOOR_VALUES.FETCH]: 2,
+        [CONSTANTS.FLOOR_VALUES.NO_DATA]: 2,
+        [CONSTANTS.FLOOR_VALUES.AD_UNIT]: 1,
+        [CONSTANTS.FLOOR_VALUES.SET_CONFIG]: 1
+      }[location];
+      slotObject.fp = floorProvider;
+    }
     slotsArray.push(slotObject);
     return slotsArray;
   }, []);
@@ -402,16 +435,24 @@ function executeBidsLoggerCall(e, highestCpmBids) {
 function executeBidWonLoggerCall(auctionId, adUnitId) {
   const winningBidId = cache.auctions[auctionId].adUnitCodes[adUnitId].bidWon;
   const winningBids = cache.auctions[auctionId].adUnitCodes[adUnitId].bids[winningBidId];
-  let winningBid = winningBids[0];
+  if (!winningBids) {
+    logWarn(LOG_PRE_FIX + 'Could not find winningBids for : ', auctionId);
+    return;
+  }
 
+  let winningBid = winningBids[0];
   if (winningBids.length > 1) {
     winningBid = winningBids.filter(bid => bid.adId === cache.auctions[auctionId].adUnitCodes[adUnitId].bidWonAdId)[0];
   }
 
   const adapterName = getAdapterNameForAlias(winningBid.adapterCode || winningBid.bidder);
+  if (isOWPubmaticBid(adapterName) && isS2SBidder(winningBid.bidder)) {
+    return;
+  }
   let origAdUnit = getAdUnit(cache.auctions[auctionId].origAdUnits, adUnitId) || {};
   let auctionCache = cache.auctions[auctionId];
   let floorData = auctionCache.floorData;
+  let wiid = cache.auctions[auctionId]?.wiid || auctionId;
   let referrer = config.getConfig('pageUrl') || cache.auctions[auctionId].referer || '';
   let adv = winningBid.bidResponse ? getAdDomain(winningBid.bidResponse) || undefined : undefined;
   let fskp = floorData ? (floorData.floorRequestData ? (floorData.floorRequestData.skipped == false ? 0 : 1) : undefined) : undefined;
@@ -420,7 +461,7 @@ function executeBidWonLoggerCall(auctionId, adUnitId) {
   pixelURL += 'pubid=' + publisherId;
   pixelURL += '&purl=' + enc(config.getConfig('pageUrl') || cache.auctions[auctionId].referer || '');
   pixelURL += '&tst=' + Math.round((new window.Date()).getTime() / 1000);
-  pixelURL += '&iid=' + enc(auctionId);
+  pixelURL += '&iid=' + enc(wiid);
   pixelURL += '&bidid=' + enc(winningBidId);
   pixelURL += '&pid=' + enc(profileId);
   pixelURL += '&pdvid=' + enc(profileVersionId);
@@ -461,7 +502,10 @@ function executeBidWonLoggerCall(auctionId, adUnitId) {
 function auctionInitHandler(args) {
   s2sBidders = (function() {
     let s2sConf = config.getConfig('s2sConfig');
-    return (s2sConf && isArray(s2sConf.bidders)) ? s2sConf.bidders : [];
+    let s2sBidders = [];
+    (s2sConf || []) &&
+      isArray(s2sConf) ? s2sConf.map(conf => s2sBidders.push(...conf.bidders)) : s2sBidders.push(...s2sConf.bidders);
+    return s2sBidders || [];
   }());
   let cacheEntry = pick(args, [
     'timestamp',
@@ -484,6 +528,9 @@ function bidRequestedHandler(args) {
         dimensions: bid.sizes
       };
     }
+    if (bid.bidder === 'pubmatic' && !!bid?.params?.wiid) {
+      cache.auctions[args.auctionId].wiid = bid.params.wiid;
+    }
     cache.auctions[args.auctionId].adUnitCodes[bid.adUnitCode].bids[bid.bidId] = [copyRequiredBidDetails(bid)];
     if (bid.floorData) {
       cache.auctions[args.auctionId].floorData['floorRequestData'] = bid.floorData;
@@ -492,6 +539,10 @@ function bidRequestedHandler(args) {
 }
 
 function bidResponseHandler(args) {
+  if (!args.requestId) {
+    logWarn(LOG_PRE_FIX + 'Got null requestId in bidResponseHandler');
+    return;
+  }
   let bid = cache.auctions[args.auctionId].adUnitCodes[args.adUnitCode].bids[args.requestId][0];
   if (!bid) {
     logError(LOG_PRE_FIX + 'Could not find associated bid request for bid response with requestId: ', args.requestId);
@@ -556,7 +607,7 @@ function auctionEndHandler(args) {
   let highestCpmBids = getGlobal().getHighestCpmBids() || [];
   setTimeout(() => {
     executeBidsLoggerCall.call(this, args, highestCpmBids);
-  }, (cache.auctions[args.auctionId].bidderDonePendingCount === 0 ? 500 : SEND_TIMEOUT));
+  }, (cache.auctions[args.auctionId]?.bidderDonePendingCount === 0 ? 500 : SEND_TIMEOUT));
 }
 
 function bidTimeoutHandler(args) {

--- a/modules/pubxBidAdapter.js
+++ b/modules/pubxBidAdapter.js
@@ -55,8 +55,8 @@ export const spec = {
   /**
    * Determine which user syncs should occur
    * @param {object} syncOptions
-   * @param {array} serverResponses
-   * @returns {array} User sync pixels
+   * @param {Array} serverResponses
+   * @returns {Array} User sync pixels
    */
   getUserSyncs: function (syncOptions, serverResponses) {
     const kwTag = document.getElementsByName('keywords');

--- a/modules/r2b2BidAdapter.js
+++ b/modules/r2b2BidAdapter.js
@@ -1,0 +1,309 @@
+import {logWarn, logError, triggerPixel, deepSetValue, getParameterByName} from '../src/utils.js';
+import {ortbConverter} from '../libraries/ortbConverter/converter.js'
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+import {Renderer} from '../src/Renderer.js';
+import {BANNER, VIDEO, NATIVE} from '../src/mediaTypes.js';
+import {pbsExtensions} from '../libraries/pbsExtensions/pbsExtensions.js';
+import {bidderSettings} from '../src/bidderSettings.js';
+
+const ADAPTER_VERSION = '1.0.0';
+const BIDDER_CODE = 'r2b2';
+const GVL_ID = 1235;
+
+const DEFAULT_CURRENCY = 'USD';
+const DEFAULT_TTL = 360;
+const DEFAULT_NET_REVENUE = true;
+const DEBUG_PARAM = 'pbjs_test_r2b2';
+const RENDERER_URL = 'https://delivery.r2b2.io/static/rendering.js';
+
+const ENDPOINT = bidderSettings.get(BIDDER_CODE, 'endpoint') || 'hb.r2b2.cz';
+const SERVER_URL = 'https://' + ENDPOINT;
+const URL_BID = SERVER_URL + '/openrtb2/bid';
+const URL_SYNC = SERVER_URL + '/cookieSync';
+const URL_EVENT = SERVER_URL + '/event';
+
+const URL_EVENT_ON_BIDDER_ERROR = URL_EVENT + '/bidError';
+const URL_EVENT_ON_TIMEOUT = URL_EVENT + '/timeout';
+
+const R2B2_TEST_UNIT = 'selfpromo';
+
+export const internal = {
+  placementsToSync: [],
+  mappedParams: {}
+}
+
+let r2b2Error = function(message, params) {
+  logError(message, params, BIDDER_CODE)
+}
+
+function getIdParamsFromPID(pid) {
+  // selfpromo test creative
+  if (pid === R2B2_TEST_UNIT) {
+    return { d: 'test', g: 'test', p: 'selfpromo', m: 0, selfpromo: 1 }
+  }
+  if (!isNaN(pid)) {
+    return { pid: Number(pid) }
+  }
+  if (typeof pid === 'string') {
+    const params = pid.split('/');
+    if (params.length === 3 || params.length === 4) {
+      const paramNames = ['d', 'g', 'p', 'm'];
+      return paramNames.reduce((p, paramName, index) => {
+        let param = params[index];
+        if (paramName === 'm') {
+          param = ['desktop', 'classic', '0'].includes(param) ? 0 : Number(!!param)
+        }
+        p[paramName] = param;
+        return p
+      }, {});
+    }
+  }
+}
+
+function pickIdFromParams(params) {
+  if (!params) return null;
+  const { d, g, p, m, pid } = params;
+  return d ? { d, g, p, m } : { pid };
+}
+
+function getIdsFromBids(bids) {
+  return bids.reduce((ids, bid) => {
+    const params = internal.mappedParams[bid.bidId];
+    const id = pickIdFromParams(params);
+    if (id) {
+      ids.push(id);
+    }
+    return ids
+  }, []);
+}
+
+function triggerEvent(eventUrl, ids) {
+  if (ids && !ids.length) return;
+  const timeStamp = new Date().getTime();
+  const symbol = (eventUrl.indexOf('?') === -1 ? '?' : '&');
+  const url = eventUrl + symbol + `p=${btoa(JSON.stringify(ids))}&cb=${timeStamp}`;
+  triggerPixel(url)
+}
+
+const converter = ortbConverter({
+  imp(buildImp, bidRequest, context) {
+    const imp = buildImp(bidRequest, context);
+    const idParams = getIdParamsFromPID(bidRequest.params.pid);
+    deepSetValue(imp, 'ext.r2b2', idParams);
+    internal.placementsToSync.push(idParams);
+    internal.mappedParams[imp.id] = Object.assign({}, bidRequest.params, idParams);
+    return imp;
+  },
+  request(buildRequest, imps, bidderRequest, context) {
+    const request = buildRequest(imps, bidderRequest, context);
+    deepSetValue(request, 'ext.version', ADAPTER_VERSION);
+    request.cur = [DEFAULT_CURRENCY];
+    const test = getParameterByName(DEBUG_PARAM) === '1' ? 1 : 0;
+    deepSetValue(request, 'test', test);
+    return request;
+  },
+  context: {
+    netRevenue: DEFAULT_NET_REVENUE,
+    ttl: DEFAULT_TTL
+  },
+  processors: pbsExtensions
+});
+
+function setUpRenderer(adUnitCode, bid) {
+  // let renderer load once in main window, but pass the renderDocument
+  let renderDoc;
+  const config = {
+    documentResolver: (bid, sourceDocument, renderDocument) => {
+      renderDoc = renderDocument;
+      return sourceDocument;
+    }
+  }
+  let renderer = Renderer.install({
+    url: RENDERER_URL,
+    config: config,
+    id: bid.requestId,
+    adUnitCode
+  });
+
+  renderer.setRender(function (bid, doc) {
+    doc = renderDoc || doc;
+    window.R2B2 = window.R2B2 || {};
+    let main = window.R2B2;
+    main.HB = main.HB || {};
+    main.HB.Render = main.HB.Render || {};
+    main.HB.Render.queue = main.HB.Render.queue || [];
+    main.HB.Render.queue.push(() => {
+      const id = pickIdFromParams(internal.mappedParams[bid.requestId])
+      main.HB.Renderer.render(id, bid, null, doc)
+    })
+  })
+
+  return renderer
+}
+
+function getExtMediaType(bidMediaType, responseBid) {
+  switch (bidMediaType) {
+    case BANNER:
+      return {
+        type: 'banner',
+        settings: {
+          chd: null,
+          width: responseBid.w,
+          height: responseBid.h,
+          ad: {
+            type: 'content',
+            data: responseBid.adm
+          }
+        }
+      };
+    case NATIVE:
+      break;
+    case VIDEO:
+      break;
+    default:
+      break;
+  }
+}
+
+function createPrebidResponseBid(requestImp, bidResponse, serverResponse, bids) {
+  const bidId = requestImp.id;
+  const adUnitCode = bids[0].adUnitCode;
+  const mediaType = bidResponse.ext.prebid.type;
+  let bidOut = {
+    requestId: bidId,
+    cpm: bidResponse.price,
+    creativeId: bidResponse.crid,
+    width: bidResponse.w,
+    height: bidResponse.h,
+    ttl: bidResponse.ttl ?? DEFAULT_TTL,
+    netRevenue: serverResponse.netRevenue ?? DEFAULT_NET_REVENUE,
+    currency: serverResponse.cur ?? DEFAULT_CURRENCY,
+    ad: bidResponse.adm,
+    mediaType: mediaType,
+    winUrl: bidResponse.nurl,
+    ext: {
+      cid: bidResponse.ext?.r2b2?.cid,
+      cdid: bidResponse.ext?.r2b2?.cdid,
+      mediaType: getExtMediaType(mediaType, bidResponse),
+      adUnit: adUnitCode,
+      dgpm: internal.mappedParams[bidId],
+      events: bidResponse.ext?.r2b2?.events
+    }
+  };
+  if (bidResponse.ext?.r2b2?.useRenderer) {
+    bidOut.renderer = setUpRenderer(adUnitCode, bidOut);
+  }
+  return bidOut;
+}
+
+export const spec = {
+  code: BIDDER_CODE,
+  gvlid: GVL_ID,
+  supportedMediaTypes: [BANNER],
+
+  isBidRequestValid: function(bid) {
+    if (!bid.params || !bid.params.pid) {
+      logWarn('Bad params, "pid" required.');
+      return false
+    }
+    const id = getIdParamsFromPID(bid.params.pid);
+    if (!id || !(id.pid || (id.d && id.g && id.p))) {
+      logWarn('Bad params, "pid" has to be either a number or a correctly assembled string.');
+      return false
+    }
+    return true
+  },
+  buildRequests: function(validBidRequests, bidderRequest) {
+    const data = converter.toORTB({
+      bidRequests: validBidRequests,
+      bidderRequest
+    });
+    return [{
+      method: 'POST',
+      url: URL_BID,
+      data,
+      bids: bidderRequest.bids
+    }]
+  },
+
+  interpretResponse: function(serverResponse, request) {
+    // r2b2Error('error message', {params: 1});
+    let prebidResponses = [];
+
+    const response = serverResponse.body;
+    if (!response || !response.seatbid || !response.seatbid[0] || !response.seatbid[0].bid) {
+      return prebidResponses;
+    }
+    let requestImps = request.data.imp || [];
+    try {
+      response.seatbid.forEach(seat => {
+        let bids = seat.bid;
+
+        for (let responseBid of bids) {
+          let responseImpId = responseBid.impid;
+          let requestCurrentImp = requestImps.find((requestImp) => requestImp.id === responseImpId);
+          if (!requestCurrentImp) {
+            r2b2Error('Cant match bid response.', {impid: Boolean(responseBid.impid)});
+            continue;// Skip this iteration if there's no match
+          }
+          prebidResponses.push(createPrebidResponseBid(requestCurrentImp, responseBid, response, request.bids));
+        }
+      })
+    } catch (e) {
+      r2b2Error('Error while interpreting response:', {msg: e.message});
+    }
+    return prebidResponses;
+  },
+  getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent) {
+    const syncs = [];
+
+    if (!syncOptions.iframeEnabled) {
+      logWarn('Please enable iframe based user sync.');
+      return syncs;
+    }
+
+    let plString;
+    try {
+      plString = btoa(JSON.stringify(internal.placementsToSync || []));
+    } catch (e) {
+      logWarn('User sync failed: ' + e.message);
+      return syncs
+    }
+
+    let url = URL_SYNC + `?p=${plString}`;
+
+    if (gdprConsent) {
+      url += `&gdpr=${Number(gdprConsent.gdprApplies)}&gdpr_consent=${gdprConsent.consentString}`
+    }
+
+    if (uspConsent) {
+      url += `&us_privacy=${uspConsent}`
+    }
+
+    syncs.push({
+      type: 'iframe',
+      url: url
+    })
+    return syncs;
+  },
+  onBidWon: function(bid) {
+    const url = bid.ext?.events?.onBidWon;
+    if (url) {
+      triggerEvent(url)
+    }
+  },
+  onSetTargeting: function(bid) {
+    const url = bid.ext?.events?.onSetTargeting;
+    if (url) {
+      triggerEvent(url)
+    }
+  },
+  onTimeout: function(bids) {
+    triggerEvent(URL_EVENT_ON_TIMEOUT, getIdsFromBids(bids))
+  },
+  onBidderError: function(params) {
+    let { bidderRequest } = params;
+    triggerEvent(URL_EVENT_ON_BIDDER_ERROR, getIdsFromBids(bidderRequest.bids))
+  }
+}
+registerBidder(spec);

--- a/modules/r2b2BidAdapter.md
+++ b/modules/r2b2BidAdapter.md
@@ -1,0 +1,37 @@
+# Overview
+
+```
+Module Name: R2B2 Bid Adapter
+Module Type: Bidder Adapter
+Maintainer: dev@r2b2.cz
+```
+
+## Description
+
+Module that integrates R2B2 demand sources. To get your bidder configuration reach out to our account team on partner@r2b2.io
+
+
+
+## Test unit
+
+```javascript
+  var adUnits = [
+    {
+      code: 'test-r2b2',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250], [300, 600]],
+        }
+      },
+      bids: [{
+        bidder: 'r2b2',
+        params: {
+            pid: 'selfpromo'
+        }
+      }]
+    }
+  ];
+```
+## Rendering
+
+Our adapter can feature a custom renderer specifically for display ads, tailored to enhance ad presentation and functionality. This is particularly beneficial for non-standard ad formats that require more complex logic. It's important to note that our rendering process operates outside of SafeFrames. For additional information, not limited to rendering aspects, please feel free to contact us at partner@r2b2.io

--- a/modules/relevantdigitalBidAdapter.js
+++ b/modules/relevantdigitalBidAdapter.js
@@ -94,7 +94,7 @@ export const spec = {
   gvlid: 1100,
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 
-  /** We need both params.placementId + a complete configuration (pbsHost + accountId) to continue **/
+  /** We need both params.placementId + a complete configuration (pbsHost + accountId) to continue */
   isBidRequestValid: (bid) => bid.params?.placementId && getBidderConfig([bid]).complete,
 
   /** Trigger impression-pixel */

--- a/modules/richaudienceBidAdapter.js
+++ b/modules/richaudienceBidAdapter.js
@@ -1,4 +1,4 @@
-import {deepAccess, isStr} from '../src/utils.js';
+import {deepAccess, isStr, triggerPixel} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {config} from '../src/config.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
@@ -183,6 +183,13 @@ export const spec = {
     }
     return syncs
   },
+
+  onTimeout: function (data) {
+    let url = raiGetTimeoutURL(data);
+    if (url) {
+      triggerPixel(url);
+    }
+  }
 };
 
 registerBidder(spec);
@@ -331,4 +338,16 @@ function raiGetFloor(bid, config) {
   } catch (e) {
     return 0
   }
+}
+
+function raiGetTimeoutURL(data) {
+  let {params, timeout} = data[0]
+  let url = 'https://s.richaudience.com/err/?ec=6&ev=[timeout_publisher]&pla=[placement_hash]&int=PREBID&pltfm=&node=&dm=[domain]';
+
+  url = url.replace('[timeout_publisher]', timeout)
+  url = url.replace('[placement_hash]', params[0].pid)
+  if (REFERER != null) {
+    url = url.replace('[domain]', document.location.host)
+  }
+  return url
 }

--- a/modules/riseBidAdapter.js
+++ b/modules/riseBidAdapter.js
@@ -19,7 +19,8 @@ const SUPPORTED_AD_TYPES = [BANNER, VIDEO];
 const BIDDER_CODE = 'rise';
 const ADAPTER_VERSION = '6.0.0';
 const TTL = 360;
-const CURRENCY = 'USD';
+const DEFAULT_CURRENCY = 'USD';
+const DEFAULT_GVLID = 1043;
 const DEFAULT_SELLER_ENDPOINT = 'https://hb.yellowblue.io/';
 const MODES = {
   PRODUCTION: 'hb-multi',
@@ -32,7 +33,11 @@ const SUPPORTED_SYNC_METHODS = {
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: 1043,
+  aliases: [
+    { code: 'risexchange', gvlid: DEFAULT_GVLID },
+    { code: 'openwebxchange', gvlid: 280 }
+  ],
+  gvlid: DEFAULT_GVLID,
   version: ADAPTER_VERSION,
   supportedMediaTypes: SUPPORTED_AD_TYPES,
   isBidRequestValid: function (bidRequest) {
@@ -73,7 +78,7 @@ export const spec = {
         const bidResponse = {
           requestId: adUnit.requestId,
           cpm: adUnit.cpm,
-          currency: adUnit.currency || CURRENCY,
+          currency: adUnit.currency || DEFAULT_CURRENCY,
           width: adUnit.width,
           height: adUnit.height,
           ttl: adUnit.ttl || TTL,
@@ -140,18 +145,20 @@ registerBidder(spec);
 /**
  * Get floor price
  * @param bid {bid}
+ * @param mediaType {string}
+ * @param currency {string}
  * @returns {Number}
  */
-function getFloor(bid, mediaType) {
+function getFloor(bid, mediaType, currency) {
   if (!isFn(bid.getFloor)) {
     return 0;
   }
   let floorResult = bid.getFloor({
-    currency: CURRENCY,
+    currency: currency,
     mediaType: mediaType,
     size: '*'
   });
-  return floorResult.currency === CURRENCY && floorResult.floor ? floorResult.floor : 0;
+  return floorResult.currency === currency && floorResult.floor ? floorResult.floor : 0;
 }
 
 /**
@@ -289,7 +296,7 @@ function generateBidParameters(bid, bidderRequest) {
   const {params} = bid;
   const mediaType = isBanner(bid) ? BANNER : VIDEO;
   const sizesArray = getSizesArray(bid, mediaType);
-
+  const currency = params.currency || config.getConfig('currency.adServerCurrency') || DEFAULT_CURRENCY;
   // fix floor price in case of NAN
   if (isNaN(params.floorPrice)) {
     params.floorPrice = 0;
@@ -299,12 +306,13 @@ function generateBidParameters(bid, bidderRequest) {
     mediaType,
     adUnitCode: getBidIdParameter('adUnitCode', bid),
     sizes: sizesArray,
-    floorPrice: Math.max(getFloor(bid, mediaType), params.floorPrice),
+    currency: currency,
+    floorPrice: Math.max(getFloor(bid, mediaType, currency), params.floorPrice),
     bidId: getBidIdParameter('bidId', bid),
     bidderRequestId: getBidIdParameter('bidderRequestId', bid),
     loop: getBidIdParameter('bidderRequestsCount', bid),
     transactionId: bid.ortb2Imp?.ext?.tid,
-    coppa: 0
+    coppa: 0,
   };
 
   const pos = deepAccess(bid, `mediaTypes.${mediaType}.pos`);

--- a/modules/riseBidAdapter.md
+++ b/modules/riseBidAdapter.md
@@ -26,6 +26,7 @@ The adapter supports Video(instream).
 | `testMode` | optional | Boolean |  This activates the test mode  | false
 | `rtbDomain` | optional | String |  Sets the seller end point  | "www.test.com"
 | `is_wrapper` | private | Boolean |  Please don't use unless your account manager asked you to  | false
+| `currency` | optional | String | 3 letters currency | "EUR"
 
 
 # Test Parameters

--- a/modules/rtbhouseBidAdapter.js
+++ b/modules/rtbhouseBidAdapter.js
@@ -195,7 +195,7 @@ registerBidder(spec);
 
 /**
  * @param {object} slot Ad Unit Params by Prebid
- * @returns {int} floor by imp type
+ * @returns {number} floor by imp type
  */
 function applyFloor(slot) {
   const floors = [];
@@ -350,7 +350,7 @@ function mapNative(slot) {
 
 /**
  * @param {object} slot Slot config by Prebid
- * @returns {array} Request Assets by OpenRTB Native Ads 1.1 §4.2
+ * @returns {Array} Request Assets by OpenRTB Native Ads 1.1 §4.2
  */
 function mapNativeAssets(slot) {
   const params = slot.nativeParams || deepAccess(slot, 'mediaTypes.native');
@@ -413,7 +413,7 @@ function mapNativeAssets(slot) {
 
 /**
  * @param {object} image Prebid native.image/icon
- * @param {int} type Image or icon code
+ * @param {number} type Image or icon code
  * @returns {object} Request Image by OpenRTB Native Ads 1.1 §4.4
  */
 function mapNativeImage(image, type) {

--- a/modules/rtdModule/index.js
+++ b/modules/rtdModule/index.js
@@ -215,7 +215,8 @@ const setEventsListeners = (function () {
         [CONSTANTS.EVENTS.AUCTION_INIT]: ['onAuctionInitEvent'],
         [CONSTANTS.EVENTS.AUCTION_END]: ['onAuctionEndEvent', getAdUnitTargeting],
         [CONSTANTS.EVENTS.BID_RESPONSE]: ['onBidResponseEvent'],
-        [CONSTANTS.EVENTS.BID_REQUESTED]: ['onBidRequestEvent']
+        [CONSTANTS.EVENTS.BID_REQUESTED]: ['onBidRequestEvent'],
+        [CONSTANTS.EVENTS.BID_ACCEPTED]: ['onBidAcceptedEvent']
       }).forEach(([ev, [handler, preprocess]]) => {
         events.on(ev, (args) => {
           preprocess && preprocess(args);
@@ -385,7 +386,7 @@ export function getAdUnitTargeting(auction) {
 
 /**
  * deep merge array of objects
- * @param {array} arr - objects array
+ * @param {Array} arr - objects array
  * @return {Object} merged object
  */
 export function deepMerge(arr) {

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -22,7 +22,6 @@ import {
   _each
 } from '../src/utils.js';
 import {getAllOrtbKeywords} from '../libraries/keywords/keywords.js';
-import {convertTypes} from '../libraries/transformParamsUtils/convertTypes.js';
 
 const DEFAULT_INTEGRATION = 'pbjs_lite';
 const DEFAULT_PBS_INTEGRATION = 'pbjs';
@@ -766,19 +765,6 @@ export const spec = {
         url: `https://${rubiConf.syncHost || 'eus'}.rubiconproject.com/usync.html` + params
       };
     }
-  },
-  /**
-   * Covert bid param types for S2S
-   * @param {Object} params bid params
-   * @param {Boolean} isOpenRtb boolean to check openrtb2 protocol
-   * @return {Object} params bid params
-   */
-  transformBidParams: function(params, isOpenRtb) {
-    return convertTypes({
-      'accountId': 'number',
-      'siteId': 'number',
-      'zoneId': 'number'
-    }, params);
   }
 };
 
@@ -1183,8 +1169,7 @@ export function hasValidVideoParams(bid) {
   var requiredParams = {
     mimes: arrayType,
     protocols: arrayType,
-    linearity: numberType,
-    api: arrayType
+    linearity: numberType
   }
   // loop through each param and verify it has the correct
   Object.keys(requiredParams).forEach(function(param) {
@@ -1199,7 +1184,7 @@ export function hasValidVideoParams(bid) {
 /**
  * Make sure the required params are present
  * @param {Object} schain
- * @param {Bool}
+ * @param {boolean}
  */
 export function hasValidSupplyChainParams(schain) {
   let isValid = false;

--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -107,7 +107,6 @@ function buildBidRequest(validBidRequest) {
       return mediaTypesMap[pbjsType];
     }
   );
-
   const bidRequest = {
     id: validBidRequest.bidId,
     transactionId: validBidRequest.ortb2Imp?.ext?.tid,
@@ -115,6 +114,7 @@ function buildBidRequest(validBidRequest) {
     supplyTypes: mediaTypes,
     adUnitId: params.adUnitId,
     adUnitCode: validBidRequest.adUnitCode,
+    geom: geom(validBidRequest.adUnitCode),
     placement: params.placement,
     requestCount: validBidRequest.bidderRequestsCount || 1, // FIXME : in unit test the parameter bidderRequestsCount is undefined
   };
@@ -196,6 +196,27 @@ function ttfb() {
   // @see https://github.com/googleChrome/web-vitals/issues/162
   //      https://github.com/googleChrome/web-vitals/issues/137
   return ttfb >= 0 && ttfb <= performance.now() ? ttfb : 0;
+}
+
+function geom(adunitCode) {
+  const slot = document.getElementById(adunitCode);
+  if (slot) {
+    const scrollY = window.scrollY;
+    const { top, left, width, height } = slot.getBoundingClientRect();
+    const viewport = {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    };
+
+    return {
+      scrollY,
+      top,
+      left,
+      width,
+      height,
+      viewport,
+    };
+  }
 }
 
 export function getTimeoutUrl(data) {

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -45,6 +45,7 @@ export const sharethroughAdapterSpec = {
         dnt: navigator.doNotTrack === '1' ? 1 : 0,
         h: window.screen.height,
         w: window.screen.width,
+        ext: {},
       },
       regs: {
         coppa: config.getConfig('coppa') === true ? 1 : 0,
@@ -62,6 +63,10 @@ export const sharethroughAdapterSpec = {
       badv: deepAccess(bidderRequest.ortb2, 'badv') || bidRequests[0].params.badv || [],
       test: 0,
     };
+
+    if (bidderRequest.ortb2?.device?.ext?.cdep) {
+      req.device.ext['cdep'] = bidderRequest.ortb2.device.ext.cdep;
+    }
 
     req.user = nullish(firstPartyData.user, {});
     if (!req.user.ext) req.user.ext = {};
@@ -220,9 +225,7 @@ export const sharethroughAdapterSpec = {
     const shouldCookieSync =
       syncOptions.pixelEnabled && deepAccess(serverResponses, '0.body.cookieSyncUrls') !== undefined;
 
-    return shouldCookieSync
-      ? serverResponses[0].body.cookieSyncUrls.map((url) => ({ type: 'image', url: url }))
-      : [];
+    return shouldCookieSync ? serverResponses[0].body.cookieSyncUrls.map((url) => ({ type: 'image', url: url })) : [];
   },
 
   // Empty implementation for prebid core to be able to find it

--- a/modules/sizeMappingV2.js
+++ b/modules/sizeMappingV2.js
@@ -63,7 +63,7 @@ export function isUsingNewSizeMapping(adUnits) {
   does not recognize.
   @params {Array<AdUnits>} adUnits
   @returns {Array<AdUnits>} validateAdUnits - Unrecognized properties are deleted.
-*/
+ */
 export function checkAdUnitSetupHook(adUnits) {
   const validateSizeConfig = function (mediaType, sizeConfig, adUnitCode) {
     let isValid = true;

--- a/modules/slimcutBidAdapter.js
+++ b/modules/slimcutBidAdapter.js
@@ -13,11 +13,11 @@ export const spec = {
   aliases: [{ code: 'scm', gvlid: 102 }],
   supportedMediaTypes: ['video', 'banner'],
   /**
-     * Determines whether or not the given bid request is valid.
-     *
-     * @param {BidRequest} bid The bid params to validate.
-     * @return boolean True if this is a valid bid, and false otherwise.
-     */
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
   isBidRequestValid: function(bid) {
     let isValid = false;
     if (typeof bid.params !== 'undefined' && !isNaN(parseInt(getValue(bid.params, 'placementId'))) && parseInt(getValue(bid.params, 'placementId')) > 0) {
@@ -26,11 +26,11 @@ export const spec = {
     return isValid;
   },
   /**
-     * Make a server request from the list of BidRequests.
-     *
-     * @param {validBidRequests[]} an array of bids
-     * @return ServerRequest Info describing the request to the server.
-     */
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} an array of bids
+   * @return ServerRequest Info describing the request to the server.
+   */
   buildRequests: function(validBidRequests, bidderRequest) {
     const bids = validBidRequests.map(buildRequestObject);
     const payload = {
@@ -55,11 +55,11 @@ export const spec = {
     };
   },
   /**
-     * Unpack the response from the server into a list of bids.
-     *
-     * @param {*} serverResponse A successful response from the server.
-     * @return {Bid[]} An array of bids which were nested inside the server.
-     */
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {*} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
   interpretResponse: function(serverResponse, request) {
     const bidResponses = [];
     serverResponse = serverResponse.body;

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -1,4 +1,4 @@
-import { deepAccess, deepClone, logError, isFn, isPlainObject } from '../src/utils.js';
+import { deepAccess, deepClone, isArrayOfNums, isFn, isInteger, isPlainObject, logError } from '../src/utils.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
@@ -55,18 +55,51 @@ export const spec = {
    * Fills the payload with specific video attributes.
    *
    * @param {*} payload Payload that will be sent in the ServerRequest
-   * @param {*} videoMediaType Video media type.
+   * @param {*} videoMediaType Video media type
    */
   fillPayloadForVideoBidRequest: function(payload, videoMediaType, videoParams) {
     const playerSize = videoMediaType.playerSize[0];
-    payload.isVideo = videoMediaType.context === 'instream';
-    payload.mediaType = VIDEO;
-    payload.videoData = {
-      videoProtocol: this.getProtocolForVideoBidRequest(videoMediaType, videoParams),
-      playerWidth: playerSize[0],
-      playerHeight: playerSize[1],
-      adBreak: this.getStartDelayForVideoBidRequest(videoMediaType, videoParams)
+    const map = {
+      maxbitrate: 'vbrmax',
+      maxduration: 'vdmax',
+      minbitrate: 'vbrmin',
+      minduration: 'vdmin',
+      placement: 'vpt',
+      plcmt: 'vplcmt',
+      skip: 'skip'
     };
+
+    payload.mediaType = VIDEO;
+    payload.isVideo = videoMediaType.context === 'instream';
+    payload.videoData = {};
+
+    for (const [key, value] of Object.entries(map)) {
+      payload.videoData = {
+        ...payload.videoData,
+        ...this.getValuableProperty(value, videoMediaType[key])
+      };
+    }
+
+    payload.videoData = {
+      ...payload.videoData,
+      ...this.getValuableProperty('playerWidth', playerSize[0]),
+      ...this.getValuableProperty('playerHeight', playerSize[1]),
+      ...this.getValuableProperty('adBreak', this.getStartDelayForVideoBidRequest(videoMediaType, videoParams)),
+      ...this.getValuableProperty('videoProtocol', this.getProtocolForVideoBidRequest(videoMediaType, videoParams)),
+      ...(isArrayOfNums(videoMediaType.api) && videoMediaType.api.length ? { iabframeworks: videoMediaType.api.toString() } : {}),
+      ...(isArrayOfNums(videoMediaType.playbackmethod) && videoMediaType.playbackmethod.length ? { vpmt: videoMediaType.playbackmethod } : {})
+    };
+  },
+
+  /**
+   * Gets a property object if the value not falsy
+   * @param {string} property
+   * @param {number} value
+   * @returns object with the property or empty
+   */
+  getValuableProperty: function(property, value) {
+    return typeof property === 'string' && isInteger(value) && value
+      ? { [property]: value } : {};
   },
 
   /**

--- a/modules/smilewantedBidAdapter.js
+++ b/modules/smilewantedBidAdapter.js
@@ -40,11 +40,13 @@ export const spec = {
         transactionId: bid.ortb2Imp?.ext?.tid,
         timeout: bidderRequest?.timeout,
         bidId: bid.bidId,
-        /** positionType is undocumented
+        /**
+         positionType is undocumented
         It is unclear what this parameter means.
         If it means the same as pos in openRTB,
         It should read from openRTB object
-        or from mediaTypes.banner.pos */
+        or from mediaTypes.banner.pos
+         */
         positionType: bid.params.positionType || '',
         prebidVersion: '$prebid.version$'
       };

--- a/modules/sovrnBidAdapter.js
+++ b/modules/sovrnBidAdapter.js
@@ -172,6 +172,11 @@ export const spec = {
         deepSetValue(sovrnBidReq, 'source.tid', tid)
       }
 
+      const coppa = deepAccess(bidderRequest, 'ortb2.regs.coppa');
+      if (coppa) {
+        deepSetValue(sovrnBidReq, 'regs.coppa', 1);
+      }
+
       if (bidderRequest.gdprConsent) {
         deepSetValue(sovrnBidReq, 'regs.ext.gdpr', +bidderRequest.gdprConsent.gdprApplies);
         deepSetValue(sovrnBidReq, 'user.ext.consent', bidderRequest.gdprConsent.consentString)
@@ -209,7 +214,7 @@ export const spec = {
    * Format Sovrn responses as Prebid bid responses
    * @param {id, seatbid} sovrnResponse A successful response from Sovrn.
    * @return {Bid[]} An array of formatted bids.
-  */
+   */
   interpretResponse: function({ body: {id, seatbid} }) {
     if (!id || !seatbid || !Array.isArray(seatbid)) return []
 

--- a/modules/sparteoBidAdapter.js
+++ b/modules/sparteoBidAdapter.js
@@ -8,6 +8,8 @@ const GVLID = 1028;
 const TTL = 60;
 const HTTP_METHOD = 'POST';
 const REQUEST_URL = 'https://bid.sparteo.com/auction';
+const USER_SYNC_URL_IFRAME = 'https://sync.sparteo.com/sync/iframe.html?from=prebidjs';
+let isSynced = window.sparteoCrossfire?.started || false;
 
 const converter = ortbConverter({
   context: {
@@ -38,7 +40,14 @@ const converter = ortbConverter({
   bidResponse(buildBidResponse, bid, context) {
     context.mediaType = deepAccess(bid, 'ext.prebid.type');
 
-    return buildBidResponse(bid, context)
+    const response = buildBidResponse(bid, context);
+
+    if (context.mediaType == 'video') {
+      response.nurl = bid.nurl;
+      response.vastUrl = deepAccess(bid, 'ext.prebid.cache.vastXml.url') ?? null;
+    }
+
+    return response;
   }
 });
 
@@ -53,7 +62,7 @@ export const spec = {
    * @param {BidRequest} bid The bid params to validate.
    * @return boolean True if this is a valid bid, and false otherwise.
    */
-  isBidRequestValid: function(bid) {
+  isBidRequestValid: function (bid) {
     let bannerParams = deepAccess(bid, 'mediaTypes.banner');
     let videoParams = deepAccess(bid, 'mediaTypes.video');
 
@@ -99,7 +108,7 @@ export const spec = {
     return true;
   },
 
-  buildRequests: function(bidRequests, bidderRequest) {
+  buildRequests: function (bidRequests, bidderRequest) {
     const payload = converter.toORTB({bidRequests, bidderRequest})
 
     return {
@@ -109,25 +118,49 @@ export const spec = {
     };
   },
 
-  interpretResponse: function(serverResponse, requests) {
+  interpretResponse: function (serverResponse, requests) {
     const bids = converter.fromORTB({response: serverResponse.body, request: requests.data}).bids;
 
     return bids;
   },
 
-  getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent) {},
+  getUserSyncs: function (syncOptions, serverResponses, gdprConsent, uspConsent) {
+    let syncurl = '';
 
-  onTimeout: function(timeoutData) {},
+    if (!isSynced && !window.sparteoCrossfire?.started) {
+      // Attaching GDPR Consent Params in UserSync url
+      if (gdprConsent) {
+        syncurl += '&gdpr=' + (gdprConsent.gdprApplies ? 1 : 0);
+        syncurl += '&gdpr_consent=' + encodeURIComponent(gdprConsent.consentString || '');
+      }
+      if (uspConsent && uspConsent.consentString) {
+        syncurl += `&usp_consent=${uspConsent.consentString}`;
+      }
 
-  onBidWon: function(bid) {
-    if (bid && bid.nurl && bid.nurl.length > 0) {
-      bid.nurl.forEach(function(winUrl) {
-        triggerPixel(winUrl, null);
-      });
+      if (syncOptions.iframeEnabled) {
+        isSynced = true;
+
+        window.sparteoCrossfire = {
+          started: true
+        };
+
+        return [{
+          type: 'iframe',
+          url: USER_SYNC_URL_IFRAME + syncurl
+        }];
+      }
     }
   },
 
-  onSetTargeting: function(bid) {}
+  onTimeout: function (timeoutData) {},
+
+  onBidWon: function (bid) {
+    if (bid && bid.nurl) {
+      triggerPixel(bid.nurl, null);
+    }
+  },
+
+  onSetTargeting: function (bid) {}
 };
 
 registerBidder(spec);

--- a/modules/sspBCBidAdapter.js
+++ b/modules/sspBCBidAdapter.js
@@ -38,7 +38,7 @@ var nativeAssetMap = {
 
 /**
  * return native asset type, based on asset id
- * @param {int} id - native asset id
+ * @param {number} id - native asset id
  * @returns {string} asset type
  */
 const getNativeAssetType = id => {
@@ -164,7 +164,7 @@ const applyClientHints = ortbRequest => {
     Check / generate page view id
     Should be generated dureing first call to applyClientHints(),
     and re-generated if pathname has changed
-  */
+   */
   if (!pageView.id || location.pathname !== pageView.path) {
     pageView.path = location.pathname;
     pageView.id = Math.floor(1E20 * Math.random()).toString();

--- a/modules/stvBidAdapter.js
+++ b/modules/stvBidAdapter.js
@@ -51,6 +51,7 @@ export const spec = {
         bid_id: bidId,
         pbver: '$prebid.version$',
         schain: '',
+        uids: '',
       };
       if (!isVideoRequest(bidRequest)) {
         payload._f = 'html';
@@ -59,6 +60,11 @@ export const spec = {
         payload.schain = serializeSChain(bidRequest.schain);
       } else {
         delete payload.schain;
+      }
+
+      payload.uids = serializeUids(bidRequest);
+      if (payload.uids == '') {
+        delete payload.uids;
       }
 
       payload.pfilter = { ...params };
@@ -201,7 +207,7 @@ function objectToQueryString(obj, prefix) {
       let v = obj[p];
       str.push((v !== null && typeof v === 'object')
         ? objectToQueryString(v, k)
-        : (k == 'schain' ? k + '=' + v : encodeURIComponent(k) + '=' + encodeURIComponent(v)));
+        : (k == 'schain' || k == 'uids' ? k + '=' + v : encodeURIComponent(k) + '=' + encodeURIComponent(v)));
     }
   }
   return str.join('&');
@@ -227,11 +233,58 @@ function serializeSChain(schain) {
     ret += encodeURIComponent(node.name ?? '');
     ret += ',';
     ret += encodeURIComponent(node.domain ?? '');
-    ret += ',';
-    ret += encodeURIComponent(node.ext ?? '');
+    if (node.ext) {
+      ret += ',';
+      ret += encodeURIComponent(node.ext ?? '');
+    }
   }
 
   return ret;
+}
+
+function serializeUids(bidRequest) {
+  let uids = [];
+
+  let id5 = deepAccess(bidRequest, 'userId.id5id.uid');
+  if (id5) {
+    uids.push(encodeURIComponent('id5:' + id5));
+    let id5Linktype = deepAccess(bidRequest, 'userId.id5id.ext.linkType');
+    if (id5Linktype) {
+      uids.push(encodeURIComponent('id5_linktype:' + id5Linktype));
+    }
+  }
+  let netId = deepAccess(bidRequest, 'userId.netId');
+  if (netId) {
+    uids.push(encodeURIComponent('netid:' + netId));
+  }
+  let uId2 = deepAccess(bidRequest, 'userId.uid2.id');
+  if (uId2) {
+    uids.push(encodeURIComponent('uid2:' + uId2));
+  }
+  let sharedId = deepAccess(bidRequest, 'userId.sharedid.id');
+  if (sharedId) {
+    uids.push(encodeURIComponent('sharedid:' + sharedId));
+  }
+  let liverampId = deepAccess(bidRequest, 'userId.idl_env');
+  if (liverampId) {
+    uids.push(encodeURIComponent('liverampid:' + liverampId));
+  }
+  let criteoId = deepAccess(bidRequest, 'userId.criteoId');
+  if (criteoId) {
+    uids.push(encodeURIComponent('criteoid:' + criteoId));
+  }
+  // documentation missing...
+  let utiqId = deepAccess(bidRequest, 'userId.utiq.id');
+  if (utiqId) {
+    uids.push(encodeURIComponent('utiq:' + utiqId));
+  } else {
+    utiqId = deepAccess(bidRequest, 'userId.utiq');
+    if (utiqId) {
+      uids.push(encodeURIComponent('utiq:' + utiqId));
+    }
+  }
+
+  return uids.join(',');
 }
 
 /**

--- a/modules/taboolaBidAdapter.js
+++ b/modules/taboolaBidAdapter.js
@@ -3,18 +3,23 @@
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER} from '../src/mediaTypes.js';
 import {config} from '../src/config.js';
-import {deepAccess, getWindowSelf, replaceAuctionPrice} from '../src/utils.js';
+import {deepAccess, deepSetValue, getWindowSelf, replaceAuctionPrice} from '../src/utils.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {ajax} from '../src/ajax.js';
+import {ortbConverter} from '../libraries/ortbConverter/converter.js';
 
 const BIDDER_CODE = 'taboola';
 const GVLID = 42;
 const CURRENCY = 'USD';
 export const END_POINT_URL = 'https://display.bidder.taboola.com/OpenRTB/TaboolaHB/auction';
 export const USER_SYNC_IMG_URL = 'https://trc.taboola.com/sg/prebidJS/1/cm';
+export const USER_SYNC_IFRAME_URL = 'https://cdn.taboola.com/scripts/prebid_iframe_sync.html';
 const USER_ID = 'user-id';
 const STORAGE_KEY = `taboola global:${USER_ID}`;
 const COOKIE_KEY = 'trc_cookie_storage';
+const TGID_COOKIE_KEY = 't_gid';
+const TBLA_ID_COOKIE_KEY = 'tbla_id';
+export const EVENT_ENDPOINT = 'https://beacon.bidder.taboola.com';
 
 /**
  *  extract User Id by that order:
@@ -38,9 +43,17 @@ export const userData = {
     const {cookiesAreEnabled, getCookie} = userData.storageManager;
     if (cookiesAreEnabled()) {
       const cookieData = getCookie(COOKIE_KEY);
-      const userId = userData.getCookieDataByKey(cookieData, USER_ID);
+      let userId = userData.getCookieDataByKey(cookieData, USER_ID);
       if (userId) {
         return userId;
+      }
+      userId = getCookie(TGID_COOKIE_KEY);
+      if (userId) {
+        return userId;
+      }
+      const tblaId = getCookie(TBLA_ID_COOKIE_KEY);
+      if (tblaId) {
+        return tblaId;
       }
     }
   },
@@ -69,6 +82,30 @@ export const internal = {
   }
 }
 
+const converter = ortbConverter({
+  context: {
+    netRevenue: true,
+    mediaType: BANNER,
+    ttl: 300
+  },
+  imp(buildImp, bidRequest, context) {
+    let imp = buildImp(bidRequest, context);
+    fillTaboolaImpData(bidRequest, imp);
+    return imp;
+  },
+  request(buildRequest, imps, bidderRequest, context) {
+    const reqData = buildRequest(imps, bidderRequest, context);
+    fillTaboolaReqData(bidderRequest, context.bidRequests[0], reqData)
+    return reqData;
+  },
+  bidResponse(buildBidResponse, bid, context) {
+    const bidResponse = buildBidResponse(bid, context);
+    bidResponse.nurl = bid.nurl;
+    bidResponse.ad = replaceAuctionPrice(bid.adm, bid.price);
+    return bidResponse
+  }
+});
+
 export const spec = {
   supportedMediaTypes: [BANNER],
   gvlid: GVLID,
@@ -81,85 +118,35 @@ export const spec = {
   },
   buildRequests: (validBidRequests, bidderRequest) => {
     const [bidRequest] = validBidRequests;
-    const {refererInfo, gdprConsent = {}, uspConsent} = bidderRequest;
+    const data = converter.toORTB({bidderRequest: bidderRequest, bidRequests: validBidRequests});
     const {publisherId} = bidRequest.params;
-    const site = getSiteProperties(bidRequest.params, refererInfo, bidderRequest.ortb2);
-    const device = {ua: navigator.userAgent};
-    const imps = getImps(validBidRequests);
-    const user = {
-      buyeruid: userData.getUserId(gdprConsent, uspConsent),
-      ext: {}
-    };
-    const regs = {
-      coppa: 0,
-      ext: {}
-    };
-
-    if (gdprConsent.gdprApplies) {
-      user.ext.consent = bidderRequest.gdprConsent.consentString;
-      regs.ext.gdpr = 1;
-    }
-
-    if (uspConsent) {
-      regs.ext.us_privacy = uspConsent;
-    }
-
-    if (bidderRequest.ortb2?.regs?.gpp) {
-      regs.ext.gpp = bidderRequest.ortb2.regs.gpp;
-      regs.ext.gpp_sid = bidderRequest.ortb2.regs.gpp_sid;
-    }
-
-    if (config.getConfig('coppa')) {
-      regs.coppa = 1;
-    }
-
-    const ortb2 = bidderRequest.ortb2 || {
-      bcat: [],
-      badv: [],
-      wlang: []
-    };
-
-    const request = {
-      id: bidderRequest.bidderRequestId,
-      imp: imps,
-      site,
-      device,
-      source: {fd: 1},
-      tmax: (bidderRequest.timeout == undefined) ? undefined : parseInt(bidderRequest.timeout),
-      bcat: ortb2.bcat || bidRequest.params.bcat || [],
-      badv: ortb2.badv || bidRequest.params.badv || [],
-      wlang: ortb2.wlang || bidRequest.params.wlang || [],
-      user,
-      regs,
-      ext: {
-        pageType: ortb2?.ext?.data?.pageType || ortb2?.ext?.data?.section || bidRequest.params.pageType
-      }
-    };
-
     const url = END_POINT_URL + '?publisher=' + publisherId;
 
     return {
       url,
       method: 'POST',
-      data: JSON.stringify(request),
+      data: data,
       bids: validBidRequests,
       options: {
         withCredentials: false
       },
     };
   },
-  interpretResponse: (serverResponse, {bids}) => {
-    if (!bids) {
+  interpretResponse: (serverResponse, request) => {
+    if (!request || !request.bids || !request.data) {
       return [];
     }
 
-    const {bidResponses, cur: currency} = getBidResponses(serverResponse);
-
-    if (!bidResponses) {
+    if (!serverResponse || !serverResponse.body) {
       return [];
     }
 
-    return bidResponses.map((bidResponse) => getBid(bids, currency, bidResponse)).filter(Boolean);
+    if (!serverResponse.body.seatbid || !serverResponse.body.seatbid.length || !serverResponse.body.seatbid[0].bid || !serverResponse.body.seatbid[0].bid.length) {
+      return [];
+    }
+
+    const bids = converter.fromORTB({response: serverResponse.body, request: request.data}).bids;
+    return bids;
   },
   onBidWon: (bid) => {
     if (bid.nurl) {
@@ -182,6 +169,13 @@ export const spec = {
       queryParams.push('gpp=' + encodeURIComponent(gppConsent));
     }
 
+    if (syncOptions.iframeEnabled) {
+      syncs.push({
+        type: 'iframe',
+        url: USER_SYNC_IFRAME_URL + (queryParams.length ? '?' + queryParams.join('&') : '')
+      });
+    }
+
     if (syncOptions.pixelEnabled) {
       syncs.push({
         type: 'image',
@@ -189,6 +183,13 @@ export const spec = {
       });
     }
     return syncs;
+  },
+  onTimeout: (timeoutData) => {
+    ajax(EVENT_ENDPOINT + '/timeout', null, JSON.stringify(timeoutData), {method: 'POST'});
+  },
+
+  onBidderError: ({ error, bidderRequest }) => {
+    ajax(EVENT_ENDPOINT + '/bidError', null, JSON.stringify(error, bidderRequest), {method: 'POST'});
   },
 };
 
@@ -209,34 +210,76 @@ function getSiteProperties({publisherId}, refererInfo, ortb2) {
   }
 }
 
-function getImps(validBidRequests) {
-  return validBidRequests.map((bid, id) => {
-    const {tagId, position} = bid.params;
-    const imp = {
-      id: id + 1,
-      banner: getBanners(bid, position),
-      tagid: tagId
+function fillTaboolaReqData(bidderRequest, bidRequest, data) {
+  const {refererInfo, gdprConsent = {}, uspConsent} = bidderRequest;
+  const site = getSiteProperties(bidRequest.params, refererInfo, bidderRequest.ortb2);
+  const device = {ua: navigator.userAgent};
+  const user = {
+    buyeruid: userData.getUserId(gdprConsent, uspConsent),
+    ext: {}
+  };
+  const regs = {
+    coppa: 0,
+    ext: {}
+  };
+
+  if (gdprConsent.gdprApplies) {
+    user.ext.consent = bidderRequest.gdprConsent.consentString;
+    regs.ext.gdpr = 1;
+  }
+
+  if (uspConsent) {
+    regs.ext.us_privacy = uspConsent;
+  }
+
+  if (bidderRequest.ortb2?.regs?.gpp) {
+    regs.ext.gpp = bidderRequest.ortb2.regs.gpp;
+    regs.ext.gpp_sid = bidderRequest.ortb2.regs.gpp_sid;
+  }
+
+  if (config.getConfig('coppa')) {
+    regs.coppa = 1;
+  }
+
+  const ortb2 = bidderRequest.ortb2 || {
+    bcat: [],
+    badv: [],
+    wlang: []
+  };
+
+  data.id = bidderRequest.bidderRequestId;
+  data.site = site;
+  data.device = device;
+  data.source = {fd: 1};
+  data.tmax = (bidderRequest.timeout == undefined) ? undefined : parseInt(bidderRequest.timeout);
+  data.bcat = ortb2.bcat || bidRequest.params.bcat || [];
+  data.badv = ortb2.badv || bidRequest.params.badv || [];
+  data.wlang = ortb2.wlang || bidRequest.params.wlang || [];
+  data.user = user;
+  data.regs = regs;
+  deepSetValue(data, 'ext.pageType', ortb2?.ext?.data?.pageType || ortb2?.ext?.data?.section || bidRequest.params.pageType);
+}
+
+function fillTaboolaImpData(bid, imp) {
+  const {tagId, position} = bid.params;
+  imp.banner = getBanners(bid, position);
+  imp.tagid = tagId;
+
+  if (typeof bid.getFloor === 'function') {
+    const floorInfo = bid.getFloor({
+      currency: CURRENCY,
+      size: '*'
+    });
+    if (typeof floorInfo === 'object' && floorInfo.currency === CURRENCY && !isNaN(parseFloat(floorInfo.floor))) {
+      imp.bidfloor = parseFloat(floorInfo.floor);
+      imp.bidfloorcur = CURRENCY;
     }
-    if (typeof bid.getFloor === 'function') {
-      const floorInfo = bid.getFloor({
-        currency: CURRENCY,
-        mediaType: BANNER,
-        size: '*'
-      });
-      if (typeof floorInfo === 'object' && floorInfo.currency === CURRENCY && !isNaN(parseFloat(floorInfo.floor))) {
-        imp.bidfloor = parseFloat(floorInfo.floor);
-        imp.bidfloorcur = CURRENCY;
-      }
-    } else {
-      const {bidfloor = null, bidfloorcur = CURRENCY} = bid.params;
-      imp.bidfloor = bidfloor;
-      imp.bidfloorcur = bidfloorcur;
-    }
-    imp['ext'] = {
-      gpid: deepAccess(bid, 'ortb2Imp.ext.gpid')
-    }
-    return imp;
-  });
+  } else {
+    const {bidfloor = null, bidfloorcur = CURRENCY} = bid.params;
+    imp.bidfloor = bidfloor;
+    imp.bidfloorcur = bidfloorcur;
+  }
+  deepSetValue(imp, 'ext.gpid', deepAccess(bid, 'ortb2Imp.ext.gpid'));
 }
 
 function getBanners(bid, pos) {
@@ -255,53 +298,6 @@ function getSizes(sizes) {
       }
     })
   }
-}
-
-function getBidResponses({body}) {
-  if (!body) {
-    return [];
-  }
-
-  const {seatbid, cur} = body;
-
-  if (!seatbid.length || !seatbid[0].bid || !seatbid[0].bid.length) {
-    return [];
-  }
-
-  return {
-    bidResponses: seatbid[0].bid,
-    cur
-  };
-}
-
-function getBid(bids, currency, bidResponse) {
-  if (!bidResponse) {
-    return;
-  }
-  let {
-    price: cpm, nurl, crid: creativeId, adm: ad, w: width, h: height, exp: ttl, adomain: advertiserDomains, meta = {}
-  } = bidResponse;
-  let requestId = bids[bidResponse.impid - 1].bidId;
-  if (advertiserDomains && advertiserDomains.length > 0) {
-    meta.advertiserDomains = advertiserDomains
-  }
-
-  ad = replaceAuctionPrice(ad, cpm);
-
-  return {
-    requestId,
-    ttl,
-    mediaType: BANNER,
-    cpm,
-    creativeId,
-    currency,
-    ad,
-    width,
-    height,
-    meta,
-    nurl,
-    netRevenue: true
-  };
 }
 
 registerBidder(spec);

--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -53,7 +53,7 @@ export const spec = {
    *
    * @param {BidRequest} bid The bid params to validate.
    * @return boolean True if this is a valid bid, and false otherwise.
-  */
+   */
   isBidRequestValid: function(bid) {
     // bid.params.host
     if ((new RegExp(`^(vz.*|zz.*)\\.*$`, 'i')).test(bid.params.host)) { // New endpoint
@@ -234,12 +234,12 @@ function interpretBid(serverBid, request) {
 }
 
 /**
-* Build and makes the request
-*
-* @param {*} validBidRequests
-* @param {*} bidderRequest
-* @return response ad
-*/
+ * Build and makes the request
+ *
+ * @param {*} validBidRequests
+ * @param {*} bidderRequest
+ * @return response ad
+ */
 function buildOneRequest(validBidRequests, bidderRequest) {
   let hostInfo = _getHostInfo(validBidRequests);
   const ENDPOINT = hostInfo.endpoint;

--- a/modules/teadsBidAdapter.js
+++ b/modules/teadsBidAdapter.js
@@ -45,6 +45,7 @@ export const spec = {
    */
   buildRequests: function(validBidRequests, bidderRequest) {
     const bids = validBidRequests.map(buildRequestObject);
+    const topWindow = window.top;
 
     const payload = {
       referrer: getReferrerInfo(bidderRequest),
@@ -55,6 +56,12 @@ export const spec = {
       timeToFirstByte: getTimeToFirstByte(window),
       data: bids,
       deviceWidth: screen.width,
+      screenOrientation: screen.orientation?.type,
+      historyLength: topWindow.history?.length,
+      viewportHeight: topWindow.visualViewport?.height,
+      viewportWidth: topWindow.visualViewport?.width,
+      hardwareConcurrency: topWindow.navigator?.hardwareConcurrency,
+      deviceMemory: topWindow.navigator?.deviceMemory,
       hb_version: '$prebid.version$',
       ...getSharedViewerIdParameters(validBidRequests),
       ...getFirstPartyTeadsIdParameter(validBidRequests)

--- a/modules/teadsIdSystem.js
+++ b/modules/teadsIdSystem.js
@@ -34,9 +34,9 @@ export const storage = getStorageManager({moduleType: MODULE_TYPE_UID, moduleNam
 /** @type {Submodule} */
 export const teadsIdSubmodule = {
   /**
-     * used to link submodule with config
-     * @type {string}
-     */
+   * used to link submodule with config
+   * @type {string}
+   */
   name: MODULE_NAME,
   /**
    * Vendor id of Teads
@@ -44,21 +44,21 @@ export const teadsIdSubmodule = {
    */
   gvlid: GVL_ID,
   /**
-     * decode the stored id value for passing to bid requests
-     * @function
-     * @param {string} value
-     * @returns {{teadsId:string}}
-     */
+   * decode the stored id value for passing to bid requests
+   * @function
+   * @param {string} value
+   * @returns {{teadsId:string}}
+   */
   decode(value) {
     return {teadsId: value}
   },
   /**
-     * performs action to obtain id and return a value in the callback's response argument
-     * @function
-     * @param {SubmoduleConfig} [submoduleConfig]
-     * @param {ConsentData} [consentData]
-     * @returns {IdResponse|undefined}
-     */
+   * performs action to obtain id and return a value in the callback's response argument
+   * @function
+   * @param {SubmoduleConfig} [submoduleConfig]
+   * @param {ConsentData} [consentData]
+   * @returns {IdResponse|undefined}
+   */
   getId(submoduleConfig, consentData) {
     const resp = function (callback) {
       const url = buildAnalyticsTagUrl(submoduleConfig, consentData);

--- a/modules/temedyaBidAdapter.js
+++ b/modules/temedyaBidAdapter.js
@@ -12,20 +12,20 @@ export const spec = {
   code: BIDDER_CODE,
   supportedMediaTypes: [BANNER, NATIVE],
   /**
-  * Determines whether or not the given bid request is valid.
-  *
-  * @param {BidRequest} bid The bid params to validate.
-  * @return boolean True if this is a valid bid, and false otherwise.
-  */
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
   isBidRequestValid: function (bid) {
     return !!(bid.params.widgetId);
   },
   /**
-  * Make a server request from the list of BidRequests.
-  *
-  * @param {validBidRequests[]} - an array of bids
-  * @return ServerRequest Info describing the request to the server.
-  */
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @return ServerRequest Info describing the request to the server.
+   */
   buildRequests: function (validBidRequests, bidderRequest) {
     // convert Native ORTB definition to old-style prebid native definition
     validBidRequests = convertOrtbRequestToProprietaryNative(validBidRequests);
@@ -54,11 +54,11 @@ export const spec = {
     });
   },
   /**
-  * Unpack the response from the server into a list of bids.
-  *
-  * @param {ServerResponse} serverResponse A successful response from the server.
-  * @return {Bid[]} An array of bids which were nested inside the server.
-  */
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
   interpretResponse: function (serverResponse, bidRequest) {
     try {
       const bidResponse = serverResponse.body;

--- a/modules/theAdxBidAdapter.js
+++ b/modules/theAdxBidAdapter.js
@@ -159,7 +159,6 @@ export const spec = {
               withCredentials: true,
             },
             bidder: 'theadx',
-            // TODO: is 'page' the right value here?
             referrer: encodeURIComponent(bidderRequest.refererInfo.page || ''),
             data: generatePayload(bidRequest, bidderRequest),
             mediaTypes: bidRequest['mediaTypes'],
@@ -261,6 +260,7 @@ export const spec = {
           ad: creative,
           ttl: ttl || 3000,
           creativeId: bid.crid,
+          dealId: bid.dealid || null,
           netRevenue: true,
           currency: responseBody.cur,
           mediaType: mediaType,
@@ -466,11 +466,19 @@ let generateImpBody = (bidRequest, bidderRequest) => {
   } else if (mediaTypes && mediaTypes.native) {
     native = generateNativeComponent(bidRequest, bidderRequest);
   }
-
   const result = {
     id: bidRequest.index,
     tagid: bidRequest.params.tagId + '',
   };
+
+  // deals support
+  if (bidRequest.params.deals && Array.isArray(bidRequest.params.deals) && bidRequest.params.deals.length > 0) {
+    result.pmp = {
+      deals: bidRequest.params.deals,
+      private_auction: 0,
+    };
+  }
+
   if (banner) {
     result['banner'] = banner;
   }

--- a/modules/theAdxBidAdapter.md
+++ b/modules/theAdxBidAdapter.md
@@ -26,9 +26,9 @@ Module that connects to TheAdx demand sources
                {
                    bidder: "theadx",
                    params: {
-                        pid: 1000, // publisher id
-                        wid: 2000, //website id
-                        tagId: 5000, //zone id
+                        pid: 1, // publisher id
+                        wid: 7, //website id
+                        tagId: 19, //zone id
                     }
                }
            ]
@@ -43,9 +43,10 @@ Module that connects to TheAdx demand sources
                {
                    bidder: "theadx",
                    params: {
-                        pid: 1000, // publisher id
-                        wid: 2000, //website id
-                        tagId: 5000, //zone id
+                        pid: 1, // publisher id
+                        wid: 7, //website id
+                        tagId: 18, //zone id
+                        deals:[{"id":"theadx:137"}] //optional
                     }
                }
            ]
@@ -80,9 +81,9 @@ Module that connects to TheAdx demand sources
                {
                    bidder: "theadx",
                    params: {
-                        pid: 1000, // publisher id
-                        wid: 2000, //website id
-                        tagId: 5000, //zone id
+                        pid: 1, // publisher id
+                        wid: 7, //website id
+                        tagId: 20, //zone id
                     }
                }
            ]

--- a/modules/timeoutRtdProvider.js
+++ b/modules/timeoutRtdProvider.js
@@ -67,7 +67,7 @@ function getConnectionSpeed() {
  * Calculate the time to be added to the timeout
  * @param {Array} adUnits
  * @param {Object} rules
- * @return {int}
+ * @return {number}
  */
 function calculateTimeoutModifier(adUnits, rules) {
   logInfo('Timeout rules', rules);

--- a/modules/topicsFpdModule.js
+++ b/modules/topicsFpdModule.js
@@ -178,8 +178,8 @@ export function receiveMessage(evt) {
 
 /**
 Function to store Topics data received from iframe in storage(name: "prebid:topics")
-* @param {Topics} topics
-*/
+ * @param {Topics} topics
+ */
 export function storeInLocalStorage(bidder, topics) {
   const storedSegments = new Map(safeJSONParse(coreStorage.getDataFromLocalStorage(topicStorageName)));
   const topicsObj = {
@@ -202,8 +202,8 @@ function isCachedDataExpired(storedTime, cacheTime) {
 }
 
 /**
-* Function to get random bidders based on count passed with array of bidders
-**/
+ * Function to get random bidders based on count passed with array of bidders
+ */
 function getRandomBidders(arr, count) {
   return ([...arr].sort(() => 0.5 - Math.random())).slice(0, count)
 }

--- a/modules/tpmnBidAdapter.js
+++ b/modules/tpmnBidAdapter.js
@@ -184,7 +184,7 @@ function createRenderer(bid) {
 
 function outstreamRender(bid, doc) {
   bid.renderer.push(() => {
-    const win = utils.getWindowFromDocument(doc) || window;
+    const win = (doc) ? doc.defaultView : window;
     win.ANOutstreamVideo.renderAd({
       sizes: [bid.playerWidth, bid.playerHeight],
       targetId: bid.adUnitCode,

--- a/modules/ucfunnelBidAdapter.js
+++ b/modules/ucfunnelBidAdapter.js
@@ -64,11 +64,10 @@ export const spec = {
    * Format ucfunnel responses as Prebid bid responses
    * @param {ucfunnelResponseObj} ucfunnelResponse A successful response from ucfunnel.
    * @return {Bid[]} An array of formatted bids.
-  */
+   */
   interpretResponse: function (ucfunnelResponseObj, request) {
     const bidRequest = request.bidRequest;
     const ad = ucfunnelResponseObj ? ucfunnelResponseObj.body : {};
-    const videoPlayerSize = parseSizes(bidRequest);
 
     let bid = {
       requestId: bidRequest.bidId,
@@ -117,10 +116,10 @@ export const spec = {
           vastXml: ad.vastXml
         });
 
-        if (videoPlayerSize && videoPlayerSize.length === 2) {
+        if (bidRequest.sizes && bidRequest.sizes.length > 0) {
           Object.assign(bid, {
-            width: videoPlayerSize[0],
-            height: videoPlayerSize[1]
+            width: bidRequest.sizes[0][0],
+            height: bidRequest.sizes[0][1]
           });
         }
         break;
@@ -128,8 +127,8 @@ export const spec = {
       default:
         var size = parseSizes(bidRequest);
         Object.assign(bid, {
-          width: ad.width || size[0],
-          height: ad.height || size[1],
+          width: ad.width || size[0][0],
+          height: ad.height || size[0][1],
           ad: ad.adm || ''
         });
     }
@@ -156,12 +155,6 @@ export const spec = {
 };
 registerBidder(spec);
 
-function transformSizes(requestSizes) {
-  if (typeof requestSizes === 'object' && requestSizes.length) {
-    return requestSizes[0];
-  }
-}
-
 function getCookieSyncParameter(gdprApplies, apiVersion, consentString, uspConsent) {
   let param = '?';
   if (gdprApplies == '1') {
@@ -187,11 +180,10 @@ function parseSizes(bid) {
         params.video.playerWidth,
         params.video.playerHeight
       ];
-      return size;
+      return [size];
     }
   }
-
-  return transformSizes(bid.sizes);
+  return bid.sizes;
 }
 
 function getSupplyChain(schain) {
@@ -244,6 +236,20 @@ function getFloor(bid, size, mediaTypes) {
   return undefined;
 }
 
+function addBidData(bidData, key, value) {
+  if (value) {
+    bidData[key] = value;
+  }
+}
+
+function getFormat(size) {
+  let formatList = []
+  for (var i = 0; i < size.length; i++) {
+    formatList.push(size[i].join(','));
+  }
+  return (formatList.length > 0) ? formatList.join(';') : '';
+}
+
 function getRequestData(bid, bidderRequest) {
   const size = parseSizes(bid);
   const language = navigator.language;
@@ -264,14 +270,8 @@ function getRequestData(bid, bidderRequest) {
     schain: supplyChain
   };
 
-  if (bidFloor) {
-    bidData.fp = bidFloor;
-  }
-
-  if (gpid) {
-    bidData.gpid = gpid;
-  }
-
+  addBidData(bidData, 'fp', bidFloor);
+  addBidData(bidData, 'gpid', gpid);
   addUserId(bidData, bid.userId);
 
   bidData.u = bidderRequest.refererInfo.page || bidderRequest.refererInfo.topmostLocation;
@@ -293,10 +293,11 @@ function getRequestData(bid, bidderRequest) {
     }
   }
 
-  if (size != undefined && size.length == 2) {
-    bidData.w = size[0];
-    bidData.h = size[1];
+  if (size != undefined && size.length > 0 && size[0].length == 2) {
+    bidData.w = size[0][0];
+    bidData.h = size[0][1];
   }
+  addBidData(bidData, 'format', getFormat(size));
 
   if (bidderRequest && bidderRequest.uspConsent) {
     Object.assign(bidData, {

--- a/modules/uid2IdSystem.js
+++ b/modules/uid2IdSystem.js
@@ -13,7 +13,7 @@ import {MODULE_TYPE_UID} from '../src/activities/modules.js';
 
 // RE below lint exception: UID2 and EUID are separate modules, but the protocol is the same and shared code makes sense here.
 // eslint-disable-next-line prebid/validate-imports
-import { Uid2GetId, Uid2CodeVersion } from './uid2IdSystem_shared.js';
+import { Uid2GetId, Uid2CodeVersion, extractIdentityFromParams } from './uid2IdSystem_shared.js';
 import {UID2_EIDS} from '../libraries/uid2Eids/uid2Eids.js';
 
 const MODULE_NAME = 'uid2';
@@ -32,18 +32,6 @@ function createLogger(logger, prefix) {
   return function (...strings) {
     logger(prefix + ' ', ...strings);
   }
-}
-
-function extractIdentityFromParams(params) {
-  const keysToCheck = ['emailHash', 'phoneHash', 'email', 'phone'];
-
-  for (let key of keysToCheck) {
-    if (params.hasOwnProperty(key)) {
-      return { [key]: params[key] };
-    }
-  }
-
-  return {};
 }
 
 const _logInfo = createLogger(logInfo, LOG_PRE_FIX);

--- a/modules/uid2IdSystem_shared.js
+++ b/modules/uid2IdSystem_shared.js
@@ -755,3 +755,15 @@ export function Uid2GetId(config, prebidStorageManager, _logInfo, _logWarn) {
   storageManager.storeValue(tokens);
   return { id: tokens };
 }
+
+export function extractIdentityFromParams(params) {
+  const keysToCheck = ['emailHash', 'phoneHash', 'email', 'phone'];
+
+  for (let key of keysToCheck) {
+    if (params.hasOwnProperty(key)) {
+      return { [key]: params[key] };
+    }
+  }
+
+  return {};
+}

--- a/modules/unicornBidAdapter.js
+++ b/modules/unicornBidAdapter.js
@@ -87,8 +87,31 @@ function buildOpenRtbBidRequestPayload(validBidRequests, bidderRequest) {
       accountId: deepAccess(validBidRequests[0], 'params.accountId')
     }
   };
+  const eids = initializeEids(validBidRequests[0]);
+  if (eids.length > 0) {
+    request.user.eids = eids;
+  }
+
   logInfo('[UNICORN] OpenRTB Formatted Request:', request);
   return JSON.stringify(request);
+}
+
+const initializeEids = (bidRequest) => {
+  let eids = [];
+
+  let id5 = deepAccess(bidRequest, 'userId.id5id.uid');
+  if (id5) {
+    eids.push({
+      source: 'id5-sync.com',
+      uids: [
+        {
+          id: id5
+        }
+      ]
+    });
+  }
+
+  return eids;
 }
 
 const interpretResponse = (serverResponse, request) => {

--- a/modules/unrulyBidAdapter.js
+++ b/modules/unrulyBidAdapter.js
@@ -80,7 +80,14 @@ const getRequests = (conf, validBidRequests, bidderRequest) => {
 
   Object.keys(requestBySiteId).forEach((key) => {
     let data = {
-      bidderRequest: Object.assign({}, {bids: requestBySiteId[key], invalidBidsCount, ...bidderRequestData})
+      bidderRequest: Object.assign({},
+        {
+          bids: requestBySiteId[key],
+          invalidBidsCount,
+          prebidVersion: '$prebid.version$',
+          ...bidderRequestData
+        }
+      )
     };
 
     request.push(Object.assign({}, {data, ...conf}));

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -1,4 +1,4 @@
-import {deepAccess, isFn, isPlainObject, isStr} from '../../src/utils.js';
+import {deepAccess, deepClone, isFn, isPlainObject, isStr} from '../../src/utils.js';
 
 export const EID_CONFIG = new Map();
 
@@ -45,7 +45,7 @@ export function createEidsArray(bidRequestUserId) {
 
   Object.entries(bidRequestUserId).forEach(([name, values]) => {
     values = Array.isArray(values) ? values : [values];
-    const eids = name === 'pubProvidedId' ? values : values.map(value => createEidObject(value, name));
+    const eids = name === 'pubProvidedId' ? deepClone(values) : values.map(value => createEidObject(value, name));
     eids.filter(eid => eid != null).forEach(collect);
   })
   return Object.values(allEids);

--- a/modules/userId/eids.md
+++ b/modules/userId/eids.md
@@ -77,6 +77,7 @@ userIdAsEids = [
         uids: [{
             id: 'the-ids-object-stringified',
             atype: 1
+        }]
     },
 
     {
@@ -117,6 +118,50 @@ userIdAsEids = [
         }]
     },
     
+    {
+        source: 'liveintent.indexexchange.com',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 3,
+            ext: {
+                provider: 'liveintent.com'
+            }
+        }]
+    },
+
+    {
+        source: 'liveintent.sovrn.com'',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 3,
+            ext: {
+                provider: 'liveintent.com'
+            }
+        }]
+    },
+
+    {
+        source: 'openx.net'',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 3,
+            ext: {
+                provider: 'liveintent.com'
+            }
+        }]
+    },
+
+    {
+        source: 'pubmatic.com'',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 3,
+            ext: {
+                provider: 'liveintent.com'
+            }
+        }]
+    },   
+
     {
         source: 'media.net',
         uids: [{
@@ -278,6 +323,13 @@ userIdAsEids = [
         uids: [{
             id: 'some-random-id-value',
             atype: 3
+        }]
+    },
+    {
+        source: 'mygaru.com',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 1
         }]
     }
 ]

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -668,8 +668,8 @@ function encryptSignals(signals, version = 1) {
 }
 
 /**
-* This function will be exposed in the global-name-space so that publisher can register the signals-ESP.
-*/
+ * This function will be exposed in the global-name-space so that publisher can register the signals-ESP.
+ */
 function registerSignalSources() {
   if (!isGptPubadsDefined()) {
     return;
@@ -886,14 +886,12 @@ function updateInitializedSubmodules(dest, submodule) {
 
 /**
  * list of submodule configurations with valid 'storage' or 'value' obj definitions
- * * storage config: contains values for storing/retrieving User ID data in browser storage
- * * value config: object properties that are copied to bids (without saving to storage)
+ * storage config: contains values for storing/retrieving User ID data in browser storage
+ * value config: object properties that are copied to bids (without saving to storage)
  * @param {SubmoduleConfig[]} configRegistry
- * @param {Submodule[]} submoduleRegistry
- * @param {string[]} activeStorageTypes
  * @returns {SubmoduleConfig[]}
  */
-function getValidSubmoduleConfigs(configRegistry, submoduleRegistry) {
+function getValidSubmoduleConfigs(configRegistry) {
   if (!Array.isArray(configRegistry)) {
     return [];
   }
@@ -958,7 +956,7 @@ function updateEIDConfig(submodules) {
  */
 function updateSubmodules() {
   updateEIDConfig(submoduleRegistry);
-  const configs = getValidSubmoduleConfigs(configRegistry, submoduleRegistry);
+  const configs = getValidSubmoduleConfigs(configRegistry);
   if (!configs.length) {
     return;
   }

--- a/modules/userId/userId.md
+++ b/modules/userId/userId.md
@@ -158,6 +158,9 @@ pbjs.setConfig({
         },
         {
             name: "gravitompId"
+        },
+        {
+            name: "mygaruId"
         }
         ],
         syncDelay: 5000,

--- a/modules/viantOrtbBidAdapter.js
+++ b/modules/viantOrtbBidAdapter.js
@@ -5,7 +5,7 @@ import {ortbConverter} from '../libraries/ortbConverter/converter.js'
 import {deepAccess, getBidIdParameter, logError} from '../src/utils.js';
 
 const BIDDER_CODE = 'viant';
-const ENDPOINT = 'https://bidders-us-east-1.adelphic.net/d/rtb/v25/prebid/bidder_test'
+const ENDPOINT = 'https://bidders-us-east-1.adelphic.net/d/rtb/v25/prebid/bidder'
 
 const DEFAULT_BID_TTL = 300;
 const DEFAULT_CURRENCY = 'USD';

--- a/modules/voxBidAdapter.js
+++ b/modules/voxBidAdapter.js
@@ -12,6 +12,7 @@ const BIDDER_CODE = 'vox';
 const SSP_ENDPOINT = 'https://ssp.hybrid.ai/auction/prebid';
 const VIDEO_RENDERER_URL = 'https://acdn.adnxs.com/video/outstream/ANOutstreamVideo.js';
 const TTL = 60;
+const GVLID = 206;
 
 function buildBidRequests(validBidRequests) {
   return _map(validBidRequests, function(bid) {
@@ -183,6 +184,7 @@ function wrapBanner(bid, bidData) {
 
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: GVLID,
   supportedMediaTypes: [BANNER, VIDEO],
 
   /**

--- a/modules/weboramaRtdProvider.js
+++ b/modules/weboramaRtdProvider.js
@@ -7,25 +7,29 @@
  * @requires module:modules/realTimeData
  */
 
-/** profile metadata
+/**
+ * profile metadata
  * @typedef dataCallbackMetadata
  * @property {boolean} user if true it is user-centric data
  * @property {string} source describe the source of data, if 'contextual' or 'wam'
  * @property {boolean} isDefault if true it the default profile defined in the configuration
  */
 
-/** profile from contextual, wam or sfbx
+/**
+ * profile from contextual, wam or sfbx
  * @typedef {Object.<string,string[]>} Profile
  */
 
-/** onData callback type
+/**
+ * onData callback type
  * @callback dataCallback
  * @param {Profile} data profile data
  * @param {dataCallbackMetadata} meta metadata
  * @returns {void}
  */
 
-/** setPrebidTargeting callback type
+/**
+ * setPrebidTargeting callback type
  * @callback setPrebidTargetingCallback
  * @param {string} adUnitCode
  * @param {Profile} data
@@ -33,7 +37,8 @@
  * @returns {boolean}
  */
 
-/** sendToBidders callback type
+/**
+ * sendToBidders callback type
  * @callback sendToBiddersCallback
  * @param {Object} bid
  * @param {string} adUnitCode
@@ -90,7 +95,8 @@
  * @property {?boolean} enabled if false, will ignore this configuration
  */
 
-/** common configuration between contextual, wam and sfbx
+/**
+ * common configuration between contextual, wam and sfbx
  * @typedef {WeboCtxConf|WeboUserDataConf|SfbxLiteDataConf} CommonConf
  */
 
@@ -188,7 +194,8 @@ class WeboramaRtdProvider {
   constructor(components) {
     this.#components = components;
   }
-  /** Initialize module
+  /**
+   * Initialize module
    * @method
    * @param {Object} moduleConfig
    * @param {?ModuleParams} moduleConfig.params
@@ -219,7 +226,8 @@ class WeboramaRtdProvider {
     return Object.values(this.#components).some((c) => c.initialized);
   }
 
-  /** function that will allow RTD sub-modules to modify the AdUnit object for each auction
+  /**
+   * function that will allow RTD sub-modules to modify the AdUnit object for each auction
    * @method
    * @param {Object} reqBidsConfigObj
    * @param {doneCallback} onDone
@@ -253,7 +261,8 @@ class WeboramaRtdProvider {
     });
   }
 
-  /** function that provides ad server targeting data to RTD-core
+  /**
+   * function that provides ad server targeting data to RTD-core
    * @method
    * @param {string[]} adUnitsCodes
    * @param {Object} moduleConfig
@@ -294,7 +303,8 @@ class WeboramaRtdProvider {
     }
   }
 
-  /** Initialize subsection module
+  /**
+   * Initialize subsection module
    * @method
    * @private
    * @param {ModuleParams} moduleParams
@@ -330,7 +340,8 @@ class WeboramaRtdProvider {
     return true;
   }
 
-  /** normalize submodule configuration
+  /**
+   * normalize submodule configuration
    * @method
    * @private
    * @param {ModuleParams} moduleParams
@@ -363,7 +374,8 @@ class WeboramaRtdProvider {
     }
   }
 
-  /** coerce setPrebidTargeting to a callback
+  /**
+   * coerce setPrebidTargeting to a callback
    * @method
    * @private
    * @param {CommonConf} submoduleParams
@@ -379,7 +391,8 @@ class WeboramaRtdProvider {
     }
   }
 
-  /** coerce sendToBidders to a callback
+  /**
+   * coerce sendToBidders to a callback
    * @method
    * @private
    * @param {CommonConf} submoduleParams
@@ -426,7 +439,8 @@ class WeboramaRtdProvider {
    * @typedef {Object} AdUnit
    * @property {Object[]} bids
    */
-  /** function that handles bid request data
+  /**
+   * function that handles bid request data
    * @method
    * @private
    * @param {Object} reqBidsConfigObj
@@ -476,18 +490,21 @@ class WeboramaRtdProvider {
     });
   }
 
-  /** onSuccess callback type
+  /**
+   * onSuccess callback type
    * @callback successCallback
    * @param {?Object} data
    * @returns {void}
    */
 
-  /** onDone callback type
+  /**
+   * onDone callback type
    * @callback doneCallback
    * @returns {void}
    */
 
-  /** Fetch Bigsea Contextual Profile
+  /**
+   * Fetch Bigsea Contextual Profile
    * @method
    * @private
    * @param {WeboCtxConf} weboCtxConf
@@ -566,7 +583,8 @@ class WeboramaRtdProvider {
     ajax(urlProfileAPI, callback, null, options);
   }
 
-  /** set bigsea contextual profile on module state
+  /**
+   * set bigsea contextual profile on module state
    * @method
    * @private
    * @param {?Object} data
@@ -579,7 +597,8 @@ class WeboramaRtdProvider {
     }
   }
 
-  /** function that provides data handlers based on the configuration
+  /**
+   * function that provides data handlers based on the configuration
    * @method
    * @private
    * @param {ModuleParams} moduleParams
@@ -667,7 +686,8 @@ class WeboramaRtdProvider {
       onData: dataConf.onData,
     };
   }
-  /** handle individual bid
+  /**
+   * handle individual bid
    * @method
    * @private
    * @param {Object} reqBidsConfigObj
@@ -694,7 +714,8 @@ class WeboramaRtdProvider {
     }
   }
 
-  /** function that handles bid request data
+  /**
+   * function that handles bid request data
    * @method
    * @private
    * @param {ProfileHandler} ph profile handler
@@ -705,7 +726,8 @@ class WeboramaRtdProvider {
     return [deepClone(ph.data), deepClone(ph.metadata)];
   }
 
-  /** handle appnexus/xandr bid
+  /**
+   * handle appnexus/xandr bid
    * @method
    * @private
    * @param {Object} reqBidsConfigObj
@@ -723,7 +745,8 @@ class WeboramaRtdProvider {
     // this.#setBidderOrtb2(reqBidsConfigObj.ortb2Fragments?.bidder, bid.bidder, base, profile);
   }
 
-  /** handle generic bid via ortb2 arbitrary data
+  /**
+   * handle generic bid via ortb2 arbitrary data
    * @method
    * @private
    * @param {Object} reqBidsConfigObj
@@ -844,7 +867,8 @@ export function isValidProfile(profile) {
  * @returns {buildProfileHandlerCallback}
  */
 function getContextualProfile(component /* equivalent to this */) {
-  /** return contextual profile
+  /**
+   * return contextual profile
    * @param {WeboCtxConf} weboCtxConf
    * @returns {[Profile,boolean]} contextual profile + isDefault boolean flag
    */
@@ -865,7 +889,8 @@ function getContextualProfile(component /* equivalent to this */) {
  * @returns {buildProfileHandlerCallback}
  */
 function getWeboUserDataProfile(component /* equivalent to this */) {
-  /** return weboUserData profile
+  /**
+   * return weboUserData profile
    * @param {WeboUserDataConf} weboUserDataConf
    * @returns {[Profile,boolean]} weboUserData profile  + isDefault boolean flag
    */
@@ -885,7 +910,8 @@ function getWeboUserDataProfile(component /* equivalent to this */) {
  * @returns {buildProfileHandlerCallback}
  */
 function getSfbxLiteDataProfile(component /* equivalent to this */) {
-  /** return weboUserData profile
+  /**
+   * return weboUserData profile
    * @param {SfbxLiteDataConf} sfbxLiteDataConf
    * @returns {[Profile,boolean]} sfbxLiteData profile + isDefault boolean flag
    */
@@ -909,7 +935,8 @@ function getSfbxLiteDataProfile(component /* equivalent to this */) {
  * @returns {void}
  */
 
-/** return generic webo data profile
+/**
+ * return generic webo data profile
  * @param {WeboUserDataConf|SfbxLiteDataConf} weboDataConf
  * @param {cacheGetCallback} cacheGet
  * @param {cacheSetCallback} cacheSet

--- a/modules/xeBidAdapter.js
+++ b/modules/xeBidAdapter.js
@@ -142,12 +142,12 @@ function interpretResponse(serverResponse, { bidderRequest }) {
 }
 
 /**
-* Register the user sync pixels which should be dropped after the auction.
-*
-* @param {SyncOptions} syncOptions Which user syncs are allowed?
-* @param {ServerResponse[]} serverResponses List of server's responses.
-* @return {UserSync[]} The user syncs which should be dropped.
-*/
+ * Register the user sync pixels which should be dropped after the auction.
+ *
+ * @param {SyncOptions} syncOptions Which user syncs are allowed?
+ * @param {ServerResponse[]} serverResponses List of server's responses.
+ * @return {UserSync[]} The user syncs which should be dropped.
+ */
 function getUserSyncs(syncOptions, serverResponses, gdprConsent = {}, uspConsent = '') {
   const syncs = [];
   const pixels = deepAccess(serverResponses, '0.body.data.0.ext.pixels');
@@ -172,11 +172,11 @@ function getUserSyncs(syncOptions, serverResponses, gdprConsent = {}, uspConsent
 }
 
 /**
-* Get valid floor value from getFloor fuction.
-*
-* @param {Object} bid Current bid request.
-* @return {null|Number} Returns floor value when bid.getFloor is function and returns valid floor object with USD currency, otherwise returns null.
-*/
+ * Get valid floor value from getFloor fuction.
+ *
+ * @param {Object} bid Current bid request.
+ * @return {null|Number} Returns floor value when bid.getFloor is function and returns valid floor object with USD currency, otherwise returns null.
+ */
 export function getBidFloor(bid) {
   if (!isFn(bid.getFloor)) {
     return null;

--- a/modules/yahoosspBidAdapter.js
+++ b/modules/yahoosspBidAdapter.js
@@ -111,7 +111,7 @@ function extractUserSyncUrls(syncOptions, pixels) {
  * @param {object} consentData
  * @param {object} consentData.gpp
  * @param {string} consentData.gpp.gppConsent
- * @param {array} consentData.gpp.applicableSections
+ * @param {Array} consentData.gpp.applicableSections
  * @param {object} consentData.gdpr
  * @param {object} consentData.gdpr.consentString
  * @param {object} consentData.gdpr.gdprApplies

--- a/modules/yahoosspBidAdapter.md
+++ b/modules/yahoosspBidAdapter.md
@@ -1,7 +1,7 @@
 # Overview
 **Module Name:** Yahoo Advertising Bid Adapter
 **Module Type:** Bidder Adapter
-**Maintainer:** hb-fe-tech@yahooinc.com
+**Maintainer:** prebid-tech-team@yahooinc.com
 
 # Description
 The Yahoo Advertising Bid Adapter is an OpenRTB interface that consolidates all previous "Oath.inc" adapters such as: "aol", "oneMobile", "oneDisplay" & "oneVideo" supply-side platforms.

--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -29,7 +29,7 @@ const VIDEO_PATH = '/exchange/prebidvideo';
 const STAGE_DOMAIN = 'https://ads-stg.yieldmo.com';
 const PROD_DOMAIN = 'https://ads.yieldmo.com';
 const OUTSTREAM_VIDEO_PLAYER_URL = 'https://prebid-outstream.yieldmo.com/bundle.js';
-const OPENRTB_VIDEO_BIDPARAMS = ['mimes', 'startdelay', 'placement', 'startdelay', 'skipafter', 'protocols', 'api',
+const OPENRTB_VIDEO_BIDPARAMS = ['mimes', 'startdelay', 'placement', 'plcmt', 'skipafter', 'protocols', 'api',
   'playbackmethod', 'maxduration', 'minduration', 'pos', 'skip', 'skippable'];
 const OPENRTB_VIDEO_SITEPARAMS = ['name', 'domain', 'cat', 'keywords'];
 const LOCAL_WINDOW = getWindowTop();
@@ -449,7 +449,7 @@ function openRtbImpression(bidRequest) {
     imp.video.skip = 1;
     delete imp.video.skippable;
   }
-  if (imp.video.placement !== 1) {
+  if (imp.video.plcmt !== 1 || imp.video.placement !== 1) {
     imp.video.startdelay = DEFAULT_START_DELAY;
     imp.video.playbackmethod = [ DEFAULT_PLAYBACK_METHOD ];
   }

--- a/modules/zetaBidAdapter.js
+++ b/modules/zetaBidAdapter.js
@@ -15,11 +15,11 @@ export const spec = {
   supportedMediaTypes: [BANNER],
 
   /**
-     * Determines whether or not the given bid request is valid.
-     *
-     * @param {BidRequest} bid The bid params to validate.
-     * @return boolean True if this is a valid bid, and false otherwise.
-     */
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
   isBidRequestValid: function(bid) {
     // check for all required bid fields
     if (!(bid &&
@@ -50,12 +50,12 @@ export const spec = {
   },
 
   /**
-     * Make a server request from the list of BidRequests.
-     *
-     * @param {Bids[]} validBidRequests - an array of bidRequest objects
-     * @param {BidderRequest} bidderRequest - master bidRequest object
-     * @return ServerRequest Info describing the request to the server.
-     */
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {Bids[]} validBidRequests - an array of bidRequest objects
+   * @param {BidderRequest} bidderRequest - master bidRequest object
+   * @return ServerRequest Info describing the request to the server.
+   */
   buildRequests: function(validBidRequests, bidderRequest) {
     const secure = 1; // treat all requests as secure
     const request = validBidRequests[0];
@@ -117,12 +117,12 @@ export const spec = {
   },
 
   /**
-     * Unpack the response from the server into a list of bids.
-     *
-     * @param {ServerResponse} serverResponse A successful response from the server.
-     * @param bidRequest The payload from the server's response.
-     * @return {Bid[]} An array of bids which were nested inside the server.
-     */
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @param bidRequest The payload from the server's response.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
   interpretResponse: function(serverResponse, bidRequest) {
     let bidResponse = [];
     if (Object.keys(serverResponse.body).length !== 0) {

--- a/modules/zeta_global_sspBidAdapter.js
+++ b/modules/zeta_global_sspBidAdapter.js
@@ -163,6 +163,7 @@ export const spec = {
     }
 
     provideEids(validBidRequests[0], payload);
+    provideSegments(bidderRequest, payload);
     const url = params.sid ? ENDPOINT_URL.concat('?sid=', params.sid) : ENDPOINT_URL;
     return {
       method: 'POST',
@@ -332,6 +333,25 @@ function checkParamDataType(key, value, datatype) {
 function provideEids(request, payload) {
   if (Array.isArray(request.userIdAsEids) && request.userIdAsEids.length > 0) {
     deepSetValue(payload, 'user.ext.eids', request.userIdAsEids);
+  }
+}
+
+function provideSegments(bidderRequest, payload) {
+  const data = bidderRequest.ortb2?.user?.data;
+  if (isArray(data)) {
+    const segments = data.filter(d => d?.segment).map(d => d.segment).filter(s => isArray(s)).flatMap(s => s).filter(s => s?.id);
+    if (segments.length > 0) {
+      if (!payload.user) {
+        payload.user = {};
+      }
+      if (!isArray(payload.user.data)) {
+        payload.user.data = [];
+      }
+      const payloadData = {
+        segment: segments
+      };
+      payload.user.data.push(payloadData);
+    }
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prebid.js",
-  "version": "8.26.0",
+  "version": "8.32.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prebid.js",
-      "version": "8.24.0-pre",
+      "version": "8.32.0-pre",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.16.7",
@@ -22,7 +22,7 @@
         "express": "^4.15.4",
         "fun-hooks": "^0.9.9",
         "just-clone": "^1.0.2",
-        "live-connect-js": "^6.3.0"
+        "live-connect-js": "^6.3.4"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.16.5",
@@ -47,6 +47,7 @@
         "eslint": "^7.27.0",
         "eslint-config-standard": "^10.2.1",
         "eslint-plugin-import": "^2.20.2",
+        "eslint-plugin-jsdoc": "^38.1.6",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prebid": "file:./plugins/eslint",
         "eslint-plugin-promise": "^5.1.0",
@@ -1667,6 +1668,20 @@
       "dev": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.22.2",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.22.2.tgz",
+      "integrity": "sha512-pM6WQKcuAtdYoqCsXSvVSu3Ij8K0HY50L8tIheOKHDl0wH1uA4zbP88etY8SIeP16NVCMCTFU+Q2DahSKheGGQ==",
+      "dev": true,
+      "dependencies": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "~2.2.5"
+      },
+      "engines": {
+        "node": "^12 || ^14 || ^16 || ^17"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -7489,6 +7504,15 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
+    "node_modules/comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -9562,6 +9586,55 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "38.1.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-38.1.6.tgz",
+      "integrity": "sha512-n4s95oYlg0L43Bs8C0dkzIldxYf8pLCutC/tCbjIdF7VDiobuzPI+HZn9Q0BvgOvgPNgh5n7CSStql25HUG4Tw==",
+      "dev": true,
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.22.1",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.4.0",
+        "regextras": "^0.8.0",
+        "semver": "^7.3.5",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || ^16 || ^17"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/eslint-plugin-node": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
@@ -10936,9 +11009,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "dev": true,
       "funding": [
         {
@@ -15610,6 +15683,15 @@
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "dev": true
     },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz",
+      "integrity": "sha512-2a6eRxSxp1BW040hFvaJxhsCMI9lT8QB8t14t+NY5tC5rckIR0U9cr2tjOeaFirmEOy6MHvmJnY7zTBHq431Lw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -16336,19 +16418,19 @@
       "dev": true
     },
     "node_modules/live-connect-common": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/live-connect-common/-/live-connect-common-3.0.2.tgz",
-      "integrity": "sha512-K3LNKd9CpREDJbXGdwKqPojjQaxd4G6c7OAD6Yzp3wsCWTH2hV8xNAbUksSOpOcVyyOT9ilteEFXIJQJrbODxQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/live-connect-common/-/live-connect-common-3.0.3.tgz",
+      "integrity": "sha512-ZPycT04ROBUvPiksnLTunrKC3ROhBSeO99fQ+4qMIkgKwP2CvS44L7fK+0WFV4nAi+65KbzSng7JWcSlckfw8w==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/live-connect-js": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.3.0.tgz",
-      "integrity": "sha512-1SnXQZq9gxHIb0scXPX1Da1rQ0oY2sloMGgeRreTAwhCtdQEuip/IYwgOh3/ZeZ6yT6iG9FLb7+AjORC4pO46g==",
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.3.4.tgz",
+      "integrity": "sha512-lg2XeCaj/eEbK66QGGDEdz9IdT/K3ExZ83Qo6xGVLdP5XJ33xAUCk/gds34rRTmpIwUfAnboOpyj3UoYtS3QUQ==",
       "dependencies": {
-        "live-connect-common": "^v3.0.2",
+        "live-connect-common": "^v3.0.3",
         "tiny-hashes": "1.0.1"
       },
       "engines": {
@@ -20565,6 +20647,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/regextras": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
+      "integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.14"
       }
     },
     "node_modules/regjsgen": {
@@ -26452,6 +26543,17 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true
     },
+    "@es-joy/jsdoccomment": {
+      "version": "0.22.2",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.22.2.tgz",
+      "integrity": "sha512-pM6WQKcuAtdYoqCsXSvVSu3Ij8K0HY50L8tIheOKHDl0wH1uA4zbP88etY8SIeP16NVCMCTFU+Q2DahSKheGGQ==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "~2.2.5"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -31123,6 +31225,12 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
+    "comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -32862,6 +32970,39 @@
         }
       }
     },
+    "eslint-plugin-jsdoc": {
+      "version": "38.1.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-38.1.6.tgz",
+      "integrity": "sha512-n4s95oYlg0L43Bs8C0dkzIldxYf8pLCutC/tCbjIdF7VDiobuzPI+HZn9Q0BvgOvgPNgh5n7CSStql25HUG4Tw==",
+      "dev": true,
+      "requires": {
+        "@es-joy/jsdoccomment": "~0.22.1",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.4.0",
+        "regextras": "^0.8.0",
+        "semver": "^7.3.5",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "eslint-plugin-node": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
@@ -33870,9 +34011,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "dev": true
     },
     "for-each": {
@@ -37487,6 +37628,12 @@
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "dev": true
     },
+    "jsdoc-type-pratt-parser": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz",
+      "integrity": "sha512-2a6eRxSxp1BW040hFvaJxhsCMI9lT8QB8t14t+NY5tC5rckIR0U9cr2tjOeaFirmEOy6MHvmJnY7zTBHq431Lw==",
+      "dev": true
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -38079,16 +38226,16 @@
       "dev": true
     },
     "live-connect-common": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/live-connect-common/-/live-connect-common-3.0.2.tgz",
-      "integrity": "sha512-K3LNKd9CpREDJbXGdwKqPojjQaxd4G6c7OAD6Yzp3wsCWTH2hV8xNAbUksSOpOcVyyOT9ilteEFXIJQJrbODxQ=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/live-connect-common/-/live-connect-common-3.0.3.tgz",
+      "integrity": "sha512-ZPycT04ROBUvPiksnLTunrKC3ROhBSeO99fQ+4qMIkgKwP2CvS44L7fK+0WFV4nAi+65KbzSng7JWcSlckfw8w=="
     },
     "live-connect-js": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.3.0.tgz",
-      "integrity": "sha512-1SnXQZq9gxHIb0scXPX1Da1rQ0oY2sloMGgeRreTAwhCtdQEuip/IYwgOh3/ZeZ6yT6iG9FLb7+AjORC4pO46g==",
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.3.4.tgz",
+      "integrity": "sha512-lg2XeCaj/eEbK66QGGDEdz9IdT/K3ExZ83Qo6xGVLdP5XJ33xAUCk/gds34rRTmpIwUfAnboOpyj3UoYtS3QUQ==",
       "requires": {
-        "live-connect-common": "^v3.0.2",
+        "live-connect-common": "^v3.0.3",
         "tiny-hashes": "1.0.1"
       }
     },
@@ -41241,6 +41388,12 @@
         "unicode-match-property-ecmascript": "^2.0.0",
         "unicode-match-property-value-ecmascript": "^2.0.0"
       }
+    },
+    "regextras": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
+      "integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==",
+      "dev": true
     },
     "regjsgen": {
       "version": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "8.26.0",
+  "version": "8.32.0",
   "description": "Header Bidding Management Library",
   "main": "src/prebid.js",
   "scripts": {
@@ -58,6 +58,7 @@
     "eslint": "^7.27.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-jsdoc": "^38.1.6",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prebid": "file:./plugins/eslint",
     "eslint-plugin-promise": "^5.1.0",
@@ -133,7 +134,7 @@
     "express": "^4.15.4",
     "fun-hooks": "^0.9.9",
     "just-clone": "^1.0.2",
-    "live-connect-js": "^6.3.0"
+    "live-connect-js": "^6.3.4"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.2"

--- a/plugins/pbjsGlobals.js
+++ b/plugins/pbjsGlobals.js
@@ -34,7 +34,8 @@ module.exports = function(api, options) {
     '$$PREBID_GLOBAL$$': pbGlobal,
     '$$DEFINE_PREBID_GLOBAL$$': defineGlobal,
     '$$REPO_AND_VERSION$$': `${prebid.repository.url.split('/')[3]}_prebid_${prebid.version}`,
-    '$$PREBID_DIST_URL_BASE$$': options.prebidDistUrlBase || `https://cdn.jsdelivr.net/npm/prebid.js@${getNpmVersion(prebid.version)}/dist/`
+    '$$PREBID_DIST_URL_BASE$$': options.prebidDistUrlBase || `https://cdn.jsdelivr.net/npm/prebid.js@${getNpmVersion(prebid.version)}/dist/`,
+    '$$LIVE_INTENT_MODULE_MODE$$': (process && process.env && process.env.LiveConnectMode) || 'standard'
   };
 
   let identifierToStringLiteral = [

--- a/src/adRendering.js
+++ b/src/adRendering.js
@@ -11,10 +11,11 @@ const {AD_RENDER_FAILED, AD_RENDER_SUCCEEDED, STALE_RENDER, BID_WON} = constants
 /**
  * Emit the AD_RENDER_FAILED event.
  *
- * @param reason one of the values in CONSTANTS.AD_RENDER_FAILED_REASON
- * @param message failure description
- * @param bid? bid response object that failed to render
- * @param id? adId that failed to render
+ * @param {Object} data
+ * @param data.reason one of the values in CONSTANTS.AD_RENDER_FAILED_REASON
+ * @param data.message failure description
+ * @param [data.bid] bid response object that failed to render
+ * @param [data.id] adId that failed to render
  */
 export function emitAdRenderFail({ reason, message, bid, id }) {
   const data = { reason, message };
@@ -28,10 +29,11 @@ export function emitAdRenderFail({ reason, message, bid, id }) {
 /**
  * Emit the AD_RENDER_SUCCEEDED event.
  * (Note: Invocation of this function indicates that the render function did not generate an error, it does not guarantee that tracking for this event has occurred yet.)
- * @param doc document object that was used to `.write` the ad. Should be `null` if unavailable (e.g. for documents in
+ * @param {Object} data
+ * @param data.doc document object that was used to `.write` the ad. Should be `null` if unavailable (e.g. for documents in
  * a cross-origin frame).
- * @param bid bid response object for the ad that was rendered
- * @param id adId that was rendered.
+ * @param [data.bid] bid response object for the ad that was rendered
+ * @param [data.id] adId that was rendered.
  */
 export function emitAdRenderSucceeded({ doc, bid, id }) {
   const data = { doc };

--- a/src/adServerManager.js
+++ b/src/adServerManager.js
@@ -34,7 +34,7 @@ const prebid = getGlobal();
 /**
  * @typedef {Object} VideoSupport
  *
- * @function {VideoAdUrlBuilder} buildVideoAdUrl
+ * @property {VideoAdUrlBuilder} buildVideoAdUrl
  */
 
 /**

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -28,6 +28,11 @@ import {MODULE_TYPE_BIDDER} from '../activities/modules.js';
 import {ACTIVITY_TRANSMIT_TID, ACTIVITY_TRANSMIT_UFPD} from '../activities/activities.js';
 
 /**
+ * @typedef {import('../mediaTypes.js').MediaType} MediaType
+ * @typedef {import('../Renderer.js').Renderer} Renderer
+ */
+
+/**
  * This file aims to support Adapters during the Prebid 0.x -> 1.x transition.
  *
  * Prebid 1.x and Prebid 0.x will be in separate branches--perhaps for a long time.
@@ -57,7 +62,7 @@ import {ACTIVITY_TRANSMIT_TID, ACTIVITY_TRANSMIT_UFPD} from '../activities/activ
  * @property {string} code A code which will be used to uniquely identify this bidder. This should be the same
  *   one as is used in the call to registerBidAdapter
  * @property {string[]} [aliases] A list of aliases which should also resolve to this bidder.
- * @property {MediaType[]} [supportedMediaTypes]: A list of Media Types which the adapter supports.
+ * @property {MediaType[]} [supportedMediaTypes] A list of Media Types which the adapter supports.
  * @property {function(object): boolean} isBidRequestValid Determines whether or not the given bid has all the params
  *   needed to make a valid request.
  * @property {function(BidRequest[], bidderRequest): ServerRequest|ServerRequest[]} buildRequests Build the request to the Server
@@ -105,7 +110,7 @@ import {ACTIVITY_TRANSMIT_TID, ACTIVITY_TRANSMIT_UFPD} from '../activities/activ
  *
  * @property {*} body The response body. If this is legal JSON, then it will be parsed. Otherwise it'll be a
  *   string with the body's content.
- * @property {{get: function(string): string} headers The response headers.
+ * @property {{get: function(string): string}} headers The response headers.
  *   Call this like `ServerResponse.headers.get("Content-Type")`
  */
 
@@ -126,7 +131,7 @@ import {ACTIVITY_TRANSMIT_TID, ACTIVITY_TRANSMIT_UFPD} from '../activities/activ
  * @property {object} [video] Object for storing video response data
  * @property {object} [meta] Object for storing bid meta data
  * @property {string} [meta.primaryCatId] The IAB primary category ID
- * @property [Renderer] renderer A Renderer which can be used as a default for this bid,
+ * @property {Renderer} renderer A Renderer which can be used as a default for this bid,
  *   if the publisher doesn't override it. This is only relevant for Outstream Video bids.
  */
 

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -29,7 +29,8 @@ const _approvedLoadExternalJSList = [
   'geoedge',
   'mediafilter',
   'qortex',
-  'dynamicAdBoost'
+  'dynamicAdBoost',
+  'contxtful'
 ]
 
 /**
@@ -39,7 +40,7 @@ const _approvedLoadExternalJSList = [
  * @param {string} moduleCode bidderCode or module code of the module requesting this resource
  * @param {function} [callback] callback function to be called after the script is loaded
  * @param {Document} [doc] the context document, in which the script will be loaded, defaults to loaded document
- * @param {object} an object of attributes to be added to the script with setAttribute by [key] and [value]; Only the attributes passed in the first request of a url will be added.
+ * @param {object} attributes an object of attributes to be added to the script with setAttribute by [key] and [value]; Only the attributes passed in the first request of a url will be added.
  */
 export function loadExternalScript(url, moduleCode, callback, doc, attributes) {
   if (!moduleCode || !url) {

--- a/src/auction.js
+++ b/src/auction.js
@@ -9,14 +9,21 @@
  */
 
 /**
-  * @typedef {Object} AdUnit An object containing the adUnit configuration.
-  *
-  * @property {string} code A code which will be used to uniquely identify this bidder. This should be the same
-  *   one as is used in the call to registerBidAdapter
-  * @property {Array.<size>} sizes A list of size for adUnit.
-  * @property {object} params Any bidder-specific params which the publisher used in their bid request.
-  *   This is guaranteed to have passed the spec.areParamsValid() test.
-  */
+ * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
+ * @typedef {import('../src/adapters/bidderFactory.js').Bid} Bid
+ * @typedef {import('../src/config.js').MediaTypePriceGranularity} MediaTypePriceGranularity
+ * @typedef {import('../src/mediaTypes.js').MediaType} MediaType
+ */
+
+/**
+ * @typedef {Object} AdUnit An object containing the adUnit configuration.
+ *
+ * @property {string} code A code which will be used to uniquely identify this bidder. This should be the same
+ *   one as is used in the call to registerBidAdapter
+ * @property {Array.<size>} sizes A list of size for adUnit.
+ * @property {object} params Any bidder-specific params which the publisher used in their bid request.
+ *   This is guaranteed to have passed the spec.areParamsValid() test.
+ */
 
 /**
  * @typedef {Array.<number>} size
@@ -119,19 +126,20 @@ export function resetAuctionState() {
 }
 
 /**
-  * Creates new auction instance
-  *
-  * @param {Object} requestConfig
-  * @param {AdUnit} requestConfig.adUnits
-  * @param {AdUnitCode} requestConfig.adUnitCodes
-  * @param {function():void} requestConfig.callback
-  * @param {number} requestConfig.cbTimeout
-  * @param {Array.<string>} requestConfig.labels
-  * @param {string} requestConfig.auctionId
-  * @param {{global: {}, bidder: {}}} ortb2Fragments first party data, separated into global
-  *    (from getConfig('ortb2') + requestBids({ortb2})) and bidder (a map from bidderCode to ortb2)
-  * @returns {Auction} auction instance
-  */
+ * Creates new auction instance
+ *
+ * @param {Object} requestConfig
+ * @param {AdUnit} requestConfig.adUnits
+ * @param {AdUnitCode} requestConfig.adUnitCodes
+ * @param {function():void} requestConfig.callback
+ * @param {number} requestConfig.cbTimeout
+ * @param {Array.<string>} requestConfig.labels
+ * @param {string} requestConfig.auctionId
+ * @param {{global: {}, bidder: {}}} requestConfig.ortb2Fragments first party data, separated into global
+ *    (from getConfig('ortb2') + requestBids({ortb2})) and bidder (a map from bidderCode to ortb2)
+ * @param {Object} requestConfig.metrics
+ * @returns {Auction} auction instance
+ */
 export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, auctionId, ortb2Fragments, metrics}) {
   metrics = useMetrics(metrics);
   const _adUnits = adUnits;
@@ -406,9 +414,10 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
 /**
  * Hook into this to intercept bids before they are added to an auction.
  *
+ * @type {Function}
  * @param adUnitCode
  * @param bid
- * @param {function(String)} reject: a function that, when called, rejects `bid` with the given reason.
+ * @param {function(String): void} reject a function that, when called, rejects `bid` with the given reason.
  */
 export const addBidResponse = hook('sync', function(adUnitCode, bid, reject) {
   this.dispatch.call(null, adUnitCode, bid);
@@ -455,7 +464,7 @@ export function auctionCallbacks(auctionDone, auctionInstance, {index = auctionM
   function acceptBidResponse(adUnitCode, bid) {
     handleBidResponse(adUnitCode, bid, (done) => {
       let bidResponse = getPreparedBidForAuction(bid);
-
+      events.emit(CONSTANTS.EVENTS.BID_ACCEPTED, bidResponse);
       if (FEATURES.VIDEO && bidResponse.mediaType === VIDEO) {
         tryAddVideoBid(auctionInstance, bidResponse, done);
       } else {
@@ -750,8 +759,9 @@ export function getMediaTypeGranularity(mediaType, mediaTypes, mediaTypePriceGra
 
 /**
  * This function returns the price granularity defined. It can be either publisher defined or default value
- * @param bid bid response object
- * @param index
+ * @param {Bid} bid bid response object
+ * @param {object} obj
+ * @param {object} obj.index
  * @returns {string} granularity
  */
 export const getPriceGranularity = (bid, {index = auctionManager.index} = {}) => {
@@ -859,7 +869,6 @@ function defaultAdserverTargeting() {
 /**
  * @param {string} mediaType
  * @param {string} bidderCode
- * @param {BidRequest} bidReq
  * @returns {*}
  */
 export function getStandardBidderSettings(mediaType, bidderCode) {

--- a/src/auctionIndex.js
+++ b/src/auctionIndex.js
@@ -1,24 +1,30 @@
 /**
+ * @typedef {Object} AuctionIndex
+ *
+ * @property {function({ auctionId: * }): *} getAuction Returns auction instance for `auctionId`
+ * @property {function({ transactionId: * }): *} getAdUnit Returns `adUnit` object for `transactionId`.
+ * You should prefer `getMediaTypes` for looking up bid media types.
+ * @property {function({ transactionId: *, requestId: * }): *} getMediaTypes Returns mediaTypes object from bidRequest (through `requestId`) falling back to the adUnit (through `transactionId`).
+ * The bidRequest is given precedence because its mediaTypes can differ from the adUnit's (if bidder-specific labels are in use).
+ * Bids that have no associated request do not have labels either, and use the adUnit's mediaTypes.
+ * @property {function({ requestId: *, bidderRequestId: * }): *} getBidderRequest Returns bidderRequest that matches both requestId and bidderRequestId (if either or both are provided).
+ * Bid responses are not guaranteed to have a corresponding request.
+ * @property {function({ requestId: * }): *} getBidRequest Returns bidRequest object for requestId.
+ * Bid responses are not guaranteed to have a corresponding request.
+ */
+
+/**
  * Retrieves request-related bid data.
  * All methods are designed to work with Bid (response) objects returned by bid adapters.
  */
 export function AuctionIndex(getAuctions) {
   Object.assign(this, {
-    /**
-     * @param auctionId
-     * @returns {*} Auction instance for `auctionId`
-     */
     getAuction({auctionId}) {
       if (auctionId != null) {
         return getAuctions()
           .find(auction => auction.getAuctionId() === auctionId);
       }
     },
-    /**
-     * NOTE: you should prefer {@link #getMediaTypes} for looking up bid media types.
-     * @param transactionId
-     * @returns adUnit object for `transactionId`
-     */
     getAdUnit({transactionId}) {
       if (transactionId != null) {
         return getAuctions()
@@ -26,14 +32,6 @@ export function AuctionIndex(getAuctions) {
           .find(au => au.transactionId === transactionId);
       }
     },
-    /**
-     * @param transactionId
-     * @param requestId?
-     * @returns {*} mediaTypes object from bidRequest (through requestId) falling back to the adUnit (through transactionId).
-     *
-     * The bidRequest is given precedence because its mediaTypes can differ from the adUnit's (if bidder-specific labels are in use).
-     * Bids that have no associated request do not have labels either, and use the adUnit's mediaTypes.
-     */
     getMediaTypes({transactionId, requestId}) {
       if (requestId != null) {
         const req = this.getBidRequest({requestId});
@@ -47,13 +45,6 @@ export function AuctionIndex(getAuctions) {
         }
       }
     },
-    /**
-     * @param requestId?
-     * @param bidderRequestId?
-     * @returns {*} bidderRequest that matches both requestId and bidderRequestId (if either or both are provided).
-     *
-     * NOTE: Bid responses are not guaranteed to have a corresponding request.
-     */
     getBidderRequest({requestId, bidderRequestId}) {
       if (requestId != null || bidderRequestId != null) {
         let bers = getAuctions().flatMap(a => a.getBidRequests());
@@ -67,12 +58,6 @@ export function AuctionIndex(getAuctions) {
         }
       }
     },
-    /**
-     * @param requestId
-     * @returns {*} bidRequest object for requestId
-     *
-     * NOTE: Bid responses are not guaranteed to have a corresponding request.
-     */
     getBidRequest({requestId}) {
       if (requestId != null) {
         return getAuctions()

--- a/src/auctionManager.js
+++ b/src/auctionManager.js
@@ -17,6 +17,7 @@
  * @property {function(): Object} getStandardBidderAdServerTargeting - returns standard bidder targeting for all the adapters. Refer http://prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.bidderSettings for more details
  * @property {function(Object): void} addWinningBid - add a winning bid to an auction based on auctionId
  * @property {function(): void} clearAllAuctions - clear all auctions for testing
+ * @property {AuctionIndex} index
  */
 
 import { uniques, logWarn } from './utils.js';

--- a/src/config.js
+++ b/src/config.js
@@ -59,13 +59,6 @@ const GRANULARITY_OPTIONS = {
 
 const ALL_TOPICS = '*';
 
-/**
- * @typedef {object} PrebidConfig
- *
- * @property {string} cache.url Set a url if we should use prebid-cache to store video bids before adding
- *   bids to the auction. **NOTE** This must be set if you want to use the dfpAdServerVideo module.
- */
-
 export function newConfig() {
   let listeners = [];
   let defaults;
@@ -551,4 +544,8 @@ export function newConfig() {
   };
 }
 
+/**
+ * Set a `cache.url` if we should use prebid-cache to store video bids before adding bids to the auction.
+ * This must be set if you want to use the dfpAdServerVideo module.
+ */
 export const config = newConfig();

--- a/src/constants.json
+++ b/src/constants.json
@@ -46,7 +46,8 @@
     "AUCTION_DEBUG": "auctionDebug",
     "BID_VIEWABLE": "bidViewable",
     "STALE_RENDER": "staleRender",
-    "BILLABLE_EVENT": "billableEvent"
+    "BILLABLE_EVENT": "billableEvent",
+    "BID_ACCEPTED": "bidAccepted"
   },
   "AD_RENDER_FAILED_REASON": {
     "PREVENT_WRITING_ON_MAIN_DOCUMENT": "preventWritingOnMainDocument",
@@ -176,6 +177,8 @@
 	"AD_UNIT": "adUnit",
 	"SET_CONFIG": "setConfig",
 	"FETCH": "fetch",
-	"SUCCESS": "success"
+	"SUCCESS": "success",
+	"ERROR": "error",
+	"TIMEOUT": "timeout"
   }
 }

--- a/src/events.js
+++ b/src/events.js
@@ -61,12 +61,13 @@ const _public = (function () {
       elapsedTime: utils.getPerformanceNow(),
     });
 
-    /** Push each specific callback to the `callbacks` array.
+    /**
+     * Push each specific callback to the `callbacks` array.
      * If the `event` map has a key that matches the value of the
      * event payload id path, e.g. `eventPayload[idPath]`, then apply
      * each function in the `que` array as an argument to push to the
      * `callbacks` array
-     * */
+     */
     if (key && eventKeys.includes(key)) {
       push.apply(callbacks, event[key].que);
     }
@@ -80,7 +81,7 @@ const _public = (function () {
       try {
         fn.apply(null, args);
       } catch (e) {
-        utils.logError('Error executing handler:', 'events.js', e);
+        utils.logError('Error executing handler:', 'events.js', e, eventString);
       }
     });
   }

--- a/src/mediaTypes.js
+++ b/src/mediaTypes.js
@@ -10,11 +10,11 @@
  * @typedef {('adpod')} VideoContext
  */
 
-/** @type MediaType */
+/** @type {MediaType} */
 export const NATIVE = 'native';
-/** @type MediaType */
+/** @type {MediaType} */
 export const VIDEO = 'video';
-/** @type MediaType */
+/** @type {MediaType} */
 export const BANNER = 'banner';
-/** @type VideoContext */
+/** @type {VideoContext} */
 export const ADPOD = 'adpod';

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -85,26 +85,26 @@ export const getHighestCpmBidsFromBidPool = hook('sync', function(bidsReceived, 
 });
 
 /**
-* A descending sort function that will sort the list of objects based on the following two dimensions:
-*  - bids with a deal are sorted before bids w/o a deal
-*  - then sort bids in each grouping based on the hb_pb value
-* eg: the following list of bids would be sorted like:
-*  [{
-*    "hb_adid": "vwx",
-*    "hb_pb": "28",
-*    "hb_deal": "7747"
-*  }, {
-*    "hb_adid": "jkl",
-*    "hb_pb": "10",
-*    "hb_deal": "9234"
-*  }, {
-*    "hb_adid": "stu",
-*    "hb_pb": "50"
-*  }, {
-*    "hb_adid": "def",
-*    "hb_pb": "2"
-*  }]
-*/
+ * A descending sort function that will sort the list of objects based on the following two dimensions:
+ *  - bids with a deal are sorted before bids w/o a deal
+ *  - then sort bids in each grouping based on the hb_pb value
+ * eg: the following list of bids would be sorted like:
+ *  [{
+ *    "hb_adid": "vwx",
+ *    "hb_pb": "28",
+ *    "hb_deal": "7747"
+ *  }, {
+ *    "hb_adid": "jkl",
+ *    "hb_pb": "10",
+ *    "hb_deal": "9234"
+ *  }, {
+ *    "hb_adid": "stu",
+ *    "hb_pb": "50"
+ *  }, {
+ *    "hb_adid": "def",
+ *    "hb_pb": "2"
+ *  }]
+ */
 export function sortByDealAndPriceBucketOrCpm(useCpm = false) {
   return function(a, b) {
     if (a.adserverTargeting.hb_deal !== undefined && b.adserverTargeting.hb_deal === undefined) {

--- a/src/userSync.js
+++ b/src/userSync.js
@@ -244,7 +244,7 @@ export function newUserSync(deps) {
    * @param {string} type The type of the sync; either image or iframe
    * @param {string} bidder The name of the adapter. e.g. "rubicon"
    * @returns {boolean} true => bidder is not allowed to register; false => bidder can register
-    */
+   */
   function shouldBidderBeBlocked(type, bidder) {
     let filterConfig = usConfig.filterSettings;
 
@@ -309,7 +309,7 @@ export function newUserSync(deps) {
    * @function syncUsers
    * @summary Trigger all the user syncs based on publisher-defined timeout
    * @public
-   * @params {int} timeout The delay in ms before syncing data - default 0
+   * @params {number} timeout The delay in ms before syncing data - default 0
    */
   publicApi.syncUsers = (timeout = 0) => {
     if (timeout) {
@@ -358,7 +358,7 @@ export const userSync = newUserSync(Object.defineProperties({
  *
  * @property {boolean} enableOverride
  * @property {boolean} syncEnabled
- * @property {int} syncsPerBidder
+ * @property {number} syncsPerBidder
  * @property {string[]} enabledBidders
  * @property {Object} filterSettings
  */

--- a/src/utils.js
+++ b/src/utils.js
@@ -653,7 +653,7 @@ export function checkCookieSupport() {
  *
  * @param {function} func The function which should be executed, once the returned function has been executed
  *   numRequiredCalls times.
- * @param {int} numRequiredCalls The number of times which the returned function needs to be called before
+ * @param {number} numRequiredCalls The number of times which the returned function needs to be called before
  *   func is.
  */
 export function delayExecution(func, numRequiredCalls) {
@@ -672,7 +672,7 @@ export function delayExecution(func, numRequiredCalls) {
 /**
  * https://stackoverflow.com/a/34890276/428704
  * @export
- * @param {array} xs
+ * @param {Array} xs
  * @param {string} key
  * @returns {Object} {${key_value}: ${groupByArray}, key_value: {groupByArray}}
  */

--- a/test/spec/e2e/modules/e2e_consent_mgt_gdpr.spec.js
+++ b/test/spec/e2e/modules/e2e_consent_mgt_gdpr.spec.js
@@ -1,4 +1,4 @@
-/**
+/*
  TODO: old CMP no longer works; see if we can fix this with https://github.com/prebid/Prebid.js/issues/6377
 const expect = require('chai').expect;
 const { testPageURL, switchFrame, waitForElement } = require('../../../helpers/testing-utils');
@@ -59,4 +59,4 @@ describe('Prebid.js GDPR Ad Unit Test', function () {
     expect(ele.isExisting()).to.be.true;
   });
 });
-**/
+ */

--- a/test/spec/modules/ad2ictionBidAdapter_spec.js
+++ b/test/spec/modules/ad2ictionBidAdapter_spec.js
@@ -1,0 +1,223 @@
+import { expect } from 'chai';
+import {
+  spec,
+  API_ENDPOINT,
+  API_VERSION_NUMBER,
+} from 'modules/ad2ictionBidAdapter.js';
+import { newBidder } from 'src/adapters/bidderFactory.js';
+
+describe('ad2ictionBidAdapter', function () {
+  const adapter = newBidder(spec);
+
+  describe('inherited functions', function () {
+    it('exists and is a function', function () {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+  });
+
+  describe('isBidRequestValid', function () {
+    const bid = {
+      bidder: 'ad2iction',
+      params: { id: '11ab384c-e936-11ed-a6a7-f23c9173ed43' },
+      mediaTypes: {
+        banner: {
+          sizes: [
+            [300, 250],
+            [336, 280],
+          ],
+        },
+      },
+      adUnitCode: 'adunit-code',
+      sizes: [
+        [300, 250],
+        [336, 280],
+      ],
+      bidId: '2a7a3b48778a1b',
+      bidderRequestId: '1e6509293abe6b',
+    };
+
+    it('should return true when required params found', function () {
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('should return false when params id is not valid (letters)', function () {
+      const mockBid = {
+        ...bid,
+        params: { id: 1234 },
+      };
+
+      expect(spec.isBidRequestValid(mockBid)).to.equal(false);
+    });
+
+    it('should return false when params id is not exist', function () {
+      const mockBid = {
+        ...bid,
+      };
+      delete mockBid.params.id;
+
+      expect(spec.isBidRequestValid(mockBid)).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', function () {
+    const mockValidBidRequests = [
+      {
+        bidder: 'ad2iction',
+        params: { id: '11ab384c-e936-11ed-a6a7-f23c9173ed43' },
+        adUnitCode: 'adunit-code',
+        sizes: [
+          [300, 250],
+          [336, 280],
+        ],
+        bidId: '57ffc0667379e1',
+        bidderRequestId: '4ddea14478a651',
+      },
+    ];
+
+    const mockBidderRequest = {
+      bidderCode: 'ad2iction',
+      bidderRequestId: '4ddea14478a651',
+      bids: [
+        {
+          bidder: 'ad2iction',
+          params: { id: '11ab384c-e936-11ed-a6a7-f23c9173ed43' },
+          adUnitCode: 'adunit-code',
+          transactionId: null,
+          sizes: [
+            [300, 250],
+            [336, 280],
+          ],
+          bidId: '57ffc0667379e1',
+          bidderRequestId: '4ddea14478a651',
+        },
+      ],
+      timeout: 1200,
+      refererInfo: {
+        ref: 'https://example.com/referer.html',
+      },
+      ortb2: {
+        source: {},
+        site: {
+          ref: 'https://example.com/referer.html',
+        },
+        device: {
+          w: 390,
+          h: 844,
+          language: 'zh',
+        },
+      },
+      start: 1702526505498,
+    };
+
+    it('should send bid request to API_ENDPOINT via POST', function () {
+      const request = spec.buildRequests(
+        mockValidBidRequests,
+        mockBidderRequest
+      );
+
+      expect(request.url).to.equal(API_ENDPOINT);
+      expect(request.method).to.equal('POST');
+    });
+
+    it('should send bid request with API version', function () {
+      const request = spec.buildRequests(
+        mockValidBidRequests,
+        mockBidderRequest
+      );
+
+      expect(request.data.v).to.equal(API_VERSION_NUMBER);
+    });
+
+    it('should send bid request with dada fields', function () {
+      const request = spec.buildRequests(
+        mockValidBidRequests,
+        mockBidderRequest
+      );
+
+      expect(request.data).to.include.all.keys('udid', '_');
+      expect(request.data).to.have.property('refererInfo');
+      expect(request.data).to.have.property('ortb2');
+    });
+  });
+
+  describe('interpretResponse', function () {
+    it('should return an empty array to indicate no valid bids', function () {
+      const mockServerResponse = {};
+
+      const bidResponses = spec.interpretResponse(mockServerResponse);
+
+      expect(bidResponses).is.an('array').that.is.empty;
+    });
+
+    it('should return a valid bid response', function () {
+      const MOCK_AD_DOM = "<div id='AD2M-BOX'>"
+      const mockServerResponse = {
+        body: [
+          {
+            requestId: '23a3d87fb6bde9',
+            cpm: 1.61,
+            currency: 'USD',
+            width: '336',
+            height: '280',
+            creativeId: '46271',
+            netRevenue: 'false',
+            ad: MOCK_AD_DOM,
+            meta: {
+              advertiserDomains: [''],
+            },
+            ttl: 360,
+          },
+          {
+            requestId: '3ce3efc40c890b',
+            cpm: 1.61,
+            currency: 'USD',
+            width: '336',
+            height: '280',
+            creativeId: '46271',
+            netRevenue: 'false',
+            ad: MOCK_AD_DOM,
+            meta: {
+              advertiserDomains: [''],
+            },
+            ttl: 360,
+          },
+        ],
+      };
+
+      const exceptServerResponse = [
+        {
+          requestId: '23a3d87fb6bde9',
+          cpm: 1.61,
+          currency: 'USD',
+          width: '336',
+          height: '280',
+          creativeId: '46271',
+          netRevenue: 'false',
+          ad: MOCK_AD_DOM,
+          meta: {
+            advertiserDomains: [''],
+          },
+          ttl: 360,
+        },
+        {
+          requestId: '3ce3efc40c890b',
+          cpm: 1.61,
+          currency: 'USD',
+          width: '336',
+          height: '280',
+          creativeId: '46271',
+          netRevenue: 'false',
+          ad: MOCK_AD_DOM,
+          meta: {
+            advertiserDomains: [''],
+          },
+          ttl: 360,
+        },
+      ]
+
+      const bidResponses = spec.interpretResponse(mockServerResponse);
+
+      expect(bidResponses).to.eql(exceptServerResponse);
+    });
+  });
+});

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -861,11 +861,6 @@ describe('Adagio bid adapter', () => {
         }
         const requests = spec.buildRequests([bid01], bidderRequest);
 
-        expect(requests[0].data.adUnits[0].floors.length).to.equal(3);
-        expect(requests[0].data.adUnits[0].floors[0]).to.deep.equal({f: 1, mt: 'banner', s: '300x250'});
-        expect(requests[0].data.adUnits[0].floors[1]).to.deep.equal({f: 1, mt: 'banner', s: '300x600'});
-        expect(requests[0].data.adUnits[0].floors[2]).to.deep.equal({f: 1, mt: 'video', s: '600x480'});
-
         expect(requests[0].data.adUnits[0].mediaTypes.banner.sizes.length).to.equal(2);
         expect(requests[0].data.adUnits[0].mediaTypes.banner.bannerSizes[0]).to.deep.equal({size: [300, 250], floor: 1});
         expect(requests[0].data.adUnits[0].mediaTypes.banner.bannerSizes[1]).to.deep.equal({size: [300, 600], floor: 1});
@@ -890,10 +885,6 @@ describe('Adagio bid adapter', () => {
         }
         const requests = spec.buildRequests([bid01], bidderRequest);
 
-        expect(requests[0].data.adUnits[0].floors.length).to.equal(2);
-        expect(requests[0].data.adUnits[0].floors[0]).to.deep.equal({f: 1, mt: 'video'});
-        expect(requests[0].data.adUnits[0].floors[1]).to.deep.equal({f: 1, mt: 'native'});
-
         expect(requests[0].data.adUnits[0].mediaTypes.video.floor).to.equal(1);
         expect(requests[0].data.adUnits[0].mediaTypes.native.floor).to.equal(1);
       });
@@ -913,8 +904,6 @@ describe('Adagio bid adapter', () => {
         }
         const requests = spec.buildRequests([bid01], bidderRequest);
 
-        expect(requests[0].data.adUnits[0].floors.length).to.equal(1);
-        expect(requests[0].data.adUnits[0].floors[0]).to.deep.equal({mt: 'video'});
         expect(requests[0].data.adUnits[0].mediaTypes.video.floor).to.be.undefined;
       });
     });

--- a/test/spec/modules/adkernelBidAdapter_spec.js
+++ b/test/spec/modules/adkernelBidAdapter_spec.js
@@ -250,6 +250,31 @@ describe('Adkernel adapter', function () {
       }],
       bidid: 'pTuOlf5KHUo',
       cur: 'EUR'
+    },
+    multiformat_response = {
+      id: '47ce4badcf7482',
+      seatbid: [{
+        bid: [{
+          id: 'sZSYq5zYMxo_0',
+          impid: 'Bid_01b__mf',
+          crid: '100_003',
+          price: 0.00145,
+          adid: '158801',
+          adm: '<!-- admarkup -->',
+          nurl: 'https://rtb.com/win?i=sZSYq5zYMxo_0&f=nurl',
+          cid: '16855'
+        }, {
+          id: 'sZSYq5zYMxo_1',
+          impid: 'Bid_01v__mf',
+          crid: '100_003',
+          price: 0.25,
+          adid: '158801',
+          nurl: 'https://rtb.com/win?i=sZSYq5zYMxo_1&f=nurl',
+          cid: '16855'
+        }]
+      }],
+      bidid: 'pTuOlf5KHUo',
+      cur: 'USD'
     };
 
   var sandbox;
@@ -460,18 +485,29 @@ describe('Adkernel adapter', function () {
   });
 
   describe('multiformat request building', function () {
-    let _, bidRequests;
+    let pbRequests, bidRequests;
     before(function () {
-      [_, bidRequests] = buildRequest([bid_multiformat]);
+      [pbRequests, bidRequests] = buildRequest([bid_multiformat]);
     });
     it('should contain single request', function () {
       expect(bidRequests).to.have.length(1);
-      expect(bidRequests[0].imp).to.have.length(1);
     });
-    it('should contain banner-only impression', function () {
-      expect(bidRequests[0].imp).to.have.length(1);
+    it('should contain both impression', function () {
+      expect(bidRequests[0].imp).to.have.length(2);
       expect(bidRequests[0].imp[0]).to.have.property('banner');
-      expect(bidRequests[0].imp[0]).to.not.have.property('video');
+      expect(bidRequests[0].imp[1]).to.have.property('video');
+      // check that splitted imps do not share same impid
+      expect(bidRequests[0].imp[0].id).to.be.not.eql('Bid_01');
+      expect(bidRequests[0].imp[1].id).to.be.not.eql('Bid_01');
+      expect(bidRequests[0].imp[1].id).to.be.not.eql(bidRequests[0].imp[0].id);
+    });
+    it('x', function() {
+      let bids = spec.interpretResponse({body: multiformat_response}, pbRequests[0]);
+      expect(bids).to.have.length(2);
+      expect(bids[0].requestId).to.be.eql('Bid_01');
+      expect(bids[0].mediaType).to.be.eql('banner');
+      expect(bids[1].requestId).to.be.eql('Bid_01');
+      expect(bids[1].mediaType).to.be.eql('video');
     });
   });
 

--- a/test/spec/modules/admaticBidAdapter_spec.js
+++ b/test/spec/modules/admaticBidAdapter_spec.js
@@ -1,12 +1,553 @@
-import {expect} from 'chai';
-import {spec, storage} from 'modules/admaticBidAdapter.js';
-import {newBidder} from 'src/adapters/bidderFactory.js';
-import {getStorageManager} from 'src/storageManager';
+import { expect } from 'chai';
+import { spec } from 'modules/admaticBidAdapter.js';
+import { newBidder } from 'src/adapters/bidderFactory.js';
+import { config } from 'src/config.js';
 
 const ENDPOINT = 'https://layer.serve.admatic.com.tr/pb';
 
 describe('admaticBidAdapter', () => {
   const adapter = newBidder(spec);
+  let validRequest = [ {
+    'refererInfo': {
+      'page': 'https://www.admatic.com.tr',
+      'domain': 'https://www.admatic.com.tr',
+    },
+    'bidder': 'admatic',
+    'params': {
+      'networkId': 10433394,
+      'host': 'layer.serve.admatic.com.tr'
+    },
+    'ortb2Imp': { 'ext': { 'instl': 1 } },
+    'ortb2': { 'badv': ['admatic.com.tr'] },
+    'mediaTypes': {
+      'banner': {
+        'sizes': [[300, 250], [728, 90]]
+      },
+      'native': {
+      },
+      'video': {
+      }
+    },
+    getFloor: inputParams => {
+      if (inputParams.mediaType === BANNER && inputParams.size[0] === 300 && inputParams.size[1] === 250) {
+        return {
+          currency: 'USD',
+          floor: 1.0
+        };
+      } else if (inputParams.mediaType === BANNER && inputParams.size[0] === 728 && inputParams.size[1] === 90) {
+        return {
+          currency: 'USD',
+          floor: 2.0
+        };
+      } else if (inputParams.mediaType === VIDEO) {
+        return {
+          currency: 'USD',
+          floor: 1.0
+        };
+      } else if (inputParams.mediaType === NATIVE) {
+        return {
+          currency: 'USD',
+          floor: 1.0
+        };
+      } else {
+        return {}
+      }
+    },
+    'schain': {
+      'ver': '1.0',
+      'complete': 1,
+      'nodes': [
+        {
+          'asi': 'pixad.com.tr',
+          'sid': 'px-pub-3000856707',
+          'hp': 1
+        }
+      ]
+    },
+    'at': 1,
+    'tmax': 1000,
+    'user': {
+      'ext': {
+        'eids': [
+          {
+            'source': 'id5-sync.com',
+            'uids': [
+              {
+                'id': '0',
+                'atype': 1,
+                'ext': {
+                  'linkType': 0,
+                  'pba': 'wMh3sAXcnhDq7CfSa6ji1g=='
+                }
+              }
+            ]
+          },
+          {
+            'source': 'pubcid.org',
+            'uids': [
+              {
+                'id': '5a49273f-a424-454b-b478-169c3551aa72',
+                'atype': 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    'ortb': {
+      'badv': [],
+      'bcat': [],
+      'site': {
+        'page': 'http://localhost:8888/admatic.html',
+        'ref': 'http://localhost:8888',
+        'publisher': {
+          'name': 'localhost'
+        }
+      },
+      'device': {
+        'ua': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36'
+      }
+    },
+    'site': {
+      'page': 'http://localhost:8888/admatic.html',
+      'ref': 'http://localhost:8888',
+      'publisher': {
+        'name': 'localhost',
+        'publisherId': 12321312
+      }
+    },
+    'imp': [
+      {
+        'size': [
+          {
+            'w': 300,
+            'h': 250
+          },
+          {
+            'w': 728,
+            'h': 90
+          }
+        ],
+        'mediatype': {},
+        'type': 'banner',
+        'id': '2205da7a81846b',
+        'floors': {
+          'banner': {
+            '300x250': { 'currency': 'USD', 'floor': 1 },
+            '728x90': { 'currency': 'USD', 'floor': 2 }
+          }
+        }
+      },
+      {
+        'size': [
+          {
+            'w': 338,
+            'h': 280
+          }
+        ],
+        'type': 'video',
+        'mediatype': {
+          'context': 'instream',
+          'mimes': [
+            'video/mp4'
+          ],
+          'maxduration': 240,
+          'api': [
+            1,
+            2
+          ],
+          'playerSize': [
+            [
+              338,
+              280
+            ]
+          ],
+          'protocols': [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8
+          ],
+          'skip': 1,
+          'playbackmethod': [
+            2
+          ],
+          'linearity': 1,
+          'placement': 2
+        },
+        'floors': {
+          'video': {
+            '338x280': { 'currency': 'USD', 'floor': 1 }
+          }
+        },
+        'id': '45e86fc7ce7fc93'
+      },
+      {
+        'size': [
+          {
+            'w': 1,
+            'h': 1
+          }
+        ],
+        'type': 'native',
+        'mediatype': {
+          'title': {
+            'required': true,
+            'len': 120
+          },
+          'image': {
+            'required': true
+          },
+          'icon': {
+            'required': false,
+            'sizes': [
+              640,
+              480
+            ]
+          },
+          'sponsoredBy': {
+            'required': false
+          },
+          'body': {
+            'required': false
+          },
+          'clickUrl': {
+            'required': false
+          },
+          'displayUrl': {
+            'required': false
+          }
+        },
+        'ext': {
+          'instl': 0,
+          'gpid': 'native-INS_b1b1269f-9570-fe3c-9bf4-f187827ec94a',
+          'data': {
+            'pbadslot': 'native-INS_b1b1269f-9570-fe3c-9bf4-f187827ec94a'
+          }
+        },
+        'floors': {
+          'native': {
+            '*': { 'currency': 'USD', 'floor': 1 }
+          }
+        },
+        'id': '16e0c8982318f91'
+      }
+    ],
+    'ext': {
+      'cur': 'USD',
+      'bidder': 'admatic'
+    }
+  } ];
+  let bidderRequest = {
+    'refererInfo': {
+      'page': 'https://www.admatic.com.tr',
+      'domain': 'https://www.admatic.com.tr',
+    },
+    'bidder': 'admatic',
+    'params': {
+      'networkId': 10433394,
+      'host': 'layer.serve.admatic.com.tr'
+    },
+    'ortb2Imp': { 'ext': { 'instl': 1 } },
+    'ortb2': { 'badv': ['admatic.com.tr'] },
+    'mediaTypes': {
+      'banner': {
+        'sizes': [[300, 250], [728, 90]]
+      },
+      'native': {
+      },
+      'video': {
+        'playerSize': [
+          336,
+          280
+        ]
+      }
+    },
+    'userId': {
+      'id5id': {
+        'uid': '0',
+        'ext': {
+          'linkType': 0,
+          'pba': 'wMh3sAXcnhDq7CfSa6ji1g=='
+        }
+      },
+      'pubcid': '5a49273f-a424-454b-b478-169c3551aa72'
+    },
+    'userIdAsEids': [
+      {
+        'source': 'id5-sync.com',
+        'uids': [
+          {
+            'id': '0',
+            'atype': 1,
+            'ext': {
+              'linkType': 0,
+              'pba': 'wMh3sAXcnhDq7CfSa6ji1g=='
+            }
+          }
+        ]
+      },
+      {
+        'source': 'pubcid.org',
+        'uids': [
+          {
+            'id': '5a49273f-a424-454b-b478-169c3551aa72',
+            'atype': 1
+          }
+        ]
+      }
+    ],
+    getFloor: inputParams => {
+      if (inputParams.mediaType === BANNER && inputParams.size[0] === 300 && inputParams.size[1] === 250) {
+        return {
+          currency: 'USD',
+          floor: 1.0
+        };
+      } else if (inputParams.mediaType === BANNER && inputParams.size[0] === 728 && inputParams.size[1] === 90) {
+        return {
+          currency: 'USD',
+          floor: 2.0
+        };
+      } else if (inputParams.mediaType === VIDEO) {
+        return {
+          currency: 'USD',
+          floor: 1.0
+        };
+      } else if (inputParams.mediaType === NATIVE) {
+        return {
+          currency: 'USD',
+          floor: 1.0
+        };
+      } else {
+        return {}
+      }
+    },
+    'schain': {
+      'ver': '1.0',
+      'complete': 1,
+      'nodes': [
+        {
+          'asi': 'pixad.com.tr',
+          'sid': 'px-pub-3000856707',
+          'hp': 1
+        }
+      ]
+    },
+    'at': 1,
+    'tmax': 1000,
+    'user': {
+      'ext': {
+        'eids': [
+          {
+            'source': 'id5-sync.com',
+            'uids': [
+              {
+                'id': '0',
+                'atype': 1,
+                'ext': {
+                  'linkType': 0,
+                  'pba': 'wMh3sAXcnhDq7CfSa6ji1g=='
+                }
+              }
+            ]
+          },
+          {
+            'source': 'pubcid.org',
+            'uids': [
+              {
+                'id': '5a49273f-a424-454b-b478-169c3551aa72',
+                'atype': 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    'ortb': {
+      'source': {},
+      'site': {
+        'domain': 'localhost:8888',
+        'publisher': {
+          'domain': 'localhost:8888'
+        },
+        'page': 'http://localhost:8888/',
+        'name': 'http://localhost:8888'
+      },
+      'badv': [],
+      'bcat': [],
+      'device': {
+        'w': 896,
+        'h': 979,
+        'dnt': 0,
+        'ua': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
+        'language': 'tr',
+        'sua': {
+          'source': 1,
+          'platform': {
+            'brand': 'macOS'
+          },
+          'browsers': [
+            {
+              'brand': 'Google Chrome',
+              'version': [
+                '119'
+              ]
+            },
+            {
+              'brand': 'Chromium',
+              'version': [
+                '119'
+              ]
+            },
+            {
+              'brand': 'Not?A_Brand',
+              'version': [
+                '24'
+              ]
+            }
+          ],
+          'mobile': 0
+        }
+      }
+    },
+    'site': {
+      'page': 'http://localhost:8888/admatic.html',
+      'ref': 'http://localhost:8888',
+      'publisher': {
+        'name': 'localhost',
+        'publisherId': 12321312
+      }
+    },
+    'imp': [
+      {
+        'size': [
+          {
+            'w': 300,
+            'h': 250
+          },
+          {
+            'w': 728,
+            'h': 90
+          }
+        ],
+        'id': '2205da7a81846b',
+        'mediatype': {},
+        'type': 'banner',
+        'floors': {
+          'banner': {
+            '300x250': { 'currency': 'USD', 'floor': 1 },
+            '728x90': { 'currency': 'USD', 'floor': 2 }
+          }
+        }
+      },
+      {
+        'size': [
+          {
+            'w': 338,
+            'h': 280
+          }
+        ],
+        'type': 'video',
+        'mediatype': {
+          'context': 'instream',
+          'mimes': [
+            'video/mp4'
+          ],
+          'maxduration': 240,
+          'api': [
+            1,
+            2
+          ],
+          'playerSize': [
+            [
+              338,
+              280
+            ]
+          ],
+          'protocols': [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8
+          ],
+          'skip': 1,
+          'playbackmethod': [
+            2
+          ],
+          'linearity': 1,
+          'placement': 2
+        },
+        'floors': {
+          'video': {
+            '338x280': { 'currency': 'USD', 'floor': 1 }
+          }
+        },
+        'id': '45e86fc7ce7fc93'
+      },
+      {
+        'size': [
+          {
+            'w': 1,
+            'h': 1
+          }
+        ],
+        'type': 'native',
+        'mediatype': {
+          'title': {
+            'required': true,
+            'len': 120
+          },
+          'image': {
+            'required': true
+          },
+          'icon': {
+            'required': false,
+            'sizes': [
+              640,
+              480
+            ]
+          },
+          'sponsoredBy': {
+            'required': false
+          },
+          'body': {
+            'required': false
+          },
+          'clickUrl': {
+            'required': false
+          },
+          'displayUrl': {
+            'required': false
+          }
+        },
+        'ext': {
+          'instl': 0,
+          'gpid': 'native-INS_b1b1269f-9570-fe3c-9bf4-f187827ec94a',
+          'data': {
+            'pbadslot': 'native-INS_b1b1269f-9570-fe3c-9bf4-f187827ec94a'
+          }
+        },
+        'floors': {
+          'native': {
+            '*': { 'currency': 'USD', 'floor': 1 }
+          }
+        },
+        'id': '16e0c8982318f91'
+      }
+    ],
+    'ext': {
+      'cur': 'USD',
+      'bidder': 'admatic'
+    }
+  };
 
   describe('inherited functions', () => {
     it('exists and is a function', () => {
@@ -51,353 +592,147 @@ describe('admaticBidAdapter', () => {
 
   describe('buildRequests', function () {
     it('sends bid request to ENDPOINT via POST', function () {
-      let validRequest = [ {
-        'refererInfo': {
-          'page': 'https://www.admatic.com.tr',
-          'domain': 'https://www.admatic.com.tr',
-        },
-        'bidder': 'admatic',
-        'params': {
-          'networkId': 10433394,
-          'host': 'layer.serve.admatic.com.tr'
-        },
-        'ortb2Imp': { 'ext': { 'instl': 1 } },
-        'ortb2': { 'badv': ['admatic.com.tr'] },
-        'mediaTypes': {
-          'banner': {
-            'sizes': [[300, 250], [728, 90]]
-          }
-        },
-        getFloor: inputParams => {
-          if (inputParams.mediaType === BANNER && inputParams.size[0] === 300 && inputParams.size[1] === 250) {
-            return {
-              currency: 'USD',
-              floor: 1.0
-            };
-          } else if (inputParams.mediaType === BANNER && inputParams.size[0] === 728 && inputParams.size[1] === 90) {
-            return {
-              currency: 'USD',
-              floor: 2.0
-            };
-          } else {
-            return {}
-          }
-        },
-        'user': {
-          'ua': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36'
-        },
-        'blacklist': [],
-        'site': {
-          'page': 'http://localhost:8888/admatic.html',
-          'ref': 'http://localhost:8888',
-          'publisher': {
-            'name': 'localhost',
-            'publisherId': 12321312
-          }
-        },
-        'imp': [
-          {
-            'size': [
-              {
-                'w': 300,
-                'h': 250
-              },
-              {
-                'w': 728,
-                'h': 90
-              }
-            ],
-            'mediatype': {},
-            'type': 'banner',
-            'id': '2205da7a81846b',
-            'floors': {
-              'banner': {
-                '300x250': { 'currency': 'USD', 'floor': 1 },
-                '728x90': { 'currency': 'USD', 'floor': 2 }
-              }
-            }
-          },
-          {
-            'size': [
-              {
-                'w': 338,
-                'h': 280
-              }
-            ],
-            'type': 'video',
-            'mediatype': {
-              'context': 'instream',
-              'mimes': [
-                'video/mp4'
-              ],
-              'maxduration': 240,
-              'api': [
-                1,
-                2
-              ],
-              'playerSize': [
-                [
-                  338,
-                  280
-                ]
-              ],
-              'protocols': [
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7,
-                8
-              ],
-              'skip': 1,
-              'playbackmethod': [
-                2
-              ],
-              'linearity': 1,
-              'placement': 2
-            },
-            'id': '45e86fc7ce7fc93'
-          },
-          {
-            'size': [
-              {
-                'w': 1,
-                'h': 1
-              }
-            ],
-            'type': 'native',
-            'mediatype': {
-              'title': {
-                'required': true,
-                'len': 120
-              },
-              'image': {
-                'required': true
-              },
-              'icon': {
-                'required': false,
-                'sizes': [
-                  640,
-                  480
-                ]
-              },
-              'sponsoredBy': {
-                'required': false
-              },
-              'body': {
-                'required': false
-              },
-              'clickUrl': {
-                'required': false
-              },
-              'displayUrl': {
-                'required': false
-              }
-            },
-            'ext': {
-              'instl': 0,
-              'gpid': 'native-INS_b1b1269f-9570-fe3c-9bf4-f187827ec94a',
-              'data': {
-                'pbadslot': 'native-INS_b1b1269f-9570-fe3c-9bf4-f187827ec94a'
-              }
-            },
-            'id': '16e0c8982318f91'
-          }
-        ],
-        'ext': {
-          'cur': 'USD',
-          'bidder': 'admatic'
-        }
-      } ];
-      let bidderRequest = {
-        'refererInfo': {
-          'page': 'https://www.admatic.com.tr',
-          'domain': 'https://www.admatic.com.tr',
-        },
-        'bidder': 'admatic',
-        'params': {
-          'networkId': 10433394,
-          'host': 'layer.serve.admatic.com.tr'
-        },
-        'ortb2Imp': { 'ext': { 'instl': 1 } },
-        'ortb2': { 'badv': ['admatic.com.tr'] },
-        'mediaTypes': {
-          'banner': {
-            'sizes': [[300, 250], [728, 90]]
-          }
-        },
-        getFloor: inputParams => {
-          if (inputParams.mediaType === BANNER && inputParams.size[0] === 300 && inputParams.size[1] === 250) {
-            return {
-              currency: 'USD',
-              floor: 1.0
-            };
-          } else if (inputParams.mediaType === BANNER && inputParams.size[0] === 728 && inputParams.size[1] === 90) {
-            return {
-              currency: 'USD',
-              floor: 2.0
-            };
-          } else {
-            return {}
-          }
-        },
-        'user': {
-          'ua': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36'
-        },
-        'blacklist': [],
-        'site': {
-          'page': 'http://localhost:8888/admatic.html',
-          'ref': 'http://localhost:8888',
-          'publisher': {
-            'name': 'localhost',
-            'publisherId': 12321312
-          }
-        },
-        'imp': [
-          {
-            'size': [
-              {
-                'w': 300,
-                'h': 250
-              },
-              {
-                'w': 728,
-                'h': 90
-              }
-            ],
-            'id': '2205da7a81846b',
-            'mediatype': {},
-            'type': 'banner',
-            'floors': {
-              'banner': {
-                '300x250': { 'currency': 'USD', 'floor': 1 },
-                '728x90': { 'currency': 'USD', 'floor': 2 }
-              }
-            }
-          },
-          {
-            'size': [
-              {
-                'w': 338,
-                'h': 280
-              }
-            ],
-            'type': 'video',
-            'mediatype': {
-              'context': 'instream',
-              'mimes': [
-                'video/mp4'
-              ],
-              'maxduration': 240,
-              'api': [
-                1,
-                2
-              ],
-              'playerSize': [
-                [
-                  338,
-                  280
-                ]
-              ],
-              'protocols': [
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7,
-                8
-              ],
-              'skip': 1,
-              'playbackmethod': [
-                2
-              ],
-              'linearity': 1,
-              'placement': 2
-            },
-            'id': '45e86fc7ce7fc93'
-          },
-          {
-            'size': [
-              {
-                'w': 1,
-                'h': 1
-              }
-            ],
-            'type': 'native',
-            'mediatype': {
-              'title': {
-                'required': true,
-                'len': 120
-              },
-              'image': {
-                'required': true
-              },
-              'icon': {
-                'required': false,
-                'sizes': [
-                  640,
-                  480
-                ]
-              },
-              'sponsoredBy': {
-                'required': false
-              },
-              'body': {
-                'required': false
-              },
-              'clickUrl': {
-                'required': false
-              },
-              'displayUrl': {
-                'required': false
-              }
-            },
-            'ext': {
-              'instl': 0,
-              'gpid': 'native-INS_b1b1269f-9570-fe3c-9bf4-f187827ec94a',
-              'data': {
-                'pbadslot': 'native-INS_b1b1269f-9570-fe3c-9bf4-f187827ec94a'
-              }
-            },
-            'id': '16e0c8982318f91'
-          }
-        ],
-        'ext': {
-          'cur': 'USD',
-          'bidder': 'admatic'
-        }
-      };
       const request = spec.buildRequests(validRequest, bidderRequest);
       expect(request.url).to.equal(ENDPOINT);
       expect(request.method).to.equal('POST');
     });
 
+    it('should not populate GDPR if for non-EEA users', function () {
+      let bidRequest = Object.assign([], validRequest);
+      const request = spec.buildRequests(
+        bidRequest,
+        Object.assign({}, bidderRequest, {
+          gdprConsent: {
+            gdprApplies: true,
+            consentString: 'BOJ8RZsOJ8RZsABAB8AAAAAZ+A=='
+          }
+        })
+      );
+      expect(request.data.regs.ext.gdpr).to.equal(1);
+      expect(request.data.regs.ext.consent).to.equal('BOJ8RZsOJ8RZsABAB8AAAAAZ-A');
+    });
+
+    it('should populate GDPR and empty consent string if available for EEA users without consent string but with consent', function () {
+      let bidRequest = Object.assign([], validRequest);
+      const request = spec.buildRequests(
+        bidRequest,
+        Object.assign({}, bidderRequest, {
+          gdprConsent: {
+            gdprApplies: true
+          }
+        })
+      );
+      expect(request.data.regs.ext.gdpr).to.equal(1);
+      expect(request.data.regs.ext.consent).to.equal('');
+    });
+
+    it('should properly build a request when coppa flag is true', function () {
+      let bidRequest = Object.assign([], validRequest);
+      const request = spec.buildRequests(
+        bidRequest,
+        Object.assign({}, bidderRequest, {
+          coppa: true
+        })
+      );
+      expect(request.data.regs.ext.coppa).to.not.be.undefined;
+      expect(request.data.regs.ext.coppa).to.equal(1);
+    });
+
+    it('should properly build a request with gpp consent field', function () {
+      let bidRequest = Object.assign([], validRequest);
+      const ortb2 = {
+        regs: {
+          gpp: 'gpp_consent_string',
+          gpp_sid: [0, 1, 2]
+        }
+      };
+      const request = spec.buildRequests(bidRequest, { ...bidderRequest, ortb2 });
+      expect(request.data.regs.ext.gpp).to.equal('gpp_consent_string');
+      expect(request.data.regs.ext.gpp_sid).to.deep.equal([0, 1, 2]);
+    });
+
+    it('should properly build a request with ccpa consent field', function () {
+      let bidRequest = Object.assign([], validRequest);
+      const request = spec.buildRequests(
+        bidRequest,
+        Object.assign({}, bidderRequest, {
+          uspConsent: '1---'
+        })
+      );
+      expect(request.data.regs.ext.uspIab).to.not.be.null;
+      expect(request.data.regs.ext.uspIab).to.equal('1---');
+    });
+
+    it('should properly forward eids', function () {
+      const bidRequests = [
+        {
+          bidder: 'admatic',
+          adUnitCode: 'bid-123',
+          transactionId: 'transaction-123',
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
+          userIdAsEids: [
+            {
+              source: 'admatic.com.tr',
+              uids: [{
+                id: 'abc',
+                atype: 1
+              }]
+            }
+          ],
+          params: {}
+        },
+      ];
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const ortbRequest = request.data;
+      expect(ortbRequest.user.ext.eids).to.deep.equal([
+        {
+          source: 'admatic.com.tr',
+          uids: [{
+            id: 'abc',
+            atype: 1
+          }]
+        }
+      ]);
+    });
+
     it('should properly build a banner request with floors', function () {
-      let bidRequests = [
+      const request = spec.buildRequests(validRequest, bidderRequest);
+      request.data.imp[0].floors = {
+        'banner': {
+          '300x250': { 'currency': 'USD', 'floor': 1 },
+          '728x90': { 'currency': 'USD', 'floor': 2 }
+        }
+      };
+    });
+
+    it('should properly build a video request with several player sizes with floors', function () {
+      const bidRequests = [
         {
           'bidder': 'admatic',
-          'params': {
-            'networkId': 10433394,
-            'host': 'layer.serve.admatic.com.tr'
-          },
+          'adUnitCode': 'bid-123',
+          'transactionId': 'transaction-123',
           'mediaTypes': {
-            'banner': {
-              'sizes': [[300, 250], [728, 90]]
+            'video': {
+              'playerSize': [[300, 250], [728, 90]]
             }
           },
           'ortb2Imp': { 'ext': { 'instl': 1 } },
           'ortb2': { 'badv': ['admatic.com.tr'] },
+          'params': {
+            'networkId': 10433394,
+            'host': 'layer.serve.admatic.com.tr'
+          },
           getFloor: inputParams => {
-            if (inputParams.mediaType === BANNER && inputParams.size[0] === 300 && inputParams.size[1] === 250) {
+            if (inputParams.mediaType === VIDEO && inputParams.size[0] === 300 && inputParams.size[1] === 250) {
               return {
                 currency: 'USD',
                 floor: 1.0
               };
-            } else if (inputParams.mediaType === BANNER && inputParams.size[0] === 728 && inputParams.size[1] === 90) {
+            } else if (inputParams.mediaType === VIDEO && inputParams.size[0] === 728 && inputParams.size[1] === 90) {
               return {
                 currency: 'USD',
                 floor: 2.0
@@ -408,37 +743,50 @@ describe('admaticBidAdapter', () => {
           }
         },
       ];
-      let bidderRequest = {
+      const bidderRequest = {
         'refererInfo': {
           'page': 'https://www.admatic.com.tr',
           'domain': 'https://www.admatic.com.tr',
-        },
-        'bidder': 'admatic',
-        'params': {
-          'networkId': 10433394,
-          'host': 'layer.serve.admatic.com.tr'
-        },
-        'ortb2Imp': { 'ext': { 'instl': 1 } },
-        'ortb2': { 'badv': ['admatic.com.tr'] },
-        'adUnitCode': 'adunit-code',
-        'sizes': [[300, 250], [728, 90]],
-        'bidId': '30b31c1838de1e',
-        'bidderRequestId': '22edbae2733bf6',
-        'auctionId': '1d1a030790a475',
-        'creativeId': 'er2ee',
-        'mediaTypes': {
-          'banner': {
-            'sizes': [[300, 250], [728, 90]]
-          }
         }
       };
       const request = spec.buildRequests(bidRequests, bidderRequest);
-      request.data.imp[0].floors = {
-        'banner': {
-          '300x250': { 'currency': 'USD', 'floor': 1 },
-          '728x90': { 'currency': 'USD', 'floor': 2 }
+    });
+
+    it('should properly build a native request with floors', function () {
+      const bidRequests = [
+        {
+          'bidder': 'admatic',
+          'adUnitCode': 'bid-123',
+          'transactionId': 'transaction-123',
+          'mediaTypes': {
+            'native': {
+            }
+          },
+          'ortb2Imp': { 'ext': { 'instl': 1 } },
+          'ortb2': { 'badv': ['admatic.com.tr'] },
+          'params': {
+            'networkId': 10433394,
+            'host': 'layer.serve.admatic.com.tr'
+          },
+          getFloor: inputParams => {
+            if (inputParams.mediaType === NATIVE) {
+              return {
+                currency: 'USD',
+                floor: 1.0
+              };
+            } else {
+              return {}
+            }
+          }
+        },
+      ];
+      const bidderRequest = {
+        'refererInfo': {
+          'page': 'https://www.admatic.com.tr',
+          'domain': 'https://www.admatic.com.tr',
         }
       };
+      const request = spec.buildRequests(bidRequests, bidderRequest);
     });
   });
 
@@ -495,7 +843,7 @@ describe('admaticBidAdapter', () => {
             'mime_type': 'iframe',
             'bidder': 'admatic',
             'adomain': ['admatic.com.tr'],
-            'party_tag': '{"native":{"ver":"1.1","assets":[{"id":1,"title":{"text":"title"}},{"id":4,"data":{"value":"body"}},{"id":5,"data":{"value":"sponsored"}},{"id":2,"img":{"url":"https://www.admatic.com.tr","w":1200,"h":628}},{"id":3,"img":{"url":"https://www.admatic.com.tr","w":640,"h":480}}],"link":{"url":"https://www.admatic.com.tr"},"imptrackers":["https://www.admatic.com.tr"]}}',
+            'party_tag': '{"native":{"ver":"1.1","assets":[{"id":1,"title":{"text":"title"}},{"id":4,"data":{"value":"body"}},{"id":5,"data":{"value":"sponsored"}},{"id":6,"data":{"value":"cta"}},{"id":2,"img":{"url":"https://www.admatic.com.tr","w":1200,"h":628}},{"id":3,"img":{"url":"https://www.admatic.com.tr","w":640,"h":480}}],"link":{"url":"https://www.admatic.com.tr"},"imptrackers":["https://www.admatic.com.tr"]}}',
             'iurl': 'https://www.admatic.com.tr'
           }
         ],
@@ -571,6 +919,7 @@ describe('admaticBidAdapter', () => {
             'title': 'title',
             'body': 'body',
             'sponsoredBy': 'sponsored',
+            'cta': 'cta',
             'image': {
               'url': 'https://www.admatic.com.tr',
               'width': 1200,

--- a/test/spec/modules/admixerBidAdapter_spec.js
+++ b/test/spec/modules/admixerBidAdapter_spec.js
@@ -4,11 +4,12 @@ import {newBidder} from 'src/adapters/bidderFactory.js';
 import {config} from '../../../src/config.js';
 
 const BIDDER_CODE = 'admixer';
-const BIDDER_CODE_ADX = 'admixeradx';
+const WL_BIDDER_CODE = 'admixerwl'
 const ENDPOINT_URL = 'https://inv-nets.admixer.net/prebid.1.2.aspx';
 const ENDPOINT_URL_CUSTOM = 'https://custom.admixer.net/prebid.aspx';
-const ENDPOINT_URL_ADX = 'https://inv-nets.admixer.net/adxprebid.1.2.aspx';
 const ZONE_ID = '2eb6bd58-865c-47ce-af7f-a918108c3fd2';
+const CLIENT_ID = 5124;
+const ENDPOINT_ID = 81264;
 
 describe('AdmixerAdapter', function () {
   const adapter = newBidder(spec);
@@ -36,8 +37,27 @@ describe('AdmixerAdapter', function () {
       auctionId: '1d1a030790a475',
     };
 
+    let wlBid = {
+      bidder: WL_BIDDER_CODE,
+      params: {
+        clientId: CLIENT_ID,
+        endpointId: ENDPOINT_ID,
+      },
+      adUnitCode: 'adunit-code',
+      sizes: [
+        [300, 250],
+        [300, 600],
+      ],
+      bidId: '30b31c1838de1e',
+      bidderRequestId: '22edbae2733bf6',
+      auctionId: '1d1a030790a475',
+    };
+
     it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+    it('should return true when params required by WL found', function () {
+      expect(spec.isBidRequestValid(wlBid)).to.equal(true);
     });
 
     it('should return false when required params are not passed', function () {
@@ -47,6 +67,14 @@ describe('AdmixerAdapter', function () {
         placementId: 0,
       };
       expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+    it('should return false when params required by WL are not passed', function () {
+      let wlBid = Object.assign({}, wlBid);
+      delete wlBid.params;
+      wlBid.params = {
+        clientId: 0,
+      };
+      expect(spec.isBidRequestValid(wlBid)).to.equal(false);
     });
   });
 
@@ -105,7 +133,10 @@ describe('AdmixerAdapter', function () {
       validRequest: [
         {
           bidder: bidder,
-          params: {
+          params: bidder === 'admixerwl' ? {
+            clientId: CLIENT_ID,
+            endpointId: ENDPOINT_ID
+          } : {
             zone: ZONE_ID,
           },
           adUnitCode: 'adunit-code',
@@ -166,6 +197,12 @@ describe('AdmixerAdapter', function () {
       const requestParams = requestParamsFor('admixeradx');
       const request = spec.buildRequests(requestParams.validRequest, requestParams.bidderRequest);
       expect(request.url).to.equal('https://inv-nets.admixer.net/adxprebid.1.2.aspx');
+      expect(request.method).to.equal('POST');
+    });
+    it('build request for admixerwl', function () {
+      const requestParams = requestParamsFor('admixerwl');
+      const request = spec.buildRequests(requestParams.validRequest, requestParams.bidderRequest);
+      expect(request.url).to.equal(`https://inv-nets-adxwl.admixer.com/adxwlprebid.aspx?client=${CLIENT_ID}`);
       expect(request.method).to.equal('POST');
     });
   });

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -42,7 +42,7 @@ describe('adnuntiusBidAdapter', function() {
   const ENDPOINT_URL_VIDEO = `${ENDPOINT_URL_BASE}&userId=${usi}&tt=vast4`;
   const ENDPOINT_URL_NOCOOKIE = `${ENDPOINT_URL_BASE}&userId=${usi}&noCookies=true`;
   const ENDPOINT_URL_SEGMENTS = `${ENDPOINT_URL_BASE}&segments=segment1,segment2,segment3&userId=${usi}`;
-  const ENDPOINT_URL_CONSENT = `${EURO_URL}${tzo}&format=json&consentString=consentString&userId=${usi}`;
+  const ENDPOINT_URL_CONSENT = `${EURO_URL}${tzo}&format=json&consentString=consentString&gdpr=1&userId=${usi}`;
   const adapter = newBidder(spec);
 
   const bidderRequests = [
@@ -909,6 +909,7 @@ describe('adnuntiusBidAdapter', function() {
         ]
       };
       serverResponse.body.adUnits[0].deals = [];
+      delete serverResponse.body.metaData.voidAuIds; // test response with no voidAuIds
 
       const interpretedResponse = spec.interpretResponse(serverResponse, altBidder);
       expect(interpretedResponse).to.have.lengthOf(0);

--- a/test/spec/modules/ampliffyBidAdapter_spec.js
+++ b/test/spec/modules/ampliffyBidAdapter_spec.js
@@ -1,0 +1,453 @@
+import {
+  parseXML,
+  isAllowedToBidUp,
+  spec,
+  getDefaultParams,
+  mergeParams,
+  paramsToQueryString, setCurrentURL
+} from 'modules/ampliffyBidAdapter.js';
+import {expect} from 'chai';
+import {BANNER, VIDEO} from 'src/mediaTypes';
+import {newBidder} from 'src/adapters/bidderFactory';
+
+describe('Ampliffy bid adapter Test', function () {
+  const adapter = newBidder(spec);
+
+  describe('inherited functions', function () {
+    it('exists and is a function', function () {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+  });
+  // Global definitions for all tests
+  const xmlStr = `<?xml version="1.0" encoding="UTF-8"?>
+                  <Ads type="video">
+                    <Companion id="138316138683">
+                      <HTMLResource><![CDATA[
+                              <ad cpmMap=\'{"ES":".23","MX":".13"}\'
+                                  cpmCurrency=\'USD\'
+                                  creativeMap=\'{"https://bidder.ampliffy.com/gampad/ads?adName=6463aa7b7f147.xml":["ES","MX"]}\'
+                                  domainMap=\'["testSports.com","sports.com"]\'
+                                  excludedURLs=\'["www.no-allowed.com/busqueda/sexo/sexo"]\' />
+                              ]]>
+                      </HTMLResource>
+                    </Companion>
+                    <VASTAdTagURI><![CDATA[http://localhost:8080?adurl=https://es.ampliffy.com/%3FgeoData%26ct%3DES%26st%3D%26city%3D0%26dma%3D0%26zp%3D08192%26bw%3D4]]></VASTAdTagURI>
+                    <Extensions><Extension type="geo"><Country>ES</Country></Extension></Extensions>
+                  </Ads>`;
+  const xml = new window.DOMParser().parseFromString(xmlStr, 'text/xml');
+  let companion = xml.getElementsByTagName('Companion')[0];
+  let htmlResource = companion.getElementsByTagName('HTMLResource')[0];
+  let htmlContent = document.createElement('html');
+  htmlContent.innerHTML = htmlResource.textContent;
+
+  describe('Is allowed to bid up', function () {
+    it('Should return true using a URL that is in domainMap', () => {
+      let allowedToBidUp = isAllowedToBidUp(htmlContent, 'https://testSports.com?id=131313&text=aaaaa&foo=foo');
+      expect(allowedToBidUp).to.be.true;
+    })
+
+    it('Should return false using an url that is not in domainMap', () => {
+      let allowedToBidUp = isAllowedToBidUp(htmlContent, 'https://test.com');
+      expect(allowedToBidUp).to.be.false;
+    })
+
+    it('Should return false using an url that is excluded.', () => {
+      let allowedToBidUp = isAllowedToBidUp(htmlContent, 'https://www.no-allowed.com/busqueda/sexo/sexo?test=1#item1');
+      expect(allowedToBidUp).to.be.false;
+    })
+  })
+
+  describe('Helper functions', function () {
+    it('Should default params not to be null', () => {
+      const defaultParams = getDefaultParams();
+
+      expect(defaultParams).not.to.be.null;
+    })
+    it('Should the merge two object params into a new object', () => {
+      const params1 = {
+        'hello': 'world',
+        'ampTest': 'this will be replaced'
+      }
+      const params2 = {
+        'test': 1,
+        'ampTest': 'This will be replace the param with the same name in other array'
+      }
+      const allParams = mergeParams(params1, params2);
+
+      const paramsComplete =
+        {
+          'hello': 'world',
+          'ampTest': 'This will be replace the param with the same name in other array',
+          'test': 1,
+        }
+      expect(allParams).not.to.be.null;
+      expect(JSON.stringify(allParams)).to.equal(JSON.stringify(paramsComplete));
+    })
+    it('Params to QueryString', () => {
+      const params = {
+        'test': 1,
+        'ampTest': 'ret',
+        'empty': null,
+        'quoteMark': '?',
+        'test1': undefined
+      }
+      const queryString = paramsToQueryString(params);
+
+      expect(queryString).not.to.be.null;
+      expect(queryString).to.equal('test=1&ampTest=ret&empty&quoteMark=%3F');
+    })
+  })
+
+  describe('isBidRequestValid', function () {
+    it('Should return true when required params found', function () {
+      const bidRequest = {
+        bidder: 'ampliffy',
+        params: {
+          server: 'bidder.ampliffy.com',
+          placementId: 1235465798,
+          format: 'all'
+        },
+        mediaTypes: {
+          banner: {
+            sizes: [1, 1]
+          }
+        },
+      }
+      expect(spec.isBidRequestValid(bidRequest)).to.be.true;
+    })
+    it('Should return false when param format is display but mediaTypes are for video', function () {
+      const bidRequest = {
+        bidder: 'ampliffy',
+        params: {
+          server: 'bidder.ampliffy.com',
+          placementId: 1235465798,
+          format: 'display'
+        },
+        mediaTypes: {
+          video: {
+            sizes: [1, 1]
+          }
+        },
+      }
+      expect(spec.isBidRequestValid(bidRequest)).to.be.false;
+    })
+    it('Should return false when param format is video but mediaTypes are for banner', function () {
+      const bidRequest = {
+        bidder: 'ampliffy',
+        params: {
+          server: 'bidder.ampliffy.com',
+          placementId: 1235465798,
+          format: 'video'
+        },
+        mediaTypes: {
+          banner: {
+            sizes: [1, 1]
+          }
+        },
+      }
+      expect(spec.isBidRequestValid(bidRequest)).to.be.false;
+    })
+    it('Should return true when param format is video and mediaTypes are for video', function () {
+      const bidRequest = {
+        bidder: 'ampliffy',
+        params: {
+          server: 'bidder.ampliffy.com',
+          placementId: 1235465798,
+          format: 'video'
+        },
+        mediaTypes: {
+          video: {
+            sizes: [1, 1]
+          }
+        },
+      }
+      expect(spec.isBidRequestValid(bidRequest)).to.be.true;
+    })
+    it('Should return true when param format is display and mediaTypes are for banner', function () {
+      const bidRequest = {
+        bidder: 'ampliffy',
+        params: {
+          server: 'bidder.ampliffy.com',
+          placementId: 1235465798,
+          format: 'display'
+        },
+        mediaTypes: {
+          banner: {
+            sizes: [1, 1]
+          }
+        },
+      }
+      expect(spec.isBidRequestValid(bidRequest)).to.be.true;
+    })
+    it('Should return true when param format is all and mediaTypes are for banner', function () {
+      const bidRequest = {
+        bidder: 'ampliffy',
+        params: {
+          server: 'bidder.ampliffy.com',
+          placementId: 1235465798,
+          format: 'all'
+        },
+        mediaTypes: {
+          banner: {
+            sizes: [1, 1]
+          }
+        },
+      }
+      expect(spec.isBidRequestValid(bidRequest)).to.be.true;
+    })
+    it('Should return true when param format is all and mediaTypes are for video', function () {
+      const bidRequest = {
+        bidder: 'ampliffy',
+        params: {
+          server: 'bidder.ampliffy.com',
+          placementId: 1235465798,
+          format: 'all'
+        },
+        mediaTypes: {
+          video: {
+            sizes: [1, 1]
+          }
+        },
+      }
+      expect(spec.isBidRequestValid(bidRequest)).to.be.true;
+    })
+    it('Should return false without placementId param', function () {
+      const bidRequest = {
+        bidder: 'ampliffy',
+        params: {}
+      }
+      expect(spec.isBidRequestValid(bidRequest)).to.be.false;
+    })
+    it('Should return false without param object', function () {
+      const bidRequest = {
+        bidder: 'ampliffy',
+      }
+      expect(spec.isBidRequestValid(bidRequest)).to.be.false;
+    })
+  });
+
+  describe('Build request function', function () {
+    const bidderRequest = {
+      'bidderCode': 'ampliffy',
+      'auctionId': 'c4a771bf-1791-4513-82b3-96c48d19ddff',
+      'bidderRequestId': '1134bdcbe47f25',
+      'bids': [{
+        'bidder': 'ampliffy',
+        'params': {
+          'placementId': 1235465798,
+          'type': 'bidder.',
+          'region': 'alan-development.k8s.',
+          'adnetwork': 'ampliffy.com',
+          'SERVER': 'bidder.ampliffy.com'
+        },
+        'crumbs': {'pubcid': '29844d69-c4e5-4b00-8602-6dd09815363a'},
+        'ortb2Imp': {'ext': {'data': {'pbadslot': 'video1'}}},
+        'mediaTypes': {
+          'video': {
+            'context': 'instream',
+            'playerSize': [[640, 480]],
+            'mimes': ['video/mp4'],
+            'protocols': [1, 2, 3, 4, 5, 6, 7, 8],
+            'playbackmethod': [2],
+            'skip': 1
+          }
+        },
+        'adUnitCode': 'video1',
+        'transactionId': 'f85c1b10-bad3-4c3f-a2bb-2c484c405bc9',
+        'sizes': [[640, 480]],
+        'bidId': '2bc71d9c058842',
+        'bidderRequestId': '1134bdcbe47f25',
+        'auctionId': 'c4a771bf-1791-4513-82b3-96c48d19ddff',
+        'src': 'client',
+        'bidRequestsCount': 1,
+        'bidderRequestsCount': 1,
+        'bidderWinsCount': 0
+      }],
+      'auctionStart': 1644029483655,
+      'timeout': 3000,
+      'refererInfo': {
+        'referer': 'http://localhost:9999/integrationExamples/gpt/hello_world_video.html?pbjs_debug=true',
+        'reachedTop': true,
+        'isAmp': false,
+        'numIframes': 0,
+        'stack': ['http://localhost:9999/integrationExamples/gpt/hello_world_video.html?pbjs_debug=true'],
+        'canonicalUrl': null
+      },
+      'start': 1644029483708
+    }
+    const validBidRequests = [
+      {
+        'bidder': 'ampliffy',
+        'params': {
+          'placementId': 1235465798,
+          'type': 'bidder.',
+          'region': 'alan-development.k8s.',
+          'adnetwork': 'ampliffy.com',
+          'SERVER': 'bidder.ampliffy.com'
+        },
+        'crumbs': {'pubcid': '29844d69-c4e5-4b00-8602-6dd09815363a'},
+        'ortb2Imp': {'ext': {'data': {'pbadslot': 'video1'}}},
+        'mediaTypes': {
+          'video': {
+            'context': 'instream',
+            'playerSize': [[640, 480]],
+            'mimes': ['video/mp4'],
+            'protocols': [1, 2, 3, 4, 5, 6, 7, 8],
+            'playbackmethod': [2],
+            'skip': 1
+          }
+        },
+        'adUnitCode': 'video1',
+        'transactionId': 'f85c1b10-bad3-4c3f-a2bb-2c484c405bc9',
+        'sizes': [[640, 480]],
+        'bidId': '2bc71d9c058842',
+        'bidderRequestId': '1134bdcbe47f25',
+        'auctionId': 'c4a771bf-1791-4513-82b3-96c48d19ddff',
+        'src': 'client',
+        'bidRequestsCount': 1,
+        'bidderRequestsCount': 1,
+        'bidderWinsCount': 0
+      }
+    ];
+    it('Should return one or more bid requests', function () {
+      expect(spec.buildRequests(validBidRequests, bidderRequest).length).to.be.greaterThan(0);
+    });
+  })
+  describe('Interpret response', function () {
+    let bidRequest = {
+      bidRequest: {
+        adUnitCode: 'div-gpt-ad-1460505748561-0',
+        auctionId: '469bb2e2-351f-4d01-b782-cdbca5e3e0ed',
+        bidId: '2d40b8dcd02ade',
+        bidRequestsCount: 1,
+        bidder: 'ampliffy',
+        bidderRequestId: '128c07edc4680f',
+        bidderRequestsCount: 1,
+        bidderWinsCount: 0,
+        crumbs: {
+          pubcid: '29844d69-c4e5-4b00-8602-6dd09815363a'
+        },
+        mediaTypes: {
+          banner: {
+            sizes: [
+              [300, 250],
+              [300, 600]
+            ]
+          }
+        },
+        ortb2Imp: {ext: {}},
+        params: {placementId: 13144370},
+        sizes: [
+          [300, 250],
+          [300, 600]
+        ],
+        src: 'client',
+        transactionId: '103b2b58-6ed1-45e9-9486-c942d6042e3'
+      },
+      data: {bidId: '2d40b8dcd02ade'},
+      method: 'GET',
+      url: 'https://test.com',
+    };
+
+    it('Should extract a CPM and currency from the xml', () => {
+      let cpmData = parseXML(xml);
+      expect(cpmData).to.not.be.a('null');
+      expect(cpmData.cpm).to.equal('.23');
+      expect(cpmData.currency).to.equal('USD');
+    });
+
+    it('It should return no ads when the CPM is less than zero.', () => {
+      const xmlStr1 = `<?xml version="1.0" encoding="UTF-8"?>
+                      <VAST xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vast.xsd" version="3.0">
+                      <Ad id="1">
+                       <Wrapper>
+                        <Companion id="138316138683" width="1" height="1">
+                          <HTMLResource>
+                            <![CDATA[<!doctype html>
+                              <html><head></head>
+                                <body>
+                                  <div class="GoogleActiveViewInnerContainer"></div>
+                                  <div>
+                                    <div data-vidco-metrics="0"
+                                    data-taxonomy-ampliffy="AMPP---000017"
+                                    data-taxonomy-creator=""
+                                    cpmMap=\'{"ES":"-1","MX":"0.0"}\'
+                                    cpmCurrency=\'{"ES":"USD","MX":"MXN"}\'></div>
+                                  </div>
+                                </body>
+                              </html>
+                            ]]>
+                          </HTMLResource>
+                        </Companion>
+                        <VASTAdTagURI><![CDATA[http://localhost:8080?adurl=https://es.ampliffy.com/%3FgeoData%26ct%3DES%26st%3D%26city%3D0%26dma%3D0%26zp%3D08192%26bw%3D4]]></VASTAdTagURI>
+                        <Extensions><Extension type="geo"><Country>ES</Country></Extension></Extensions>
+                        </Wrapper>
+                       </Ad>
+                      </VAST>`;
+      let serverResponse = {
+        'body': xmlStr1,
+      }
+      const bidResponses = spec.interpretResponse(serverResponse, bidRequest);
+      expect(bidResponses.length).to.equal(0);
+    })
+
+    it('It should return no ads when the creative url is not in the xml', () => {
+      const xmlStr1 = `<?xml version="1.0" encoding="UTF-8"?>
+                        <VAST xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vast.xsd" version="3.0">
+                         <Ad id="1">
+                          <Wrapper>
+                            <Companion id="138316138683" width="1" height="1">
+                            <HTMLResource>
+                              <![CDATA[<!doctype html><html>
+                                <head></head>
+                                <body>
+                                  <div class="GoogleActiveViewInnerContainer"></div>
+                                  <div style="display:inline">
+                                    <div data-title="Bidder test"
+                                    cpmMap=\'{"ES":".10","MX":"0"}\'
+                                    cpmCurrency=\'{"ES":"USD","MX":"MXN"}\'>
+                                  </div>
+                                </body>
+                              </html>]]>
+                            </HTMLResource>
+                          </Companion>
+                          <Extensions><Extension type="geo"><Country>ES</Country></Extension></Extensions>
+                          </Wrapper>
+                         </Ad>
+                        </VAST>`;
+      let serverResponse = {
+        'body': xmlStr1,
+      }
+      const bidResponses = spec.interpretResponse(serverResponse, bidRequest);
+      expect(bidResponses.length).to.equal(0);
+    })
+    it('It should return a banner ad.', () => {
+      let serverResponse = {
+        'body': xmlStr,
+      }
+      setCurrentURL('https://www.sports.com');
+      const bidResponses = spec.interpretResponse(serverResponse, bidRequest);
+      expect(bidResponses.length).greaterThan(0);
+      expect(bidResponses[0].mediaType).to.be.equal(BANNER);
+      expect(bidResponses[0].ad).not.to.be.null;
+    })
+    it('It should return a video ad.', () => {
+      let serverResponse = {
+        'body': xmlStr,
+      }
+      setCurrentURL('https://www.sports.com');
+      bidRequest.bidRequest.mediaTypes = {
+        video: {
+          sizes: [
+            [300, 250],
+            [300, 600]
+          ]
+        }
+      }
+      const bidResponses = spec.interpretResponse(serverResponse, bidRequest);
+      expect(bidResponses.length).greaterThan(0);
+      expect(bidResponses[0].mediaType).to.be.equal(VIDEO);
+      expect(bidResponses[0].vastUrl).not.to.be.null;
+    })
+  });
+});

--- a/test/spec/modules/amxBidAdapter_spec.js
+++ b/test/spec/modules/amxBidAdapter_spec.js
@@ -3,6 +3,7 @@ import { spec } from 'modules/amxBidAdapter.js';
 import { createEidsArray } from 'modules/userId/eids.js';
 import { BANNER, VIDEO } from 'src/mediaTypes.js';
 import { config } from 'src/config.js';
+import { server } from 'test/mocks/xhr.js';
 import * as utils from 'src/utils.js';
 
 const sampleRequestId = '82c91e127a9b93e';
@@ -11,7 +12,7 @@ const sampleDisplayCRID = '78827819';
 // minimal example vast
 const sampleVideoAd = (addlImpression) =>
   `
-<?xml version="1.0" encoding="UTF-8" ?><VAST version="2.0"><Ad id="128a6.44d74.46b3"><InLine><Error><![CDATA[http://example.net/hbx/verr?e=]]></Error><Impression><![CDATA[http://example.net/hbx/vimp?lid=test&aid=testapp]]></Impression><Creatives><Creative sequence="1"><Linear><Duration>00:00:15</Duration><TrackingEvents><Tracking event="firstQuartile"><![CDATA[https://example.com?event=first_quartile]]></Tracking></TrackingEvents><VideoClicks><ClickThrough><![CDATA[http://example.com]]></ClickThrough></VideoClicks><MediaFiles><MediaFile delivery="progressive" width="16" height="9" type="video/mp4" bitrate="800"><![CDATA[https://example.com/media.mp4]]></MediaFile></MediaFiles></Linear></Creative></Creatives>${addlImpression}</InLine></Ad></VAST>
+<?xml version='1.0' encoding='UTF-8' ?><VAST version='2.0'><Ad id='128a6.44d74.46b3'><InLine><Error><![CDATA[http://example.net/hbx/verr?e=]]></Error><Impression><![CDATA[http://example.net/hbx/vimp?lid=test&aid=testapp]]></Impression><Creatives><Creative sequence='1'><Linear><Duration>00:00:15</Duration><TrackingEvents><Tracking event='firstQuartile'><![CDATA[https://example.com?event=first_quartile]]></Tracking></TrackingEvents><VideoClicks><ClickThrough><![CDATA[http://example.com]]></ClickThrough></VideoClicks><MediaFiles><MediaFile delivery='progressive' width='16' height='9' type='video/mp4' bitrate='800'><![CDATA[https://example.com/media.mp4]]></MediaFile></MediaFiles></Linear></Creative></Creatives>${addlImpression}</InLine></Ad></VAST>
 `.replace(/\n+/g, '');
 
 const sampleFPD = {
@@ -37,7 +38,7 @@ const sampleBidderRequest = {
   },
   gppConsent: {
     gppString: 'example',
-    applicableSections: 'example'
+    applicableSections: 'example',
   },
 
   auctionId: null,
@@ -209,10 +210,12 @@ describe('AmxBidAdapter', () => {
   describe('getUserSync', () => {
     it('Will perform an iframe sync even if there is no server response..', () => {
       const syncs = spec.getUserSyncs({ iframeEnabled: true });
-      expect(syncs).to.eql([{
-        type: 'iframe',
-        url: 'https://prebid.a-mo.net/isyn?gdpr_consent=&gdpr=0&us_privacy=&gpp=&gpp_sid='
-      }]);
+      expect(syncs).to.eql([
+        {
+          type: 'iframe',
+          url: 'https://prebid.a-mo.net/isyn?gdpr_consent=&gdpr=0&us_privacy=&gpp=&gpp_sid=',
+        },
+      ]);
     });
 
     it('will return valid syncs from a server response', () => {
@@ -276,8 +279,13 @@ describe('AmxBidAdapter', () => {
     });
 
     it('will attach additional referrer info data', () => {
-      const { data } = spec.buildRequests([sampleBidRequestBase], sampleBidderRequest);
-      expect(data.ri.r).to.equal(sampleBidderRequest.refererInfo.topmostLocation);
+      const { data } = spec.buildRequests(
+        [sampleBidRequestBase],
+        sampleBidderRequest
+      );
+      expect(data.ri.r).to.equal(
+        sampleBidderRequest.refererInfo.topmostLocation
+      );
       expect(data.ri.t).to.equal(sampleBidderRequest.refererInfo.reachedTop);
       expect(data.ri.l).to.equal(sampleBidderRequest.refererInfo.numIframes);
       expect(data.ri.s).to.equal(sampleBidderRequest.refererInfo.stack);
@@ -315,7 +323,7 @@ describe('AmxBidAdapter', () => {
         [sampleBidRequestBase],
         sampleBidderRequest
       );
-      delete data.m; // don't deal with "m" in this test
+      delete data.m; // don't deal with 'm' in this test
       expect(data.gs).to.equal(sampleBidderRequest.gdprConsent.gdprApplies);
       expect(data.gc).to.equal(sampleBidderRequest.gdprConsent.consentString);
       expect(data.usp).to.equal(sampleBidderRequest.uspConsent);
@@ -343,10 +351,8 @@ describe('AmxBidAdapter', () => {
     });
 
     it('will attach sync configuration', () => {
-      const request = () => spec.buildRequests(
-        [sampleBidRequestBase],
-        sampleBidderRequest
-      );
+      const request = () =>
+        spec.buildRequests([sampleBidRequestBase], sampleBidderRequest);
 
       const setConfig = (filterSettings) =>
         config.setConfig({
@@ -355,56 +361,73 @@ describe('AmxBidAdapter', () => {
             syncDelay: 2300,
             syncEnabled: true,
             filterSettings,
-          }
+          },
         });
 
       const test = (filterSettings) => {
         setConfig(filterSettings);
         return request().data.sync;
-      }
+      };
 
       const base = { d: 2300, l: 2, e: true };
 
-      const tests = [[
-        undefined,
-        { ...base, t: 0 }
-      ], [{
-        image: {
-          bidders: '*',
-          filter: 'include'
-        },
-        iframe: {
-          bidders: '*',
-          filter: 'include'
-        }
-      }, { ...base, t: 3 }], [{
-        image: {
-          bidders: ['amx'],
-        },
-        iframe: {
-          bidders: '*',
-          filter: 'include'
-        }
-      }, { ...base, t: 3 }], [{
-        image: {
-          bidders: ['other'],
-        },
-        iframe: {
-          bidders: '*'
-        }
-      }, { ...base, t: 2 }], [{
-        image: {
-          bidders: ['amx']
-        },
-        iframe: {
-          bidders: ['amx'],
-          filter: 'exclude'
-        }
-      }, { ...base, t: 1 }]]
+      const tests = [
+        [undefined, { ...base, t: 0 }],
+        [
+          {
+            image: {
+              bidders: '*',
+              filter: 'include',
+            },
+            iframe: {
+              bidders: '*',
+              filter: 'include',
+            },
+          },
+          { ...base, t: 3 },
+        ],
+        [
+          {
+            image: {
+              bidders: ['amx'],
+            },
+            iframe: {
+              bidders: '*',
+              filter: 'include',
+            },
+          },
+          { ...base, t: 3 },
+        ],
+        [
+          {
+            image: {
+              bidders: ['other'],
+            },
+            iframe: {
+              bidders: '*',
+            },
+          },
+          { ...base, t: 2 },
+        ],
+        [
+          {
+            image: {
+              bidders: ['amx'],
+            },
+            iframe: {
+              bidders: ['amx'],
+              filter: 'exclude',
+            },
+          },
+          { ...base, t: 1 },
+        ],
+      ];
 
       for (let i = 0, l = tests.length; i < l; i++) {
         const [result, expected] = tests[i];
-        expect(test(result), `input: ${JSON.stringify(result)}`).to.deep.equal(expected);
+        expect(test(result), `input: ${JSON.stringify(result)}`).to.deep.equal(
+          expected
+        );
       }
     });
 
@@ -497,7 +520,15 @@ describe('AmxBidAdapter', () => {
 
     it('can build a video request', () => {
       const { data } = spec.buildRequests(
-        [{ ...sampleBidRequestVideo, params: { ...sampleBidRequestVideo.params, adUnitId: 'custom-auid' } }],
+        [
+          {
+            ...sampleBidRequestVideo,
+            params: {
+              ...sampleBidRequestVideo.params,
+              adUnitId: 'custom-auid',
+            },
+          },
+        ],
         sampleBidderRequest
       );
       expect(Object.keys(data.m).length).to.equal(1);
@@ -659,15 +690,49 @@ describe('AmxBidAdapter', () => {
     });
 
     it('will log an event for timeout', () => {
-      spec.onTimeout({
-        bidder: 'example',
-        bidId: 'test-bid-id',
-        adUnitCode: 'div-gpt-ad',
-        timeout: 300,
-        auctionId: utils.getUniqueIdentifierStr(),
+      // this will use sendBeacon..
+      spec.onTimeout([
+        {
+          bidder: 'example',
+          bidId: 'test-bid-id',
+          adUnitCode: 'div-gpt-ad',
+          ortb2: {
+            site: {
+              ref: 'https://example.com',
+            },
+          },
+          params: {
+            tagId: 'tag-id',
+          },
+          timeout: 300,
+          auctionId: utils.getUniqueIdentifierStr(),
+        },
+      ]);
+
+      const [request] = server.requests;
+      request.respond(204, {'Content-Type': 'text/html'}, null);
+      expect(request.url).to.equal('https://1x1.a-mo.net/e');
+
+      if (typeof Request !== 'undefined' && 'keepalive' in Request.prototype) {
+        expect(request.fetch.request.keepalive).to.equal(true);
+      }
+
+      const {c: common, e: events} = JSON.parse(request.requestBody)
+      expect(common).to.deep.equal({
+        V: '$prebid.version$',
+        vg: '$$PREBID_GLOBAL$$',
+        U: null,
+        re: 'https://example.com',
       });
-      expect(firedPixels.length).to.equal(1);
-      expect(firedPixels[0]).to.match(/\/hbx\/g_pbto/);
+
+      expect(events.length).to.equal(1);
+      const [event] = events;
+      expect(event.n).to.equal('g_pbto')
+      expect(event.A).to.equal('example');
+      expect(event.mid).to.equal('tag-id');
+      expect(event.cn).to.equal(300);
+      expect(event.bid).to.equal('test-bid-id');
+      expect(event.a).to.equal('div-gpt-ad');
     });
 
     it('will log an event for prebid win', () => {

--- a/test/spec/modules/browsiRtdProvider_spec.js
+++ b/test/spec/modules/browsiRtdProvider_spec.js
@@ -89,12 +89,6 @@ describe('browsi Real time  data sub module', function () {
       expect(browsiRTD.browsiSubmodule.getTargetingData([], null, null, auction)).to.eql({});
     });
 
-    it('should return NA if no prediction for ad unit', function () {
-      makeSlot({code: 'adMock', divId: 'browsiAd_2'});
-      browsiRTD.setData({});
-      expect(browsiRTD.browsiSubmodule.getTargetingData(['adMock'], null, null, auction)).to.eql({adMock: {bv: 'NA'}});
-    });
-
     it('should return prediction from server', function () {
       makeSlot({code: 'hasPrediction', divId: 'hasPrediction'});
       const data = {

--- a/test/spec/modules/consentManagementGpp_spec.js
+++ b/test/spec/modules/consentManagementGpp_spec.js
@@ -290,7 +290,7 @@ describe('consentManagementGpp', function () {
     });
 
     it('should not re-use errors', (done) => {
-      cmpResult = Promise.reject(new Error());
+      cmpResult = GreedyPromise.reject(new Error());
       GPPClient.init(makeCmp).catch(() => {
         cmpResult = {signalStatus: 'ready'};
         return GPPClient.init(makeCmp).then(([client]) => {

--- a/test/spec/modules/contxtfulRtdProvider_spec.js
+++ b/test/spec/modules/contxtfulRtdProvider_spec.js
@@ -1,0 +1,200 @@
+import { contxtfulSubmodule } from '../../../modules/contxtfulRtdProvider.js';
+import { expect } from 'chai';
+import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
+
+import * as events from '../../../src/events';
+
+const _ = null;
+const VERSION = 'v1';
+const CUSTOMER = 'CUSTOMER';
+const CONTXTFUL_CONNECTOR_ENDPOINT = `https://api.receptivity.io/${VERSION}/prebid/${CUSTOMER}/connector/p.js`;
+const INITIAL_RECEPTIVITY = { ReceptivityState: 'INITIAL_RECEPTIVITY' };
+const INITIAL_RECEPTIVITY_EVENT = new CustomEvent('initialReceptivity', { detail: INITIAL_RECEPTIVITY });
+
+const CONTXTFUL_API = { GetReceptivity: sinon.stub() }
+const RX_ENGINE_IS_READY_EVENT = new CustomEvent('rxEngineIsReady', {detail: CONTXTFUL_API});
+
+function buildInitConfig(version, customer) {
+  return {
+    name: 'contxtful',
+    params: {
+      version,
+      customer,
+    },
+  };
+}
+
+describe('contxtfulRtdProvider', function () {
+  let sandbox = sinon.sandbox.create();
+  let loadExternalScriptTag;
+  let eventsEmitSpy;
+
+  beforeEach(() => {
+    loadExternalScriptTag = document.createElement('script');
+    loadExternalScriptStub.callsFake((_url, _moduleName) => loadExternalScriptTag);
+
+    CONTXTFUL_API.GetReceptivity.reset();
+
+    eventsEmitSpy = sandbox.spy(events, ['emit']);
+  });
+
+  afterEach(function () {
+    delete window.Contxtful;
+    sandbox.restore();
+  });
+
+  describe('extractParameters with invalid configuration', () => {
+    const {
+      params: { customer, version },
+    } = buildInitConfig(VERSION, CUSTOMER);
+    const theories = [
+      [
+        null,
+        'params.version should be a non-empty string',
+        'null object for config',
+      ],
+      [
+        {},
+        'params.version should be a non-empty string',
+        'empty object for config',
+      ],
+      [
+        { customer },
+        'params.version should be a non-empty string',
+        'customer only in config',
+      ],
+      [
+        { version },
+        'params.customer should be a non-empty string',
+        'version only in config',
+      ],
+      [
+        { customer, version: '' },
+        'params.version should be a non-empty string',
+        'empty string for version',
+      ],
+      [
+        { customer: '', version },
+        'params.customer should be a non-empty string',
+        'empty string for customer',
+      ],
+      [
+        { customer: '', version: '' },
+        'params.version should be a non-empty string',
+        'empty string for version & customer',
+      ],
+    ];
+
+    theories.forEach(([params, expectedErrorMessage, _description]) => {
+      const config = { name: 'contxtful', params };
+      it('throws the expected error', () => {
+        expect(() => contxtfulSubmodule.extractParameters(config)).to.throw(
+          expectedErrorMessage
+        );
+      });
+    });
+  });
+
+  describe('initialization with invalid config', function () {
+    it('returns false', () => {
+      expect(contxtfulSubmodule.init({})).to.be.false;
+    });
+  });
+
+  describe('initialization with valid config', function () {
+    it('returns true when initializing', () => {
+      const config = buildInitConfig(VERSION, CUSTOMER);
+      expect(contxtfulSubmodule.init(config)).to.be.true;
+    });
+
+    it('loads contxtful module script asynchronously', (done) => {
+      contxtfulSubmodule.init(buildInitConfig(VERSION, CUSTOMER));
+
+      setTimeout(() => {
+        expect(loadExternalScriptStub.calledOnce).to.be.true;
+        expect(loadExternalScriptStub.args[0][0]).to.equal(
+          CONTXTFUL_CONNECTOR_ENDPOINT
+        );
+        done();
+      }, 10);
+    });
+  });
+
+  describe('load external script return falsy', function () {
+    it('returns true when initializing', () => {
+      loadExternalScriptStub.callsFake(() => {});
+      const config = buildInitConfig(VERSION, CUSTOMER);
+      expect(contxtfulSubmodule.init(config)).to.be.true;
+    });
+  });
+
+  describe('rxEngine from external script', function () {
+    it('use rxEngine api to get receptivity', () => {
+      contxtfulSubmodule.init(buildInitConfig(VERSION, CUSTOMER));
+      loadExternalScriptTag.dispatchEvent(RX_ENGINE_IS_READY_EVENT);
+
+      contxtfulSubmodule.getTargetingData(['ad-slot']);
+
+      expect(CONTXTFUL_API.GetReceptivity.calledOnce).to.be.true;
+    });
+  });
+
+  describe('initial receptivity is not dispatched', function () {
+    it('does not initialize receptivity value', () => {
+      contxtfulSubmodule.init(buildInitConfig(VERSION, CUSTOMER));
+
+      let targetingData = contxtfulSubmodule.getTargetingData(['ad-slot']);
+      expect(targetingData).to.deep.equal({});
+    });
+  });
+
+  describe('initial receptivity is invalid', function () {
+    const theories = [
+      [new Event('initialReceptivity'), 'event without details'],
+      [new CustomEvent('initialReceptivity', { }), 'custom event without details'],
+      [new CustomEvent('initialReceptivity', { detail: {} }), 'custom event with invalid details'],
+      [new CustomEvent('initialReceptivity', { detail: { ReceptivityState: '' } }), 'custom event with details without ReceptivityState'],
+    ];
+
+    theories.forEach(([initialReceptivityEvent, _description]) => {
+      it('does not initialize receptivity value', () => {
+        contxtfulSubmodule.init(buildInitConfig(VERSION, CUSTOMER));
+        loadExternalScriptTag.dispatchEvent(initialReceptivityEvent);
+
+        let targetingData = contxtfulSubmodule.getTargetingData(['ad-slot']);
+        expect(targetingData).to.deep.equal({});
+      });
+    })
+  });
+
+  describe('getTargetingData', function () {
+    const theories = [
+      [undefined, {}, 'undefined ad-slots'],
+      [[], {}, 'empty ad-slots'],
+      [
+        ['ad-slot'],
+        { 'ad-slot': { ReceptivityState: 'INITIAL_RECEPTIVITY' } },
+        'single ad-slot',
+      ],
+      [
+        ['ad-slot-1', 'ad-slot-2'],
+        {
+          'ad-slot-1': { ReceptivityState: 'INITIAL_RECEPTIVITY' },
+          'ad-slot-2': { ReceptivityState: 'INITIAL_RECEPTIVITY' },
+        },
+        'many ad-slots',
+      ],
+    ];
+
+    theories.forEach(([adUnits, expected, _description]) => {
+      it('adds "ReceptivityState" to the adUnits', function () {
+        contxtfulSubmodule.init(buildInitConfig(VERSION, CUSTOMER));
+        loadExternalScriptTag.dispatchEvent(INITIAL_RECEPTIVITY_EVENT);
+
+        expect(contxtfulSubmodule.getTargetingData(adUnits)).to.deep.equal(
+          expected
+        );
+      });
+    });
+  });
+});

--- a/test/spec/modules/discoveryBidAdapter_spec.js
+++ b/test/spec/modules/discoveryBidAdapter_spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import { spec } from 'modules/discoveryBidAdapter.js';
+import { spec, getPmgUID, storage, getPageTitle, getPageDescription, getPageKeywords, getConnectionDownLink } from 'modules/discoveryBidAdapter.js';
+import * as utils from 'src/utils.js';
 
 describe('discovery:BidAdapterTests', function () {
   let bidRequestData = {
@@ -98,6 +99,47 @@ describe('discovery:BidAdapterTests', function () {
     expect(req_data.imp).to.have.lengthOf(1);
   });
 
+  describe('discovery: buildRequests', function() {
+    describe('getPmgUID function', function() {
+      let sandbox;
+
+      beforeEach(() => {
+        sandbox = sinon.sandbox.create();
+        sandbox.stub(storage, 'getCookie');
+        sandbox.stub(storage, 'setCookie');
+        sandbox.stub(utils, 'generateUUID').returns('new-uuid');
+        sandbox.stub(storage, 'cookiesAreEnabled');
+      })
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should generate new UUID and set cookie if not exists', () => {
+        storage.cookiesAreEnabled.callsFake(() => true);
+        storage.getCookie.callsFake(() => null);
+        const uid = getPmgUID();
+        expect(uid).to.equal('new-uuid');
+        expect(storage.setCookie.calledOnce).to.be.true;
+      });
+
+      it('should return existing UUID from cookie', () => {
+        storage.cookiesAreEnabled.callsFake(() => true);
+        storage.getCookie.callsFake(() => 'existing-uuid');
+        const uid = getPmgUID();
+        expect(uid).to.equal('existing-uuid');
+        expect(storage.setCookie.called).to.be.false;
+      });
+
+      it('should not set new UUID when cookies are not enabled', () => {
+        storage.cookiesAreEnabled.callsFake(() => false);
+        storage.getCookie.callsFake(() => null);
+        getPmgUID();
+        expect(storage.setCookie.calledOnce).to.be.false;
+      });
+    })
+  });
+
   it('discovery:validate_response_params', function () {
     let tempAdm = '<link rel=\"stylesheet\" href=\"https://cdn.mediago.io/js/style/style_banner_336x280_standard.css\"><div id=\"mgcontainer-e1746bcc817beaba9d63bd4254aad533\" class=\"mediago-placement_46ee9c c336x280_standard_46ee9c mediago-placement c336x280_standard\" style=\"width:336px;height:280px;overflow:hidden\"><a class=\"mediago-placement-track_46ee9c mediago-placement-track\" title=\"秘密のしかけのネックレスをプレゼントした男性。2年後に彼女は中身に気付いて悲鳴を上げた\" href=\"https://trace.mediago.cc/api/bidder/track?tn=d0f4902b616cc5c38cbe0a08676d0ed9&price=zM_t6HbCS8OclsiLiZUjtAqxHOGHkHjKXNZ9_buiV_s&evt=102&rid=3f6700b5e61e1476bed629b6ea6c7a4d&campaignid=1366258&impid=50-3663.infoseek.co.jp.336x280-1&offerid=28316825&test=0&time=1660811542&cp=mMrvLk32jGlArvPzkLzohkmMOOp6YSaVPquxpJIAub4&clickid=50_3f6700b5e61e1476bed629b6ea6c7a4d_50-3663.infoseek.co.jp.336x280-1&acid=1120&trackingid=e1746bcc817beaba9d63bd4254aad533&uid=7544198412013119947&jt=2&url=O7fi1nLA9qLQjcPq7rIDvxMyybMbcc2iUh-TuaqiVSD1Dj4cKrR82gRYdWy1Ao22yhq2FoY79tmyI3X_bsO3CusXggmpW8bZvwTlHPxfOxekArClcRSpWmkVorlnMSYf7yM6QBVTuTLCCP-cK8eXMZnQVR7PdOImYZGJis6q9Xx9MToxvPkWRVa13OaCtKVeqzGdglYH3G2mqo1qLP1RCCZJHE1Fq8fgCYmLJ0Xli-nLvFZjt3g0HIui_IvyZi6YtXS97p9ohgfgDJnqcGH6l053AP0cO7ZQDHtS2_9P9UqgaA47gmltDVEDkSThX7js&bm=50&la=ja&cn=jp&cid=4215873&info=x_ME1qzmB7TY6hTSn_XUw5s6N-EkBgxcE4qJ0fd9amgsJzO3-Gtm2Nja777SyGlpkF6k_tSzbcLYYecYQlHncOAAIyuNaT2rvqrhxrQPfC7opZUGQ8WMx4Rwkx8R2k0nDiBI8xnegLWYTvY-Fc99Rw&sid=38__149__12__24__144__163__47__1__99&sp=zM_t6HbCS8OclsiLiZUjtAqxHOGHkHjKXNZ9_buiV_s&scp=WDWnWmVvDyEauBe8AfxyP7vfEVRzDMzzKOeztgGoSWY&acu=JPY&scu=USD&sgcp=mMrvLk32jGlArvPzkLzohkmMOOp6YSaVPquxpJIAub4&gprice=zM_t6HbCS8OclsiLiZUjtAqxHOGHkHjKXNZ9_buiV_s&gcp=WDWnWmVvDyEauBe8AfxyP7vfEVRzDMzzKOeztgGoSWY&ah=&pb=m&de=infoseek.co.jp&cat=&iv=0\" target=\"_blank\"><div class=\"mediago-placement-top_46ee9c mediago-placement-top\" style=\"background-image:url(https://d2cli4kgl5uxre.cloudfront.net/ML/d8e9b4aa20fae1739d2aad8c926d3f15__scv1__306x304.png)\"></div></a><div class=\"mediago-placement-bottom_46ee9c mediago-placement-bottom\"><div class=\"mediago-middle_46ee9c mediago-middle\"><a class=\"mediago-placement-track_46ee9c mediago-placement-track\" title=\"秘密のしかけのネックレスをプレゼントした男性。2年後に彼女は中身に気付いて悲鳴を上げた\" href=\"https://trace.mediago.cc/api/bidder/track?tn=d0f4902b616cc5c38cbe0a08676d0ed9&price=zM_t6HbCS8OclsiLiZUjtAqxHOGHkHjKXNZ9_buiV_s&evt=102&rid=3f6700b5e61e1476bed629b6ea6c7a4d&campaignid=1366258&impid=50-3663.infoseek.co.jp.336x280-1&offerid=28316825&test=0&time=1660811542&cp=mMrvLk32jGlArvPzkLzohkmMOOp6YSaVPquxpJIAub4&clickid=50_3f6700b5e61e1476bed629b6ea6c7a4d_50-3663.infoseek.co.jp.336x280-1&acid=1120&trackingid=e1746bcc817beaba9d63bd4254aad533&uid=7544198412013119947&jt=2&url=O7fi1nLA9qLQjcPq7rIDvxMyybMbcc2iUh-TuaqiVSD1Dj4cKrR82gRYdWy1Ao22yhq2FoY79tmyI3X_bsO3CusXggmpW8bZvwTlHPxfOxekArClcRSpWmkVorlnMSYf7yM6QBVTuTLCCP-cK8eXMZnQVR7PdOImYZGJis6q9Xx9MToxvPkWRVa13OaCtKVeqzGdglYH3G2mqo1qLP1RCCZJHE1Fq8fgCYmLJ0Xli-nLvFZjt3g0HIui_IvyZi6YtXS97p9ohgfgDJnqcGH6l053AP0cO7ZQDHtS2_9P9UqgaA47gmltDVEDkSThX7js&bm=50&la=ja&cn=jp&cid=4215873&info=x_ME1qzmB7TY6hTSn_XUw5s6N-EkBgxcE4qJ0fd9amgsJzO3-Gtm2Nja777SyGlpkF6k_tSzbcLYYecYQlHncOAAIyuNaT2rvqrhxrQPfC7opZUGQ8WMx4Rwkx8R2k0nDiBI8xnegLWYTvY-Fc99Rw&sid=38__149__12__24__144__163__47__1__99&sp=zM_t6HbCS8OclsiLiZUjtAqxHOGHkHjKXNZ9_buiV_s&scp=WDWnWmVvDyEauBe8AfxyP7vfEVRzDMzzKOeztgGoSWY&acu=JPY&scu=USD&sgcp=mMrvLk32jGlArvPzkLzohkmMOOp6YSaVPquxpJIAub4&gprice=zM_t6HbCS8OclsiLiZUjtAqxHOGHkHjKXNZ9_buiV_s&gcp=WDWnWmVvDyEauBe8AfxyP7vfEVRzDMzzKOeztgGoSWY&ah=&pb=m&de=infoseek.co.jp&cat=&iv=0\" target=\"_blank\"><div class=\"mediago-title_46ee9c mediago-title\">秘密のしかけのネックレスをプレゼントした男性。2年後に彼女は中身に気付いて悲鳴を上げた</div></a><div style=\"margin-top:10px;\"><a class=\"mediago-ad-icon_46ee9c mediago-ad-icon\" title=\"ad\" href=\"//www.mediago.io/privacy\" target=\"_blank\">AD</a> <a class=\"mediago-placement-track_46ee9c mediago-placement-track\" title=\"秘密のしかけのネックレスをプレゼントした男性。2年後に彼女は中身に気付いて悲鳴を上げた\" href=\"https://trace.mediago.cc/api/bidder/track?tn=d0f4902b616cc5c38cbe0a08676d0ed9&price=zM_t6HbCS8OclsiLiZUjtAqxHOGHkHjKXNZ9_buiV_s&evt=102&rid=3f6700b5e61e1476bed629b6ea6c7a4d&campaignid=1366258&impid=50-3663.infoseek.co.jp.336x280-1&offerid=28316825&test=0&time=1660811542&cp=mMrvLk32jGlArvPzkLzohkmMOOp6YSaVPquxpJIAub4&clickid=50_3f6700b5e61e1476bed629b6ea6c7a4d_50-3663.infoseek.co.jp.336x280-1&acid=1120&trackingid=e1746bcc817beaba9d63bd4254aad533&uid=7544198412013119947&jt=2&url=O7fi1nLA9qLQjcPq7rIDvxMyybMbcc2iUh-TuaqiVSD1Dj4cKrR82gRYdWy1Ao22yhq2FoY79tmyI3X_bsO3CusXggmpW8bZvwTlHPxfOxekArClcRSpWmkVorlnMSYf7yM6QBVTuTLCCP-cK8eXMZnQVR7PdOImYZGJis6q9Xx9MToxvPkWRVa13OaCtKVeqzGdglYH3G2mqo1qLP1RCCZJHE1Fq8fgCYmLJ0Xli-nLvFZjt3g0HIui_IvyZi6YtXS97p9ohgfgDJnqcGH6l053AP0cO7ZQDHtS2_9P9UqgaA47gmltDVEDkSThX7js&bm=50&la=ja&cn=jp&cid=4215873&info=x_ME1qzmB7TY6hTSn_XUw5s6N-EkBgxcE4qJ0fd9amgsJzO3-Gtm2Nja777SyGlpkF6k_tSzbcLYYecYQlHncOAAIyuNaT2rvqrhxrQPfC7opZUGQ8WMx4Rwkx8R2k0nDiBI8xnegLWYTvY-Fc99Rw&sid=38__149__12__24__144__163__47__1__99&sp=zM_t6HbCS8OclsiLiZUjtAqxHOGHkHjKXNZ9_buiV_s&scp=WDWnWmVvDyEauBe8AfxyP7vfEVRzDMzzKOeztgGoSWY&acu=JPY&scu=USD&sgcp=mMrvLk32jGlArvPzkLzohkmMOOp6YSaVPquxpJIAub4&gprice=zM_t6HbCS8OclsiLiZUjtAqxHOGHkHjKXNZ9_buiV_s&gcp=WDWnWmVvDyEauBe8AfxyP7vfEVRzDMzzKOeztgGoSWY&ah=&pb=m&de=infoseek.co.jp&cat=&iv=0\" target=\"_blank\"><div class=\"mediago-brand-name_46ee9c mediago-brand-name\">Factable</div></a></div></div></div></div>'
     tempAdm += '%3Cscr';
@@ -136,5 +178,270 @@ describe('discovery:BidAdapterTests', function () {
     expect(bid.width).to.equal(300);
     expect(bid.height).to.equal(250);
     expect(bid.currency).to.equal('USD');
+  });
+
+  describe('discovery: getUserSyncs', function() {
+    const COOKY_SYNC_IFRAME_URL = 'https://asset.popin.cc/js/cookieSync.html';
+    const IFRAME_ENABLED = {
+      iframeEnabled: true,
+      pixelEnabled: false,
+    };
+    const IFRAME_DISABLED = {
+      iframeEnabled: false,
+      pixelEnabled: false,
+    };
+    const GDPR_CONSENT = {
+      consentString: 'gdprConsentString',
+      gdprApplies: true
+    };
+    const USP_CONSENT = {
+      consentString: 'uspConsentString'
+    }
+
+    let syncParamUrl = `dm=${encodeURIComponent(location.origin || `https://${location.host}`)}`;
+    syncParamUrl += '&gdpr=1&gdpr_consent=gdprConsentString&ccpa_consent=uspConsentString';
+    const expectedIframeSyncs = [
+      {
+        type: 'iframe',
+        url: `${COOKY_SYNC_IFRAME_URL}?${syncParamUrl}`
+      }
+    ];
+
+    it('should return nothing if iframe is disabled', () => {
+      const userSyncs = spec.getUserSyncs(IFRAME_DISABLED, undefined, GDPR_CONSENT, USP_CONSENT, undefined);
+      expect(userSyncs).to.be.undefined;
+    });
+
+    it('should do userSyncs if iframe is enabled', () => {
+      const userSyncs = spec.getUserSyncs(IFRAME_ENABLED, undefined, GDPR_CONSENT, USP_CONSENT, undefined);
+      expect(userSyncs).to.deep.equal(expectedIframeSyncs);
+    });
+  });
+});
+
+describe('discovery Bid Adapter Tests', function () {
+  describe('buildRequests', () => {
+    describe('getPageTitle function', function() {
+      let sandbox;
+
+      beforeEach(() => {
+        sandbox = sinon.createSandbox();
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should return the top document title if available', function() {
+        const fakeTopDocument = {
+          title: 'Top Document Title',
+          querySelector: () => ({ content: 'Top Document Title test' })
+        };
+        const fakeTopWindow = {
+          document: fakeTopDocument
+        };
+        const result = getPageTitle({ top: fakeTopWindow });
+        expect(result).to.equal('Top Document Title');
+      });
+
+      it('should return the content of top og:title meta tag if title is empty', function() {
+        const ogTitleContent = 'Top OG Title Content';
+        const fakeTopWindow = {
+          document: {
+            title: '',
+            querySelector: sandbox.stub().withArgs('meta[property="og:title"]').returns({ content: ogTitleContent })
+          }
+        };
+
+        const result = getPageTitle({ top: fakeTopWindow });
+        expect(result).to.equal(ogTitleContent);
+      });
+
+      it('should return the document title if no og:title meta tag is present', function() {
+        document.title = 'Test Page Title';
+        sandbox.stub(document, 'querySelector').withArgs('meta[property="og:title"]').returns(null);
+
+        const result = getPageTitle({ top: undefined });
+        expect(result).to.equal('Test Page Title');
+      });
+
+      it('should return the content of og:title meta tag if present', function() {
+        document.title = '';
+        const ogTitleContent = 'Top OG Title Content';
+        sandbox.stub(document, 'querySelector').withArgs('meta[property="og:title"]').returns({ content: ogTitleContent });
+        const result = getPageTitle({ top: undefined });
+        expect(result).to.equal(ogTitleContent);
+      });
+
+      it('should return an empty string if no title or og:title meta tag is found', function() {
+        document.title = '';
+        sandbox.stub(document, 'querySelector').withArgs('meta[property="og:title"]').returns(null);
+        const result = getPageTitle({ top: undefined });
+        expect(result).to.equal('');
+      });
+
+      it('should handle exceptions when accessing top.document and fallback to current document', function() {
+        const fakeWindow = {
+          get top() {
+            throw new Error('Access denied');
+          }
+        };
+        const ogTitleContent = 'Current OG Title Content';
+        document.title = 'Current Document Title';
+        sandbox.stub(document, 'querySelector').withArgs('meta[property="og:title"]').returns({ content: ogTitleContent });
+        const result = getPageTitle(fakeWindow);
+        expect(result).to.equal('Current Document Title');
+      });
+    });
+
+    describe('getPageDescription function', function() {
+      let sandbox;
+
+      beforeEach(() => {
+        sandbox = sinon.createSandbox();
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should return the top document description if available', function() {
+        const descriptionContent = 'Top Document Description';
+        const fakeTopDocument = {
+          querySelector: sandbox.stub().withArgs('meta[name="description"]').returns({ content: descriptionContent })
+        };
+        const fakeTopWindow = { document: fakeTopDocument };
+        const result = getPageDescription({ top: fakeTopWindow });
+        expect(result).to.equal(descriptionContent);
+      });
+
+      it('should return the top document og:description if description is not present', function() {
+        const ogDescriptionContent = 'Top OG Description';
+        const fakeTopDocument = {
+          querySelector: sandbox.stub().withArgs('meta[property="og:description"]').returns({ content: ogDescriptionContent })
+        };
+        const fakeTopWindow = { document: fakeTopDocument };
+        const result = getPageDescription({ top: fakeTopWindow });
+        expect(result).to.equal(ogDescriptionContent);
+      });
+
+      it('should return the current document description if top document is not accessible', function() {
+        const descriptionContent = 'Current Document Description';
+        sandbox.stub(document, 'querySelector')
+          .withArgs('meta[name="description"]').returns({ content: descriptionContent })
+        const fakeWindow = {
+          get top() {
+            throw new Error('Access denied');
+          }
+        };
+        const result = getPageDescription(fakeWindow);
+        expect(result).to.equal(descriptionContent);
+      });
+
+      it('should return the current document og:description if description is not present and top document is not accessible', function() {
+        const ogDescriptionContent = 'Current OG Description';
+        sandbox.stub(document, 'querySelector')
+          .withArgs('meta[property="og:description"]').returns({ content: ogDescriptionContent });
+
+        const fakeWindow = {
+          get top() {
+            throw new Error('Access denied');
+          }
+        };
+        const result = getPageDescription(fakeWindow);
+        expect(result).to.equal(ogDescriptionContent);
+      });
+    });
+
+    describe('getPageKeywords function', function() {
+      let sandbox;
+
+      beforeEach(() => {
+        sandbox = sinon.createSandbox();
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should return the top document keywords if available', function() {
+        const keywordsContent = 'keyword1, keyword2, keyword3';
+        const fakeTopDocument = {
+          querySelector: sandbox.stub()
+            .withArgs('meta[name="keywords"]').returns({ content: keywordsContent })
+        };
+        const fakeTopWindow = { document: fakeTopDocument };
+
+        const result = getPageKeywords({ top: fakeTopWindow });
+        expect(result).to.equal(keywordsContent);
+      });
+
+      it('should return the current document keywords if top document is not accessible', function() {
+        const keywordsContent = 'keyword1, keyword2, keyword3';
+        sandbox.stub(document, 'querySelector')
+          .withArgs('meta[name="keywords"]').returns({ content: keywordsContent });
+
+        // 模拟顶层窗口访问异常
+        const fakeWindow = {
+          get top() {
+            throw new Error('Access denied');
+          }
+        };
+
+        const result = getPageKeywords(fakeWindow);
+        expect(result).to.equal(keywordsContent);
+      });
+
+      it('should return an empty string if no keywords meta tag is found', function() {
+        sandbox.stub(document, 'querySelector').withArgs('meta[name="keywords"]').returns(null);
+
+        const result = getPageKeywords();
+        expect(result).to.equal('');
+      });
+    });
+    describe('getConnectionDownLink function', function() {
+      let sandbox;
+
+      beforeEach(() => {
+        sandbox = sinon.createSandbox();
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should return the downlink value as a string if available', function() {
+        const downlinkValue = 2.5;
+        const fakeNavigator = {
+          connection: {
+            downlink: downlinkValue
+          }
+        };
+
+        const result = getConnectionDownLink({ navigator: fakeNavigator });
+        expect(result).to.equal(downlinkValue.toString());
+      });
+
+      it('should return undefined if downlink is not available', function() {
+        const fakeNavigator = {
+          connection: {}
+        };
+
+        const result = getConnectionDownLink({ navigator: fakeNavigator });
+        expect(result).to.be.undefined;
+      });
+
+      it('should return undefined if connection is not available', function() {
+        const fakeNavigator = {};
+
+        const result = getConnectionDownLink({ navigator: fakeNavigator });
+        expect(result).to.be.undefined;
+      });
+
+      it('should handle cases where navigator is not defined', function() {
+        const result = getConnectionDownLink({});
+        expect(result).to.be.undefined;
+      });
+    });
   });
 });

--- a/test/spec/modules/dsp_genieeBidAdapter_spec.js
+++ b/test/spec/modules/dsp_genieeBidAdapter_spec.js
@@ -1,0 +1,173 @@
+import { expect } from 'chai';
+import { spec } from 'modules/dsp_genieeBidAdapter.js';
+import { config } from 'src/config';
+
+describe('Geniee adapter tests', () => {
+  const validBidderRequest = {
+    code: 'sample_request',
+    bids: [{
+      bidId: 'bid-id',
+      bidder: 'dsp_geniee',
+      params: {
+        test: 1
+      }
+    }],
+    gdprConsent: {
+      gdprApplies: false
+    },
+    uspConsent: '1YNY'
+  };
+
+  describe('isBidRequestValid function test', () => {
+    it('valid', () => {
+      expect(spec.isBidRequestValid(validBidderRequest.bids[0])).equal(true);
+    });
+  });
+  describe('buildRequests function test', () => {
+    it('auction', () => {
+      const request = spec.buildRequests(validBidderRequest.bids, validBidderRequest);
+      const auction_id = request.data.id;
+      expect(request).deep.equal({
+        method: 'POST',
+        url: 'https://rt.gsspat.jp/prebid_auction',
+        data: {
+          at: 1,
+          id: auction_id,
+          imp: [
+            {
+              ext: {
+                test: 1
+              },
+              id: 'bid-id'
+            }
+          ],
+          test: 1
+        },
+      });
+    });
+    it('uncomfortable (gdpr)', () => {
+      validBidderRequest.gdprConsent.gdprApplies = true;
+      const request = spec.buildRequests(validBidderRequest.bids, validBidderRequest);
+      expect(request).deep.equal({
+        method: 'GET',
+        url: 'https://rt.gsspat.jp/prebid_uncomfortable',
+      });
+      validBidderRequest.gdprConsent.gdprApplies = false;
+    });
+    it('uncomfortable (usp)', () => {
+      validBidderRequest.uspConsent = '1YYY';
+      const request = spec.buildRequests(validBidderRequest.bids, validBidderRequest);
+      expect(request).deep.equal({
+        method: 'GET',
+        url: 'https://rt.gsspat.jp/prebid_uncomfortable',
+      });
+      validBidderRequest.uspConsent = '1YNY';
+    });
+    it('uncomfortable (coppa)', () => {
+      config.setConfig({ coppa: true });
+      const request = spec.buildRequests(validBidderRequest.bids, validBidderRequest);
+      expect(request).deep.equal({
+        method: 'GET',
+        url: 'https://rt.gsspat.jp/prebid_uncomfortable',
+      });
+      config.resetConfig();
+    });
+    it('uncomfortable (currency)', () => {
+      config.setConfig({ currency: { adServerCurrency: 'TWD' } });
+      const request = spec.buildRequests(validBidderRequest.bids, validBidderRequest);
+      expect(request).deep.equal({
+        method: 'GET',
+        url: 'https://rt.gsspat.jp/prebid_uncomfortable',
+      });
+      config.resetConfig();
+    });
+  });
+  describe('interpretResponse function test', () => {
+    it('sample bid', () => {
+      const request = spec.buildRequests(validBidderRequest.bids, validBidderRequest);
+      const auction_id = request.data.id;
+      const adm = "<script type=\"text/javascript\">\ndocument.write('<span id=\"banner-1855322083\" style=\"border:none;margin:0;padding:0;position:relative;display:inline-block\">\\n<a href=\"https://rt.gsspat.jp/c?c=&amp;y=0&amp;p=firstprice&amp;do=https%3A%2F%2Fgeniee.co.jp%2F&amp;vs=RxDOvFcIFzFPYJ8ElZ_45u7UY3yp1S9pO7dcBAzxwv_m99E1iHIGCmCaRsaXGFiNsYrcsH6-uySE3CH8ezAm0a-CMemKmP7aXusy95z0NQiheDDukZJ4V3FhOl9VNNVGKTiJIc98Ha6Gj9dH_6e_xrFK6Uxu1StCTGRr9ttKI18RbiXMGziOeK9iJAspcPOt5a9-DiPOMSwNl4cPCCUlRc1ryzxDtNu0i6_FAV1hI-Q7GFKVTtmyl1pnXFgcK6VTIsaWX_uGJCpekJU-9j1sWJOTX42hoR4HvviiEj2CN_kItq_UtAu6jNAqC8nluWB97JYfhVl6_06yLYGWw3Qk9mEJUg531zuBFyrhtvgjNutdGRbOo6CyUWd2DsehC0l_nQKEpgwXkFR4Fu4OkodGm10Wau_nOQzAmv38yXKQY1NDZq_M6x6Seq6_qa08Qj1hfSbHBrPg03uKdTh0k-12P9k8hsD10ASIiTU3oSvy_sBDmyywZuoaij2ILD6iFSYdiikJ54VLuLWHN_PSvDct6gYOFfW3O3gk5jA9EaUMuTIq_iu0wJ2129T_v9ZchC1irYGzxfVOrbdxAzLRxEdzjnWKbkPAStsUV7wpl5xC-VRbUqSOr_PcMKE3AH5MA7BKPfdE3zjFmrT7xzzzISzxAUWxOX-yxpnHq9LtSw_Z4FvOscBCoMd8uvw815pGlDj-GTZJWozzNmbXVAFcyczagw\" style=\"border:none;margin:0;padding:0;\" target=\"_top\" >\\n');\n(function(){var scheme = (location.protocol=='https:' ? 'https:' : 'http:');document.write(\"<img src=\\\"\" + scheme + \"//img.gsspat.jp/e/068c8e1eafbf0cb6ac1ee95c36152bd2/04f4bd4e6b71f978d343d84ecede3877.png\\\" height='250' width='300' style='border:none;margin:0;padding:0;left:0;top:0;position:relative;display:inline;'>\\n\");})();document.write('</a></span>\\n');\n</script>\n<script type=\"text/javascript\">\nvar Optout_IXaeJoo6aeniaboo;\n(function(k){function g(c,d){return function(){var e=document.getElementById(c),h=document.getElementById(d),g=e.style.display;e.style.display=h.style.display;h.style.display=g}}k.addOptoutInfoIcons=function(c,d,e,h,k,f,n,l){var m=document.getElementById(c),b=document.createElement(\"img\");b.src=\"https://img.gsspat.jp/e/optout/img/opt_icon.png\";b.style.width=\"15px\";b.style.height=\"15px\";var a=String(+d-15);e=c+\"-icon\";b.id=e;b.style.position=\"absolute\";b.style.top=\"0px\";b.style.left=a+\"px\";b.style.margin=\"0px\";\nb.style.padding=\"0px\";b.style.border=\"none\";b.style.opacity=\"0.8\";a=document.createElement(\"a\");c+=\"-optout-link\";a.id=c;a.style.position=\"absolute\";a.style.top=\"0px\";a.style.left=+d-75+\"px\";a.style.display=\"none\";a.style.border=\"none\";a.style.margin=\"0px\";a.style.padding=\"0px\";d=k.replace(\"{USER_ID}\",h);d=d.replace(\"{OPTOUT}\",String(f));d=d.replace(\"{TYPE}\",String(n));a.href=d;a.target=\"_blank\";f=document.createElement(\"img\");f.src=\"https://img.gsspat.jp/e/optout/img/opt_icon_text.png\";f.style.width=\"75px\";\nf.style.height=\"15px\";f.style.border=\"none\";f.style.opacity=\"0.8\";m.appendChild(b);a.appendChild(f);m.appendChild(a);l?document.getElementById(e).onclick=g(e,c):(l=document.getElementById(e),f=document.getElementById(c),l.onmouseover=g(e,c),f.onmouseout=g(e,c))}})(Optout_IXaeJoo6aeniaboo||(Optout_IXaeJoo6aeniaboo={}));\nOptout_IXaeJoo6aeniaboo.addOptoutInfoIcons(\"banner-1855322083\",300,250,\"3567cfcf0d705c1519293e147970841a\",\"https://geniee.co.jp/optout.html?id={USER_ID}&optout={OPTOUT}&type={TYPE}\",0,0,false);</script><script type=\"text/javascript\">(function(){var scheme = (location.protocol=='https:' ? 'https:' : 'http:');document.write(\"<img src=\\\"\" + scheme + \"//rt.gsspat.jp/b?p=firstprice&amp;y=0&amp;v=RxDOvFcIFzFPYJ8ElZ_45u7UY3yp1S9pO7dcBAzxwv_m99E1iHIGCmCaRsaXGFiNsYrcsH6-uySE3CH8ezAm0a-CMemKmP7aXusy95z0NQiheDDukZJ4V3FhOl9VNNVGKTiJIc98Ha7TwRtio8v0oH6GuqAv7sq5exHnn9VgRPkeS4fjg7nrNL6dKH1tC_DlX7nl5MBPq4Hq4I6Y94mgxg6FOd-oxppjr2IkCylw863lr34OI84xLO8-JO-bp9a9zWvLPEO027SLr8UBXWEj5DsYUpVO2bKXWmdcWBwrpVMixpZf-4YkKl6QlT72PWxYk5NfjaGhHge--KISPYI3-Qi2r9S0C7qM0CoLyeW5YH3slh-FWXr_TrItgZbDdCT2YQlSDnfXO4EXKuG2-CM2610ZFs6joLJRZ3YOx6ELSX-dAoSmDBeQVHgW7g6Sh0abXRZq7-c5DMCa_fzJcpBjU0Nmr8zrHpJ6rr-prTxCPWF9JscGs-DTe4p1OHST7XY_2TyGwPXQBIiJNTehK_L-wCnrNSvWV5QIhzfz0rw3LeoGDhX1tzt4JOYwPRGlDLkyKv4rtMCdtdvU_7_WXIQtYq2Bs8X1Tq23cQMy0cRHc451im5DwErbFFe8KZecQvlUW1Kkjq_z3DChNwB-TAOwSj33RN84xZq0-8c88yEs8QFFsTl_ssaZx6vS7UsP2eBbzrHAQqDHfLqvdyKxHNH0TkeItMbPzF8pc_BFdLlYw1q0sNJURZcOR4UiQR0CUyP_HfQlKBqdlGMusz6cBHUFzvHaIXV0UN3S\\\" height='1' width='1' style='display: none;'>\");})();</script>";
+      const serverResponse = {
+        body: {
+          id: auction_id,
+          cur: 'JPY',
+          seatbid: [{
+            bid: [{
+              id: '7b77235d599e06d289e58ddfa9390443e22d7071',
+              impid: 'bid-id',
+              price: 0.6666000000000001,
+              adid: '8405715',
+              adm: adm,
+              adomain: ['geniee.co.jp'],
+              iurl: 'http://img.gsspat.jp/e/068c8e1eafbf0cb6ac1ee95c36152bd2/04f4bd4e6b71f978d343d84ecede3877.png',
+              cid: '8405715',
+              crid: '1383823',
+              cat: ['IAB1'],
+              w: 300,
+              h: 250,
+              mtype: 1
+            }]
+          }]
+        }
+      };
+      const bids = spec.interpretResponse(serverResponse, request);
+      expect(bids).deep.equal([{
+        ad: adm,
+        cpm: 0.6666000000000001,
+        creativeId: '1383823',
+        creative_id: '1383823',
+        height: 250,
+        width: 300,
+        currency: 'JPY',
+        mediaType: 'banner',
+        meta: {
+          advertiserDomains: ['geniee.co.jp']
+        },
+        netRevenue: true,
+        requestId: 'bid-id',
+        seatBidId: '7b77235d599e06d289e58ddfa9390443e22d7071',
+        ttl: 300
+      }]);
+    });
+    it('no bid', () => {
+      const serverResponse = {};
+      const bids = spec.interpretResponse(serverResponse, validBidderRequest);
+      expect(bids).deep.equal([]);
+    });
+  });
+  describe('getUserSyncs function test', () => {
+    it('sync enabled', () => {
+      const syncOptions = {
+        iframeEnabled: true,
+        pixelEnabled: true
+      };
+      const serverResponses = [];
+      const syncs = spec.getUserSyncs(syncOptions, serverResponses);
+      expect(syncs).deep.equal([{
+        type: 'image',
+        url: 'https://rt.gsspat.jp/prebid_cs'
+      }]);
+    });
+    it('sync disabled (option false)', () => {
+      const syncOptions = {
+        iframeEnabled: false,
+        pixelEnabled: false
+      };
+      const serverResponses = [];
+      const syncs = spec.getUserSyncs(syncOptions, serverResponses);
+      expect(syncs).deep.equal([]);
+    });
+    it('sync disabled (gdpr)', () => {
+      const syncOptions = {
+        iframeEnabled: true,
+        pixelEnabled: true
+      };
+      const serverResponses = [];
+      const gdprConsent = {
+        gdprApplies: true
+      };
+      const syncs = spec.getUserSyncs(syncOptions, serverResponses, gdprConsent);
+      expect(syncs).deep.equal([]);
+    });
+  });
+});

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -238,6 +238,39 @@ describe('eids array generation for known sub-modules', function() {
     });
   });
 
+  it('sovrn', function() {
+    const userId = {
+      sovrn: {'id': 'sample_id'}
+    };
+    const newEids = createEidsArray(userId);
+    expect(newEids.length).to.equal(1);
+    expect(newEids[0]).to.deep.equal({
+      source: 'liveintent.sovrn.com',
+      uids: [{
+        id: 'sample_id',
+        atype: 3
+      }]
+    });
+  });
+
+  it('sovrn with ext', function() {
+    const userId = {
+      sovrn: {'id': 'sample_id', 'ext': {'provider': 'some.provider.com'}}
+    };
+    const newEids = createEidsArray(userId);
+    expect(newEids.length).to.equal(1);
+    expect(newEids[0]).to.deep.equal({
+      source: 'liveintent.sovrn.com',
+      uids: [{
+        id: 'sample_id',
+        atype: 3,
+        ext: {
+          provider: 'some.provider.com'
+        }
+      }]
+    });
+  });
+
   it('magnite', function() {
     const userId = {
       magnite: {'id': 'sample_id'}
@@ -311,7 +344,7 @@ describe('eids array generation for known sub-modules', function() {
     const newEids = createEidsArray(userId);
     expect(newEids.length).to.equal(1);
     expect(newEids[0]).to.deep.equal({
-      source: 'openx.com',
+      source: 'openx.net',
       uids: [{
         id: 'sample_id',
         atype: 3
@@ -326,7 +359,7 @@ describe('eids array generation for known sub-modules', function() {
     const newEids = createEidsArray(userId);
     expect(newEids.length).to.equal(1);
     expect(newEids[0]).to.deep.equal({
-      source: 'openx.com',
+      source: 'openx.net',
       uids: [{
         id: 'sample_id',
         atype: 3,

--- a/test/spec/modules/geoedgeRtdProvider_spec.js
+++ b/test/spec/modules/geoedgeRtdProvider_spec.js
@@ -1,17 +1,21 @@
 import * as utils from '../../../src/utils.js';
 import {loadExternalScript} from '../../../src/adloader.js';
-import {
+import * as geoedgeRtdModule from '../../../modules/geoedgeRtdProvider.js';
+import {server} from '../../../test/mocks/xhr.js';
+import * as events from '../../../src/events.js';
+import CONSTANTS from '../../../src/constants.json';
+
+let {
   geoedgeSubmodule,
   getClientUrl,
   getInPageUrl,
   htmlPlaceholder,
   setWrapper,
-  wrapper,
-  WRAPPER_URL
-} from '../../../modules/geoedgeRtdProvider.js';
-import {server} from '../../../test/mocks/xhr.js';
-import * as events from '../../../src/events.js';
-import CONSTANTS from '../../../src/constants.json';
+  getMacros,
+  WRAPPER_URL,
+  preloadClient,
+  markAsLoaded
+} = geoedgeRtdModule;
 
 let key = '123123123';
 function makeConfig(gpt) {
@@ -64,13 +68,11 @@ describe('Geoedge RTD module', function () {
       });
     });
     describe('init', function () {
-      let insertElementStub;
-
       before(function () {
-        insertElementStub = sinon.stub(utils, 'insertElement');
+        sinon.spy(geoedgeRtdModule, 'preloadClient');
       });
       after(function () {
-        utils.insertElement.restore();
+        geoedgeRtdModule.preloadClient.restore();
       });
       it('should return false when missing params or key', function () {
         let missingParams = geoedgeSubmodule.init({});
@@ -86,14 +88,13 @@ describe('Geoedge RTD module', function () {
         let isWrapperRequest = request && request.url && request.url && request.url === WRAPPER_URL;
         expect(isWrapperRequest).to.equal(true);
       });
-      it('should preload the client', function () {
-        let isLinkPreloadAsScript = arg => arg.tagName === 'LINK' && arg.rel === 'preload' && arg.as === 'script' && arg.href === getClientUrl(key);
-        expect(insertElementStub.calledWith(sinon.match(isLinkPreloadAsScript))).to.equal(true);
+      it('should call preloadClient', function () {
+        expect(preloadClient.called);
       });
       it('should emit billable events with applicable winning bids', function (done) {
         let counter = 0;
         events.on(CONSTANTS.EVENTS.BILLABLE_EVENT, function (event) {
-          if (event.vendor === 'geoedge' && event.type === 'impression') {
+          if (event.vendor === geoedgeSubmodule.name && event.type === 'impression') {
             counter += 1;
           }
           expect(counter).to.equal(1);
@@ -103,7 +104,7 @@ describe('Geoedge RTD module', function () {
       });
       it('should load the in page code when gpt params is true', function () {
         geoedgeSubmodule.init(makeConfig(true));
-        let isInPageUrl = arg => arg == getInPageUrl(key);
+        let isInPageUrl = arg => arg === getInPageUrl(key);
         expect(loadExternalScript.calledWith(sinon.match(isInPageUrl))).to.equal(true);
       });
       it('should set the window.grumi config object when gpt params is true', function () {
@@ -111,10 +112,36 @@ describe('Geoedge RTD module', function () {
         expect(hasGrumiObj && window.grumi.key === key && window.grumi.fromPrebid).to.equal(true);
       });
     });
+    describe('preloadClient', function () {
+      let iframe;
+      preloadClient(key);
+      let loadExternalScriptCall = loadExternalScript.getCall(0);
+      it('should create an invisible iframe and insert it to the DOM', function () {
+        iframe = document.getElementById('grumiFrame');
+        expect(iframe && iframe.style.display === 'none');
+      });
+      it('should assign params object to the iframe\'s window', function () {
+        let grumi = iframe.contentWindow.grumi;
+        expect(grumi.key).to.equal(key);
+      });
+      it('should preload the client into the iframe', function () {
+        let isClientUrl = arg => arg === getClientUrl(key);
+        expect(loadExternalScriptCall.calledWithMatch(isClientUrl)).to.equal(true);
+      });
+    });
     describe('setWrapper', function () {
       it('should set the wrapper', function () {
         setWrapper(mockWrapper);
-        expect(wrapper).to.equal(mockWrapper);
+        expect(geoedgeRtdModule.wrapper).to.equal(mockWrapper);
+      });
+    });
+    describe('getMacros', function () {
+      it('return a dictionary of macros replaced with values from bid object', function () {
+        let bid = mockBid('testBidder');
+        let dict = getMacros(bid, key);
+        let hasCpm = dict['%_hbCpm!'] === bid.cpm;
+        let hasCurrency = dict['%_hbCurrency!'] === bid.currency;
+        expect(hasCpm && hasCurrency);
       });
     });
     describe('onBidResponseEvent', function () {

--- a/test/spec/modules/greenbidsAnalyticsAdapter_spec.js
+++ b/test/spec/modules/greenbidsAnalyticsAdapter_spec.js
@@ -1,8 +1,11 @@
 import {
-  greenbidsAnalyticsAdapter, parseBidderCode,
+  greenbidsAnalyticsAdapter,
+  isSampled,
   ANALYTICS_VERSION, BIDDER_STATUS
 } from 'modules/greenbidsAnalyticsAdapter.js';
-
+import {
+  generateUUID,
+} from '../../../src/utils.js';
 import {expect} from 'chai';
 import sinon from 'sinon';
 
@@ -13,13 +16,12 @@ const pbuid = 'pbuid-AA778D8A796AEA7A0843E2BBEB677766';
 const auctionId = 'b0b39610-b941-4659-a87c-de9f62d3e13e';
 
 describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
-  describe('event tracking and message cache manager', function () {
+  describe('enableAnalytics and config parser', function () {
+    const configOptions = {
+      pbuid: pbuid,
+      greenbidsSampling: 1,
+    };
     beforeEach(function () {
-      const configOptions = {
-        pbuid: pbuid,
-        sampling: 0,
-      };
-
       greenbidsAnalyticsAdapter.enableAnalytics({
         provider: 'greenbidsAnalytics',
         options: configOptions
@@ -30,41 +32,36 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
       greenbidsAnalyticsAdapter.disableAnalytics();
     });
 
-    describe('#parseBidderCode()', function() {
-      it('should get lower case bidder code from bidderCode field value', function() {
-        const receivedBids = [
-          {
-            auctionId: auctionId,
-            adUnitCode: 'adunit_1',
-            bidder: 'greenbids',
-            bidderCode: 'GREENBIDS',
-            requestId: 'a1b2c3d4',
-            timeToRespond: 72,
-            cpm: 0.1,
-            currency: 'USD',
-            ad: '<html>fake ad1</html>'
-          },
-        ];
-        const result = parseBidderCode(receivedBids[0]);
-        expect(result).to.equal('greenbids');
+    it('should parse config correctly with optional values', function () {
+      expect(greenbidsAnalyticsAdapter.getAnalyticsOptions().options).to.deep.equal(configOptions);
+      expect(greenbidsAnalyticsAdapter.getAnalyticsOptions().pbuid).to.equal(configOptions.pbuid);
+    });
+
+    it('should not enable Analytics when pbuid is missing', function () {
+      const configOptions = {
+        options: {
+        }
+      };
+      const validConfig = greenbidsAnalyticsAdapter.initConfig(configOptions);
+      expect(validConfig).to.equal(false);
+    });
+  });
+
+  describe('event tracking and message cache manager', function () {
+    beforeEach(function () {
+      const configOptions = {
+        pbuid: pbuid,
+        greenbidsSampling: 1,
+      };
+
+      greenbidsAnalyticsAdapter.enableAnalytics({
+        provider: 'greenbidsAnalytics',
+        options: configOptions
       });
-      it('should get lower case bidder code from bidder field value as bidderCode field is missing', function() {
-        const receivedBids = [
-          {
-            auctionId: auctionId,
-            adUnitCode: 'adunit_1',
-            bidder: 'greenbids',
-            bidderCode: '',
-            requestId: 'a1b2c3d4',
-            timeToRespond: 72,
-            cpm: 0.1,
-            currency: 'USD',
-            ad: '<html>fake ad1</html>'
-          },
-        ];
-        const result = parseBidderCode(receivedBids[0]);
-        expect(result).to.equal('greenbids');
-      });
+    });
+
+    afterEach(function () {
+      greenbidsAnalyticsAdapter.disableAnalytics();
     });
 
     describe('#getCachedAuction()', function() {
@@ -146,7 +143,7 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
           auctionId: auctionId,
           pbuid: pbuid,
           referrer: window.location.href,
-          sampling: 0,
+          sampling: 1,
           prebid: '$prebid.version$',
         });
       }
@@ -260,7 +257,9 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
             noBids: noBids
           };
 
+          sinon.stub(greenbidsAnalyticsAdapter, 'getCachedAuction').returns({timeoutBids: timeoutBids});
           const result = greenbidsAnalyticsAdapter.createBidMessage(args, timeoutBids);
+          greenbidsAnalyticsAdapter.getCachedAuction.restore();
 
           assertHavingRequiredMessageFields(result);
           expect(result).to.deep.include({
@@ -330,7 +329,7 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
             timeout: 3000,
             auctionEnd: 1234567990,
             bidsReceived: receivedBids,
-            noBids: noBids
+            noBids: noBids,
           }];
 
           greenbidsAnalyticsAdapter.handleBidTimeout(args);
@@ -353,7 +352,7 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
   describe('greenbids Analytics Adapter track handler ', function () {
     const configOptions = {
       pbuid: pbuid,
-      sampling: 1,
+      greenbidsSampling: 1,
     };
 
     beforeEach(function () {
@@ -369,50 +368,52 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
       events.getEvents.restore();
     });
 
+    it('should call handleAuctionInit as AUCTION_INIT trigger event', function() {
+      sinon.spy(greenbidsAnalyticsAdapter, 'handleAuctionInit');
+      events.emit(constants.EVENTS.AUCTION_INIT, {auctionId: 'auctionId'});
+      sinon.assert.callCount(greenbidsAnalyticsAdapter.handleAuctionInit, 1);
+      greenbidsAnalyticsAdapter.handleAuctionInit.restore();
+    });
+
     it('should call handleBidTimeout as BID_TIMEOUT trigger event', function() {
       sinon.spy(greenbidsAnalyticsAdapter, 'handleBidTimeout');
-      events.emit(constants.EVENTS.BID_TIMEOUT, {});
+      events.emit(constants.EVENTS.BID_TIMEOUT, {auctionId: 'auctionId'});
       sinon.assert.callCount(greenbidsAnalyticsAdapter.handleBidTimeout, 1);
       greenbidsAnalyticsAdapter.handleBidTimeout.restore();
     });
 
     it('should call handleAuctionEnd as AUCTION_END trigger event', function() {
       sinon.spy(greenbidsAnalyticsAdapter, 'handleAuctionEnd');
-      events.emit(constants.EVENTS.AUCTION_END, {});
+      events.emit(constants.EVENTS.AUCTION_END, {auctionId: 'auctionId'});
       sinon.assert.callCount(greenbidsAnalyticsAdapter.handleAuctionEnd, 1);
       greenbidsAnalyticsAdapter.handleAuctionEnd.restore();
     });
+
+    it('should call handleBillable as BILLABLE_EVENT trigger event', function() {
+      sinon.spy(greenbidsAnalyticsAdapter, 'handleBillable');
+      events.emit(constants.EVENTS.BILLABLE_EVENT, {
+        type: 'auction',
+        billingId: generateUUID(),
+        auctionId: 'auctionId',
+        vendor: 'greenbidsRtdProvider'
+      });
+      sinon.assert.callCount(greenbidsAnalyticsAdapter.handleBillable, 1);
+      greenbidsAnalyticsAdapter.handleBillable.restore();
+    });
   });
 
-  describe('enableAnalytics and config parser', function () {
-    const configOptions = {
-      pbuid: pbuid,
-      sampling: 0,
-    };
-
-    beforeEach(function () {
-      greenbidsAnalyticsAdapter.enableAnalytics({
-        provider: 'greenbidsAnalytics',
-        options: configOptions
-      });
+  describe('isSampled', function() {
+    it('should return true for invalid sampling rates', function() {
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', -1)).to.be.true;
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 1.2)).to.be.true;
     });
 
-    afterEach(function () {
-      greenbidsAnalyticsAdapter.disableAnalytics();
+    it('should return determinist falsevalue for valid sampling rate given the predifined id and rate', function() {
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 0.0001)).to.be.false;
     });
 
-    it('should parse config correctly with optional values', function () {
-      expect(greenbidsAnalyticsAdapter.getAnalyticsOptions().options).to.deep.equal(configOptions);
-      expect(greenbidsAnalyticsAdapter.getAnalyticsOptions().pbuid).to.equal(configOptions.pbuid);
-    });
-
-    it('should not enable Analytics when pbuid is missing', function () {
-      const configOptions = {
-        options: {
-        }
-      };
-      const validConfig = greenbidsAnalyticsAdapter.initConfig(configOptions);
-      expect(validConfig).to.equal(false);
+    it('should return determinist true value for valid sampling rate given the predifined id and rate', function() {
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 0.9999)).to.be.true;
     });
   });
 });

--- a/test/spec/modules/greenbidsRtdProvider_spec.js
+++ b/test/spec/modules/greenbidsRtdProvider_spec.js
@@ -6,7 +6,9 @@ import {
 import {
   greenbidsSubmodule
 } from 'modules/greenbidsRtdProvider.js';
-import {server} from '../../mocks/xhr.js';
+import { server } from '../../mocks/xhr.js';
+import * as events from '../../../src/events.js';
+import CONSTANTS from '../../../src/constants.json';
 
 describe('greenbidsRtdProvider', () => {
   const endPoint = 't.greenbids.ai';
@@ -39,14 +41,15 @@ describe('greenbidsRtdProvider', () => {
       }]
   };
 
-  const SAMPLE_RESPONSE_ADUNITS = [
+  const SAMPLE_RESPONSE_ADUNITS_NOT_EXPLORED = [
     {
       code: 'adUnit1',
       bidders: {
         'appnexus': true,
         'rubicon': false,
         'ix': true
-      }
+      },
+      isExploration: false
     },
     {
       code: 'adUnit2',
@@ -54,7 +57,30 @@ describe('greenbidsRtdProvider', () => {
         'appnexus': false,
         'rubicon': true,
         'openx': true
-      }
+      },
+      isExploration: false
+
+    }];
+
+  const SAMPLE_RESPONSE_ADUNITS_EXPLORED = [
+    {
+      code: 'adUnit1',
+      bidders: {
+        'appnexus': true,
+        'rubicon': false,
+        'ix': true
+      },
+      isExploration: true
+    },
+    {
+      code: 'adUnit2',
+      bidders: {
+        'appnexus': false,
+        'rubicon': true,
+        'openx': true
+      },
+      isExploration: true
+
     }];
 
   describe('init', () => {
@@ -70,22 +96,37 @@ describe('greenbidsRtdProvider', () => {
   });
 
   describe('updateAdUnitsBasedOnResponse', () => {
-    it('should update ad units based on response', () => {
+    it('should update ad units based on response if not exploring', () => {
       const adUnits = JSON.parse(JSON.stringify(SAMPLE_REQUEST_BIDS_CONFIG_OBJ.adUnits));
-      greenbidsSubmodule.updateAdUnitsBasedOnResponse(adUnits, SAMPLE_RESPONSE_ADUNITS);
+      greenbidsSubmodule.updateAdUnitsBasedOnResponse(adUnits, SAMPLE_RESPONSE_ADUNITS_NOT_EXPLORED);
 
       expect(adUnits[0].bids).to.have.length(2);
       expect(adUnits[1].bids).to.have.length(2);
+    });
+
+    it('should not update ad units based on response if exploring', () => {
+      const adUnits = JSON.parse(JSON.stringify(SAMPLE_REQUEST_BIDS_CONFIG_OBJ.adUnits));
+      greenbidsSubmodule.updateAdUnitsBasedOnResponse(adUnits, SAMPLE_RESPONSE_ADUNITS_EXPLORED);
+
+      expect(adUnits[0].bids).to.have.length(3);
+      expect(adUnits[1].bids).to.have.length(3);
+      expect(adUnits[0].ortb2Imp.ext.greenbids.greenbidsId).to.be.a.string;
+      expect(adUnits[1].ortb2Imp.ext.greenbids.greenbidsId).to.be.a.string;
+      expect(adUnits[0].ortb2Imp.ext.greenbids.greenbidsId).to.equal(adUnits[0].ortb2Imp.ext.greenbids.greenbidsId);
+      expect(adUnits[0].ortb2Imp.ext.greenbids.keptInAuction).to.deep.equal(SAMPLE_RESPONSE_ADUNITS_EXPLORED[0].bidders);
+      expect(adUnits[1].ortb2Imp.ext.greenbids.keptInAuction).to.deep.equal(SAMPLE_RESPONSE_ADUNITS_EXPLORED[1].bidders);
+      expect(adUnits[0].ortb2Imp.ext.greenbids.isExploration).to.equal(SAMPLE_RESPONSE_ADUNITS_EXPLORED[0].isExploration);
+      expect(adUnits[1].ortb2Imp.ext.greenbids.isExploration).to.equal(SAMPLE_RESPONSE_ADUNITS_EXPLORED[1].isExploration);
     });
   });
 
   describe('findMatchingAdUnit', () => {
     it('should find matching ad unit by code', () => {
-      const matchingAdUnit = greenbidsSubmodule.findMatchingAdUnit(SAMPLE_RESPONSE_ADUNITS, 'adUnit1');
-      expect(matchingAdUnit).to.deep.equal(SAMPLE_RESPONSE_ADUNITS[0]);
+      const matchingAdUnit = greenbidsSubmodule.findMatchingAdUnit(SAMPLE_RESPONSE_ADUNITS_NOT_EXPLORED, 'adUnit1');
+      expect(matchingAdUnit).to.deep.equal(SAMPLE_RESPONSE_ADUNITS_NOT_EXPLORED[0]);
     });
     it('should return undefined if no matching ad unit is found', () => {
-      const matchingAdUnit = greenbidsSubmodule.findMatchingAdUnit(SAMPLE_RESPONSE_ADUNITS, 'nonexistent');
+      const matchingAdUnit = greenbidsSubmodule.findMatchingAdUnit(SAMPLE_RESPONSE_ADUNITS_NOT_EXPLORED, 'nonexistent');
       expect(matchingAdUnit).to.be.undefined;
     });
   });
@@ -93,7 +134,7 @@ describe('greenbidsRtdProvider', () => {
   describe('removeFalseBidders', () => {
     it('should remove bidders with false value', () => {
       const adUnit = JSON.parse(JSON.stringify(SAMPLE_REQUEST_BIDS_CONFIG_OBJ.adUnits[0]));
-      const matchingAdUnit = SAMPLE_RESPONSE_ADUNITS[0];
+      const matchingAdUnit = SAMPLE_RESPONSE_ADUNITS_NOT_EXPLORED[0];
       greenbidsSubmodule.removeFalseBidders(adUnit, matchingAdUnit);
       expect(adUnit.bids).to.have.length(2);
       expect(adUnit.bids.map((bid) => bid.bidder)).to.not.include('rubicon');
@@ -125,14 +166,15 @@ describe('greenbidsRtdProvider', () => {
       setTimeout(() => {
         server.requests[0].respond(
           200,
-          {'Content-Type': 'application/json'},
-          JSON.stringify(SAMPLE_RESPONSE_ADUNITS)
+          { 'Content-Type': 'application/json' },
+          JSON.stringify(SAMPLE_RESPONSE_ADUNITS_NOT_EXPLORED)
         );
       }, 50);
 
       setTimeout(() => {
         const requestUrl = new URL(server.requests[0].url);
         expect(requestUrl.host).to.be.eq(endPoint);
+        expect(requestBids.greenbidsId).to.be.a.string;
         expect(requestBids.adUnits[0].bids).to.have.length(2);
         expect(requestBids.adUnits[0].bids.map((bid) => bid.bidder)).to.not.include('rubicon');
         expect(requestBids.adUnits[0].bids.map((bid) => bid.bidder)).to.include('ix');
@@ -157,8 +199,8 @@ describe('greenbidsRtdProvider', () => {
       setTimeout(() => {
         server.requests[0].respond(
           200,
-          {'Content-Type': 'application/json'},
-          JSON.stringify(SAMPLE_RESPONSE_ADUNITS)
+          { 'Content-Type': 'application/json' },
+          JSON.stringify(SAMPLE_RESPONSE_ADUNITS_NOT_EXPLORED)
         );
         done();
       }, 300);
@@ -166,6 +208,7 @@ describe('greenbidsRtdProvider', () => {
       setTimeout(() => {
         const requestUrl = new URL(server.requests[0].url);
         expect(requestUrl.host).to.be.eq(endPoint);
+        expect(requestBids.greenbidsId).to.be.a.string;
         expect(requestBids.adUnits[0].bids).to.have.length(3);
         expect(requestBids.adUnits[1].bids).to.have.length(3);
         expect(callback.calledOnce).to.be.true;
@@ -183,19 +226,132 @@ describe('greenbidsRtdProvider', () => {
       setTimeout(() => {
         server.requests[0].respond(
           500,
-          {'Content-Type': 'application/json'},
-          JSON.stringify({'failure': 'fail'})
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({ 'failure': 'fail' })
         );
       }, 50);
 
       setTimeout(() => {
         const requestUrl = new URL(server.requests[0].url);
         expect(requestUrl.host).to.be.eq(endPoint);
+        expect(requestBids.greenbidsId).to.be.a.string;
         expect(requestBids.adUnits[0].bids).to.have.length(3);
         expect(requestBids.adUnits[1].bids).to.have.length(3);
         expect(callback.calledOnce).to.be.true;
         done();
       }, 60);
+    });
+  });
+
+  describe('stripAdUnits', function () {
+    it('should strip all properties except bidder from each bid in adUnits', function () {
+      const adUnits =
+        [
+          {
+            bids: [
+              { bidder: 'bidder1', otherProp: 'value1' },
+              { bidder: 'bidder2', otherProp: 'value2' }
+            ],
+            mediaTypes: { 'banner': { prop: 'value3' } }
+          }
+        ];
+      const expectedOutput = [
+        {
+          bids: [
+            { bidder: 'bidder1' },
+            { bidder: 'bidder2' }
+          ],
+          mediaTypes: { 'banner': { prop: 'value3' } }
+        }
+      ];
+
+      // Perform the test
+      const output = greenbidsSubmodule.stripAdUnits(adUnits);
+      expect(output).to.deep.equal(expectedOutput);
+    });
+
+    it('should strip all properties except bidder from each bid in adUnits but keep ortb2Imp', function () {
+      const adUnits =
+        [
+          {
+            bids: [
+              { bidder: 'bidder1', otherProp: 'value1' },
+              { bidder: 'bidder2', otherProp: 'value2' }
+            ],
+            mediaTypes: { 'banner': { prop: 'value3' } },
+            ortb2Imp: {
+              ext: {
+                greenbids: {
+                  greenbidsId: 'test'
+                }
+              }
+            }
+          }
+        ];
+      const expectedOutput = [
+        {
+          bids: [
+            { bidder: 'bidder1' },
+            { bidder: 'bidder2' }
+          ],
+          mediaTypes: { 'banner': { prop: 'value3' } },
+          ortb2Imp: {
+            ext: {
+              greenbids: {
+                greenbidsId: 'test'
+              }
+            }
+          }
+        }
+      ];
+
+      // Perform the test
+      const output = greenbidsSubmodule.stripAdUnits(adUnits);
+      expect(output).to.deep.equal(expectedOutput);
+    });
+  });
+
+  describe('onAuctionInitEvent', function () {
+    it('should not emit billable event if greenbids hasn\'t set the adunit.ext value', function () {
+      sinon.spy(events, 'emit');
+      greenbidsSubmodule.onAuctionInitEvent({
+        auctionId: 'test',
+        adUnits: [
+          {
+            bids: [
+              { bidder: 'bidder1', otherProp: 'value1' },
+              { bidder: 'bidder2', otherProp: 'value2' }
+            ],
+            mediaTypes: { 'banner': { prop: 'value3' } },
+          }
+        ]
+      });
+      sinon.assert.callCount(events.emit, 0);
+      events.emit.restore();
+    });
+
+    it('should  emit billable event if greenbids has set the adunit.ext value', function (done) {
+      let counter = 0;
+      events.on(CONSTANTS.EVENTS.BILLABLE_EVENT, function (event) {
+        if (event.vendor === 'greenbidsRtdProvider' && event.type === 'auction') {
+          counter += 1;
+        }
+        expect(counter).to.equal(1);
+        done();
+      });
+      greenbidsSubmodule.onAuctionInitEvent({
+        auctionId: 'test',
+        adUnits: [
+          {
+            bids: [
+              { bidder: 'bidder1', otherProp: 'value1' },
+              { bidder: 'bidder2', otherProp: 'value2' }
+            ],
+            mediaTypes: { 'banner': { prop: 'value3' } },
+            ortb2Imp: { ext: { greenbids: { greenbidsId: 'b0b39610-b941-4659-a87c-de9f62d3e13e' } } }
+          }
+        ]
+      });
     });
   });
 });

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -297,6 +297,14 @@ describe('gumgumAdapter', function () {
       expect(bidRequest.data.gpid).to.equal(pbadslot);
     });
 
+    it('should set the global placement id (gpid) if media type is video', function () {
+      const pbadslot = 'cde456'
+      const req = { ...bidRequests[0], ortb2Imp: { ext: { data: { pbadslot } } }, params: zoneParam, mediaTypes: vidMediaTypes }
+      const bidRequest = spec.buildRequests([req])[0];
+      expect(bidRequest.data).to.have.property('gpid');
+      expect(bidRequest.data.gpid).to.equal(pbadslot);
+    });
+
     it('should set the bid floor if getFloor module is not present but static bid floor is defined', function () {
       const req = { ...bidRequests[0], params: { bidfloor: 42 } }
       const bidRequest = spec.buildRequests([req])[0];

--- a/test/spec/modules/hadronIdSystem_spec.js
+++ b/test/spec/modules/hadronIdSystem_spec.js
@@ -22,7 +22,7 @@ describe('HadronIdSystem', function () {
       const callback = hadronIdSubmodule.getId(config).callback;
       callback(callbackSpy);
       const request = server.requests[0];
-      expect(request.url).to.eq(`https://id.hadron.ad.gt/api/v1/pbhid?partner_id=0&_it=prebid`);
+      expect(request.url).to.match(/^https:\/\/id\.hadron\.ad\.gt\/api\/v1\/pbhid/);
       request.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify({ hadronId: 'testHadronId1' }));
       expect(callbackSpy.lastCall.lastArg).to.deep.equal({ id: { hadronId: 'testHadronId1' } });
     });
@@ -47,7 +47,7 @@ describe('HadronIdSystem', function () {
       const callback = hadronIdSubmodule.getId(config).callback;
       callback(callbackSpy);
       const request = server.requests[0];
-      expect(request.url).to.eq('https://hadronid.publync.com/?partner_id=0&_it=prebid');
+      expect(request.url).to.match(/^https:\/\/hadronid\.publync\.com\//);
       request.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify({ hadronId: 'testHadronId1' }));
       expect(callbackSpy.lastCall.lastArg).to.deep.equal({ id: { hadronId: 'testHadronId1' } });
     });

--- a/test/spec/modules/identityLinkIdSystem_spec.js
+++ b/test/spec/modules/identityLinkIdSystem_spec.js
@@ -75,24 +75,6 @@ describe('IdentityLinkId tests', function () {
     expect(submoduleCallback).to.be.undefined;
   });
 
-  it('should call the LiveRamp envelope endpoint with IAB consent string v1', function () {
-    let callBackSpy = sinon.spy();
-    let consentData = {
-      gdprApplies: true,
-      consentString: 'BOkIpDSOkIpDSADABAENCc-AAAApOAFAAMAAsAMIAcAA_g'
-    };
-    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams, consentData).callback;
-    submoduleCallback(callBackSpy);
-    let request = server.requests[0];
-    expect(request.url).to.be.eq('https://api.rlcdn.com/api/identity/envelope?pid=14&ct=1&cv=BOkIpDSOkIpDSADABAENCc-AAAApOAFAAMAAsAMIAcAA_g');
-    request.respond(
-      200,
-      responseHeader,
-      JSON.stringify({})
-    );
-    expect(callBackSpy.calledOnce).to.be.true;
-  });
-
   it('should call the LiveRamp envelope endpoint with IAB consent string v2', function () {
     let callBackSpy = sinon.spy();
     let consentData = {

--- a/test/spec/modules/insticatorBidAdapter_spec.js
+++ b/test/spec/modules/insticatorBidAdapter_spec.js
@@ -179,6 +179,43 @@ describe('InsticatorBidAdapter', function () {
         }
       })).to.be.false;
     });
+
+    it('should return false if video plcmt is not a number', () => {
+      expect(spec.isBidRequestValid({
+        ...bidRequest,
+        ...{
+          mediaTypes: {
+            video: {
+              mimes: [
+                'video/mp4',
+                'video/mpeg',
+              ],
+              w: 250,
+              h: 300,
+              plcmt: 'NaN',
+            },
+          }
+        }
+      })).to.be.false;
+    });
+
+    it('should return true if playerSize is present instead of w and h', () => {
+      expect(spec.isBidRequestValid({
+        ...bidRequest,
+        ...{
+          mediaTypes: {
+            video: {
+              mimes: [
+                'video/mp4',
+                'video/mpeg',
+              ],
+              playerSize: [250, 300],
+              placement: 1,
+            },
+          }
+        }
+      })).to.be.true;
+    });
   });
 
   describe('buildRequests', function () {
@@ -570,4 +607,87 @@ describe('InsticatorBidAdapter', function () {
       expect(spec.getUserSyncs({}, [response])).to.have.length(0);
     })
   });
+
+  describe('Response with video Instream', function () {
+    const bidRequestVid = {
+      method: 'POST',
+      url: 'https://ex.ingage.tech/v1/openrtb',
+      options: {
+        contentType: 'application/json',
+        withCredentials: true,
+      },
+      data: '',
+      bidderRequest: {
+        bidderRequestId: '22edbae2733bf6',
+        auctionId: '74f78609-a92d-4cf1-869f-1b244bbfb5d2',
+        timeout: 300,
+        bids: [
+          {
+            bidder: 'insticator',
+            params: {
+              adUnitId: '1a2b3c4d5e6f1a2b3c4d'
+            },
+            adUnitCode: 'adunit-code-1',
+            mediaTypes: {
+              video: {
+                mimes: [
+                  'video/mp4',
+                  'video/mpeg',
+                ],
+                playerSize: [[250, 300]],
+                placement: 2,
+                plcmt: 2,
+              }
+            },
+            bidId: 'bid1',
+          }
+        ]
+      }
+    };
+
+    const bidResponseVid = {
+      body: {
+        id: '22edbae2733bf6',
+        bidid: 'foo9876',
+        cur: 'USD',
+        seatbid: [
+          {
+            seat: 'some-dsp',
+            bid: [
+              {
+                ad: '<Vast></Vast>',
+                impid: 'bid1',
+                crid: 'crid1',
+                price: 0.5,
+                w: 300,
+                h: 250,
+                adm: '<VAST version="4.0"><Ad></Ad></VAST>',
+                exp: 60,
+                adomain: ['test1.com'],
+                ext: {
+                  meta: {
+                    test: 1
+                  }
+                },
+              }
+            ],
+          },
+        ]
+      }
+    };
+    const bidRequestWithVideo = utils.deepClone(bidRequestVid);
+
+    it('should have related properties for video Instream', function() {
+      const serverResponseWithInstream = utils.deepClone(bidResponseVid);
+      serverResponseWithInstream.body.seatbid[0].bid[0].vastXml = '<VAST version="4.0"><Ad></Ad></VAST>';
+      serverResponseWithInstream.body.seatbid[0].bid[0].mediaType = 'video';
+      const bidResponse = spec.interpretResponse(serverResponseWithInstream, bidRequestWithVideo)[0];
+      expect(bidResponse).to.have.any.keys('mediaType', 'vastXml', 'vastUrl');
+      expect(bidResponse).to.have.property('mediaType', 'video');
+      expect(bidResponse.width).to.equal(300);
+      expect(bidResponse.height).to.equal(250);
+      expect(bidResponse).to.have.property('vastXml', '<VAST version="4.0"><Ad></Ad></VAST>');
+      expect(bidResponse.vastUrl).to.match(/^data:text\/xml;charset=utf-8;base64,[\w+/=]+$/)
+    });
+  })
 });

--- a/test/spec/modules/invibesBidAdapter_spec.js
+++ b/test/spec/modules/invibesBidAdapter_spec.js
@@ -44,6 +44,78 @@ describe('invibesBidAdapter:', function () {
     }
   ];
 
+  let bidRequestsWithDuplicatedplacementId = [
+    {
+      bidId: 'b1',
+      bidder: BIDDER_CODE,
+      bidderRequestId: 'r1',
+      params: {
+        placementId: PLACEMENT_ID,
+        disableUserSyncs: false
+
+      },
+      adUnitCode: 'test-div1',
+      auctionId: 'a1',
+      sizes: [
+        [300, 250],
+        [400, 300],
+        [125, 125]
+      ],
+      transactionId: 't1'
+    }, {
+      bidId: 'b2',
+      bidder: BIDDER_CODE,
+      bidderRequestId: 'r2',
+      params: {
+        placementId: PLACEMENT_ID,
+        disableUserSyncs: false
+      },
+      adUnitCode: 'test-div2',
+      auctionId: 'a2',
+      sizes: [
+        [300, 250],
+        [400, 300]
+      ],
+      transactionId: 't2'
+    }
+  ];
+
+  let bidRequestsWithUniquePlacementId = [
+    {
+      bidId: 'b1',
+      bidder: BIDDER_CODE,
+      bidderRequestId: 'r1',
+      params: {
+        placementId: 'PLACEMENT_ID_1',
+        disableUserSyncs: false
+
+      },
+      adUnitCode: 'test-div1',
+      auctionId: 'a1',
+      sizes: [
+        [300, 250],
+        [400, 300],
+        [125, 125]
+      ],
+      transactionId: 't1'
+    }, {
+      bidId: 'b2',
+      bidder: BIDDER_CODE,
+      bidderRequestId: 'r2',
+      params: {
+        placementId: 'PLACEMENT_ID_2',
+        disableUserSyncs: false
+      },
+      adUnitCode: 'test-div2',
+      auctionId: 'a2',
+      sizes: [
+        [300, 250],
+        [400, 300]
+      ],
+      transactionId: 't2'
+    }
+  ];
+
   let bidRequestsWithUserId = [
     {
       bidId: 'b1',
@@ -185,15 +257,42 @@ describe('invibesBidAdapter:', function () {
       expect(request.data.preventPageViewEvent).to.be.false;
     });
 
+    it('sends isPlacementRefresh as false when the placement ids are used for the first time', function () {
+      let request = spec.buildRequests(bidRequestsWithUniquePlacementId, bidderRequestWithPageInfo);
+      expect(request.data.isPlacementRefresh).to.be.false;
+    });
+
     it('sends preventPageViewEvent as true on 2nd call', function () {
       let request = spec.buildRequests(bidRequests, bidderRequestWithPageInfo);
       expect(request.data.preventPageViewEvent).to.be.true;
+    });
+
+    it('sends isPlacementRefresh as true on multi requests on the same placement id', function () {
+      let request = spec.buildRequests(bidRequestsWithDuplicatedplacementId, bidderRequestWithPageInfo);
+      expect(request.data.isPlacementRefresh).to.be.true;
+    });
+
+    it('sends isInfiniteScrollPage as false initially', function () {
+      let request = spec.buildRequests(bidRequests, bidderRequestWithPageInfo);
+      expect(request.data.isInfiniteScrollPage).to.be.false;
+    });
+
+    it('sends isPlacementRefresh as true on multi requests multiple calls with the same placement id from second call', function () {
+      let request = spec.buildRequests(bidRequests, bidderRequestWithPageInfo);
+      expect(request.data.isInfiniteScrollPage).to.be.false;
+      let duplicatedRequest = spec.buildRequests(bidRequests, bidderRequestWithPageInfo);
+      expect(duplicatedRequest.data.isPlacementRefresh).to.be.true;
     });
 
     it('sends bid request to ENDPOINT via GET', function () {
       const request = spec.buildRequests(bidRequests, bidderRequestWithPageInfo);
       expect(request.url).to.equal(ENDPOINT);
       expect(request.method).to.equal('GET');
+    });
+
+    it('generates a visitId of length 32', function () {
+      spec.buildRequests(bidRequests, bidderRequestWithPageInfo);
+      expect(top.window.invibes.visitId.length).to.equal(32);
     });
 
     it('sends bid request to custom endpoint via GET', function () {

--- a/test/spec/modules/liveIntentIdMinimalSystem_spec.js
+++ b/test/spec/modules/liveIntentIdMinimalSystem_spec.js
@@ -73,7 +73,7 @@ describe('LiveIntentMinimalId', function() {
     expect(callBackSpy.calledOnce).to.be.true;
   });
 
-  it('should call the Identity Exchange endpoint with the privided distributorId', function() {
+  it('should call the Identity Exchange endpoint with the provided distributorId', function() {
     getCookieStub.returns(null);
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId({ params: { fireEventDelay: 1, distributorId: 'did-1111' } }).callback;
@@ -87,7 +87,7 @@ describe('LiveIntentMinimalId', function() {
     expect(callBackSpy.calledOnceWith({})).to.be.true;
   });
 
-  it('should call the Identity Exchange endpoint without the privided distributorId when appId is provided', function() {
+  it('should call the Identity Exchange endpoint without the provided distributorId when appId is provided', function() {
     getCookieStub.returns(null);
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId({ params: { fireEventDelay: 1, distributorId: 'did-1111', liCollectConfig: { appId: 'a-0001' } } }).callback;
@@ -259,6 +259,11 @@ describe('LiveIntentMinimalId', function() {
   it('should decode a medianet id to a seperate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', medianet: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'medianet': 'bar'}, 'medianet': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
+  it('should decode a sovrn id to a seperate object when present', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', sovrn: 'bar' });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'sovrn': 'bar'}, 'sovrn': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
   it('should decode a magnite id to a seperate object when present', function() {

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -94,6 +94,16 @@ describe('LiveIntentId', function() {
     }, 200);
   });
 
+  it('should initialize LiveConnect and forward the prebid version when decode and emit an event', function(done) {
+    liveIntentIdSubmodule.decode({}, { params: {
+      ...defaultConfigParams
+    }});
+    setTimeout(() => {
+      expect(server.requests[0].url).to.contain('tv=$prebid.version$')
+      done();
+    }, 200);
+  });
+
   it('should initialize LiveConnect with the config params when decode and emit an event', function (done) {
     liveIntentIdSubmodule.decode({}, { params: {
       ...defaultConfigParams.params,
@@ -186,7 +196,7 @@ describe('LiveIntentId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId({ params: {...defaultConfigParams.params, ...{'url': 'https://dummy.liveintent.com/idex'}} }).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/prebid/89899?resolve=nonId');
+    expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/prebid/89899?cd=.localhost&resolve=nonId');
     request.respond(
       204,
       responseHeader
@@ -194,13 +204,13 @@ describe('LiveIntentId', function() {
     expect(callBackSpy.calledOnceWith({})).to.be.true;
   });
 
-  it('should call the Identity Exchange endpoint with the privided distributorId', function() {
+  it('should call the Identity Exchange endpoint with the provided distributorId', function() {
     getCookieStub.returns(null);
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId({ params: { fireEventDelay: 1, distributorId: 'did-1111' } }).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq('https://idx.liadm.com/idex/did-1111/any?did=did-1111&resolve=nonId');
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/did-1111/any?did=did-1111&cd=.localhost&resolve=nonId');
     request.respond(
       204,
       responseHeader
@@ -208,13 +218,13 @@ describe('LiveIntentId', function() {
     expect(callBackSpy.calledOnceWith({})).to.be.true;
   });
 
-  it('should call the Identity Exchange endpoint without the privided distributorId when appId is provided', function() {
+  it('should call the Identity Exchange endpoint without the provided distributorId when appId is provided', function() {
     getCookieStub.returns(null);
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId({ params: { fireEventDelay: 1, distributorId: 'did-1111', liCollectConfig: { appId: 'a-0001' } } }).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/any?resolve=nonId');
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/any?cd=.localhost&resolve=nonId');
     request.respond(
       204,
       responseHeader
@@ -234,7 +244,7 @@ describe('LiveIntentId', function() {
     } }).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/rubicon/89899?resolve=nonId');
+    expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/rubicon/89899?cd=.localhost&resolve=nonId');
     request.respond(
       200,
       responseHeader,
@@ -249,7 +259,7 @@ describe('LiveIntentId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?resolve=nonId');
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?cd=.localhost&resolve=nonId');
     request.respond(
       200,
       responseHeader,
@@ -264,7 +274,7 @@ describe('LiveIntentId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?resolve=nonId');
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?cd=.localhost&resolve=nonId');
     request.respond(
       503,
       responseHeader,
@@ -281,7 +291,7 @@ describe('LiveIntentId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?duid=${oldCookie}&resolve=nonId`);
+    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?duid=${oldCookie}&cd=.localhost&resolve=nonId`);
     request.respond(
       200,
       responseHeader,
@@ -304,7 +314,7 @@ describe('LiveIntentId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(configParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?duid=${oldCookie}&_thirdPC=third-pc&resolve=nonId`);
+    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?duid=${oldCookie}&cd=.localhost&_thirdPC=third-pc&resolve=nonId`);
     request.respond(
       200,
       responseHeader,
@@ -326,7 +336,7 @@ describe('LiveIntentId', function() {
     let submoduleCallback = liveIntentIdSubmodule.getId(configParams).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?_thirdPC=%7B%22key%22%3A%22value%22%7D&resolve=nonId');
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?cd=.localhost&_thirdPC=%7B%22key%22%3A%22value%22%7D&resolve=nonId');
     request.respond(
       200,
       responseHeader,
@@ -359,7 +369,7 @@ describe('LiveIntentId', function() {
     } }).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?resolve=nonId&resolve=foo`);
+    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?cd=.localhost&resolve=nonId&resolve=foo`);
     request.respond(
       200,
       responseHeader,
@@ -368,7 +378,7 @@ describe('LiveIntentId', function() {
     expect(callBackSpy.calledOnce).to.be.true;
   });
 
-  it('should decode a uid2 to a seperate object when present', function() {
+  it('should decode a uid2 to a separate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', uid2: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'uid2': 'bar'}, 'uid2': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
@@ -378,32 +388,37 @@ describe('LiveIntentId', function() {
     expect(result).to.eql({'uid2': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
-  it('should decode a bidswitch id to a seperate object when present', function() {
+  it('should decode a bidswitch id to a separate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', bidswitch: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'bidswitch': 'bar'}, 'bidswitch': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
-  it('should decode a medianet id to a seperate object when present', function() {
+  it('should decode a medianet id to a separate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', medianet: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'medianet': 'bar'}, 'medianet': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
-  it('should decode a magnite id to a seperate object when present', function() {
+  it('should decode a sovrn id to a separate object when present', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', sovrn: 'bar' });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'sovrn': 'bar'}, 'sovrn': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
+  it('should decode a magnite id to a separate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', magnite: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'magnite': 'bar'}, 'magnite': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
-  it('should decode an index id to a seperate object when present', function() {
+  it('should decode an index id to a separate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', index: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'index': 'bar'}, 'index': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
-  it('should decode an openx id to a seperate object when present', function () {
+  it('should decode an openx id to a separate object when present', function () {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', openx: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'openx': 'bar'}, 'openx': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
-  it('should decode an pubmatic id to a seperate object when present', function() {
+  it('should decode an pubmatic id to a separate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', pubmatic: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'pubmatic': 'bar'}, 'pubmatic': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
@@ -416,7 +431,7 @@ describe('LiveIntentId', function() {
     } }).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
-    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?resolve=uid2`);
+    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?cd=.localhost&resolve=uid2`);
     request.respond(
       200,
       responseHeader,

--- a/test/spec/modules/mediagoBidAdapter_spec.js
+++ b/test/spec/modules/mediagoBidAdapter_spec.js
@@ -23,29 +23,37 @@ describe('mediago:BidAdapterTests', function () {
               tid: 'tid_01',
               data: {
                 browsi: {
-                  browsiViewability: 'NA',
+                  browsiViewability: 'NA'
                 },
                 adserver: {
                   name: 'adserver_name',
-                  adslot: 'adslot_name',
+                  adslot: 'adslot_name'
                 },
-              },
-            },
-          },
+                pbadslot: '/12345/my-gpt-tag-0'
+              }
+            }
+          }
         },
         mediaTypes: {
           banner: {
             sizes: [[300, 250]],
-            pos: 'left',
-          },
+            pos: 'left'
+          }
         },
         ortb2: {
+          site: {
+        	cat: ['IAB2'],
+            keywords: 'power tools, drills, tools=industrial',
+            content: {
+              keywords: 'video, source=streaming'
+            },
+
+          },
           user: {
             ext: {
-              data: {
-              },
-            },
-          },
+              data: {}
+            }
+          }
         },
         adUnitCode: 'regular_iframe',
         transactionId: '7b26fdae-96e6-4c35-a18b-218dda11397d',
@@ -56,9 +64,83 @@ describe('mediago:BidAdapterTests', function () {
         src: 'client',
         bidRequestsCount: 1,
         bidderRequestsCount: 1,
-        bidderWinsCount: 0,
-      },
+        bidderWinsCount: 0
+      }
     ],
+    gdprConsent: {
+      consentString: 'BOJ8RZsOJ8RZsABAB8AAAAAZ+A==',
+      gdprApplies: true,
+      apiVersion: 2,
+      vendorData: {
+        purpose: {
+          consents: {
+            1: false
+          }
+        }
+      }
+    },
+    userId: {
+      tdid: 'sample-userid',
+      uid2: { id: 'sample-uid2-value' },
+      criteoId: 'sample-criteo-userid',
+      netId: 'sample-netId-userid',
+      idl_env: 'sample-idl-userid',
+      pubProvidedId: [
+        {
+          source: 'puburl.com',
+          uids: [
+            {
+              id: 'pubid2',
+              atype: 1,
+              ext: {
+                stype: 'ppuid'
+              }
+            }
+          ]
+        },
+        {
+          source: 'puburl2.com',
+          uids: [
+            {
+              id: 'pubid2'
+            },
+            {
+              id: 'pubid2-123'
+            }
+          ]
+        }
+      ]
+    },
+    userIdAsEids: [
+      {
+        source: 'adserver.org',
+        uids: [{ id: 'sample-userid' }]
+      },
+      {
+        source: 'criteo.com',
+        uids: [{ id: 'sample-criteo-userid' }]
+      },
+      {
+        source: 'netid.de',
+        uids: [{ id: 'sample-netId-userid' }]
+      },
+      {
+        source: 'liveramp.com',
+        uids: [{ id: 'sample-idl-userid' }]
+      },
+      {
+        source: 'uidapi.com',
+        uids: [{ id: 'sample-uid2-value' }]
+      },
+      {
+        source: 'puburl.com',
+        uids: [{ id: 'pubid1' }]
+      },
+      {
+        source: 'puburl2.com',
+        uids: [{ id: 'pubid2' }, { id: 'pubid2-123' }]
+      }
+    ]
   };
   let request = [];
 
@@ -67,8 +149,8 @@ describe('mediago:BidAdapterTests', function () {
       spec.isBidRequestValid({
         bidder: 'mediago',
         params: {
-          token: ['85a6b01e41ac36d49744fad726e3655d'],
-        },
+          token: ['85a6b01e41ac36d49744fad726e3655d']
+        }
       })
     ).to.equal(true);
   });
@@ -80,10 +162,12 @@ describe('mediago:BidAdapterTests', function () {
   });
 
   it('mediago:validate_response_params', function () {
-    let adm = "<link rel=\"stylesheet\" href=\"https://cdn.mediago.io/js/style/style_banner_300*250.css\"><div id=\"mgcontainer-99afea272c2b0e8626489674ddb7a0bb\" class=\"mediago-placement imgTopTitleBottom\" style=\"position:relative;width:298px;height:248px;overflow:hidden\"><a href=\"https://trace.mediago.io/api/bidder/track?tn=39934c2bda4debbe4c680be1dd02f5d3&price=djUJcggeuWWfbm28q4WXHdgMFkO28DrGw49FnubQ0Bk&evt=102&rid=6e28cfaf115a354ea1ad8e1304d6d7b8&campaignid=1339145&impid=44-300x250-1&offerid=24054386&test=0&time=1660789795&cp=jZDh1xu6_QqJLlKVtCkiHIP_TER6gL9jeTrlHCBoxOM&clickid=44_6e28cfaf115a354ea1ad8e1304d6d7b8_44-300x250-1&acid=599&trackingid=99afea272c2b0e8626489674ddb7a0bb&uid=a865b9ae-fa9e-4c09-8204-2db99ac7c8f7&jt=2&url=oxZA2i2aUVY76Xy2t3HffaK_ZtBDsgFwFc_Nbnw-bz3yCxmoUyZvATKnFc9ZkUfT1eQizhtczCwDzjHwwwDgTehUnp1EwdY4g1LRcuOwlRpXnVTt3zPQdaVx5nVDw25by7lQ0q469LCv2eEFDTAv_FOuVT32WiOx_ArOIlxCnDGpjPLUNyxm3cTZFGOJn4B7&bm=2&la=en&cn=us&cid=3998296&info=Si3oM-qfCbw2iZRYs01BkUWyH6c5CQWHrA8CQLE0VHcXAcf4ljY9dyLzQ4vAlTWd6-j_ou4ySor3e70Ll7wlKiiauQKaUkZqNoTizHm73C4FK8DYJSTP3VkhJV8RzrYk&sid=128__110__1__12__28__38__163__96__58__24__47__99&sp=djUJcggeuWWfbm28q4WXHdgMFkO28DrGw49FnubQ0Bk&scp=zK0DRYY1UV-syqSpmcMYBpOebtoQJV9ZEJT0JFqbTQg&acu=USD&scu=USD&sgcp=zK0DRYY1UV-syqSpmcMYBpOebtoQJV9ZEJT0JFqbTQg&gprice=djUJcggeuWWfbm28q4WXHdgMFkO28DrGw49FnubQ0Bk&gcp=zK0DRYY1UV-syqSpmcMYBpOebtoQJV9ZEJT0JFqbTQg&ah=&pb=&de=wjh.popin.cc&cat=&iv=0\" target=\"_blank\" class=\"mediago-placement-track\" style=\"display: inline-block;\"><img alt=\"Ranger's spot giant lion - vet is shocked when looking at the ultrasound\" src=\"https://d2cli4kgl5uxre.cloudfront.net/ML/ff32b6f9b3bbc45c00b78b6674a2952e__scv1__300x175.png\" style=\"height:70%;width:100%;border-width:0;border:none;\"><h3 class=\"title\" style=\"font-size:16px;\">Ranger's spot giant lion - vet is shocked when looking at the ultrasound</h3></a><span class=\"source\"><a class=\"sourcename\" href=\"//www.mediago.io\" target=\"_blank\"><span>Ad</span> </a><a class=\"mgmgsrcnameadslabelurl\" href=\"//www.mediago.io/privacy\" target=\"_blank\"><span>soo-healthy</span></a></span></div>";
+    let adm =
+      '<link rel="stylesheet" href="https://cdn.mediago.io/js/style/style_banner_300*250.css"><div id="mgcontainer-99afea272c2b0e8626489674ddb7a0bb" class="mediago-placement imgTopTitleBottom" style="position:relative;width:298px;height:248px;overflow:hidden"><a href="https://trace.mediago.io/api/bidder/track?tn=39934c2bda4debbe4c680be1dd02f5d3&price=djUJcggeuWWfbm28q4WXHdgMFkO28DrGw49FnubQ0Bk&evt=102&rid=6e28cfaf115a354ea1ad8e1304d6d7b8&campaignid=1339145&impid=44-300x250-1&offerid=24054386&test=0&time=1660789795&cp=jZDh1xu6_QqJLlKVtCkiHIP_TER6gL9jeTrlHCBoxOM&clickid=44_6e28cfaf115a354ea1ad8e1304d6d7b8_44-300x250-1&acid=599&trackingid=99afea272c2b0e8626489674ddb7a0bb&uid=a865b9ae-fa9e-4c09-8204-2db99ac7c8f7&jt=2&url=oxZA2i2aUVY76Xy2t3HffaK_ZtBDsgFwFc_Nbnw-bz3yCxmoUyZvATKnFc9ZkUfT1eQizhtczCwDzjHwwwDgTehUnp1EwdY4g1LRcuOwlRpXnVTt3zPQdaVx5nVDw25by7lQ0q469LCv2eEFDTAv_FOuVT32WiOx_ArOIlxCnDGpjPLUNyxm3cTZFGOJn4B7&bm=2&la=en&cn=us&cid=3998296&info=Si3oM-qfCbw2iZRYs01BkUWyH6c5CQWHrA8CQLE0VHcXAcf4ljY9dyLzQ4vAlTWd6-j_ou4ySor3e70Ll7wlKiiauQKaUkZqNoTizHm73C4FK8DYJSTP3VkhJV8RzrYk&sid=128__110__1__12__28__38__163__96__58__24__47__99&sp=djUJcggeuWWfbm28q4WXHdgMFkO28DrGw49FnubQ0Bk&scp=zK0DRYY1UV-syqSpmcMYBpOebtoQJV9ZEJT0JFqbTQg&acu=USD&scu=USD&sgcp=zK0DRYY1UV-syqSpmcMYBpOebtoQJV9ZEJT0JFqbTQg&gprice=djUJcggeuWWfbm28q4WXHdgMFkO28DrGw49FnubQ0Bk&gcp=zK0DRYY1UV-syqSpmcMYBpOebtoQJV9ZEJT0JFqbTQg&ah=&pb=&de=wjh.popin.cc&cat=&iv=0" target="_blank" class="mediago-placement-track" style="display: inline-block;"><img alt="Ranger\'s spot giant lion - vet is shocked when looking at the ultrasound" src="https://d2cli4kgl5uxre.cloudfront.net/ML/ff32b6f9b3bbc45c00b78b6674a2952e__scv1__300x175.png" style="height:70%;width:100%;border-width:0;border:none;"><h3 class="title" style="font-size:16px;">Ranger\'s spot giant lion - vet is shocked when looking at the ultrasound</h3></a><span class="source"><a class="sourcename" href="//www.mediago.io" target="_blank"><span>Ad</span> </a><a class="mgmgsrcnameadslabelurl" href="//www.mediago.io/privacy" target="_blank"><span>soo-healthy</span></a></span></div>';
     let temp = '%3Cscr';
     temp += 'ipt%3E';
-    temp += '!function()%7B%22use%20strict%22%3Bfunction%20f(t)%7Breturn(f%3D%22function%22%3D%3Dtypeof%20Symbol%26%26%22symbol%22%3D%3Dtypeof%20Symbol.iterator%3Ffunction(t)%7Breturn%20typeof%20t%7D%3Afunction(t)%7Breturn%20t%26%26%22function%22%3D%3Dtypeof%20Symbol%26%26t.constructor%3D%3D%3DSymbol%26%26t!%3D%3DSymbol.prototype%3F%22symbol%22%3Atypeof%20t%7D)(t)%7Dfunction%20l(t)%7Bvar%20e%3D0%3Carguments.length%26%26void%200!%3D%3Dt%3Ft%3A%7B%7D%3Btry%7Be.random_t%3D(new%20Date).getTime()%2Cg(function(t)%7Bvar%20e%3D1%3Carguments.length%26%26void%200!%3D%3Darguments%5B1%5D%3Farguments%5B1%5D%3A%22%22%3Bif(%22object%22!%3D%3Df(t))return%20e%3Bvar%20n%3Dfunction(t)%7Bfor(var%20e%2Cn%3D%5B%5D%2Co%3D0%2Ci%3DObject.keys(t)%3Bo%3Ci.length%3Bo%2B%2B)e%3Di%5Bo%5D%2Cn.push(%22%22.concat(e%2C%22%3D%22).concat(t%5Be%5D))%3Breturn%20n%7D(t).join(%22%26%22)%2Co%3De.indexOf(%22%23%22)%2Ci%3De%2Ct%3D%22%22%3Breturn-1!%3D%3Do%26%26(i%3De.slice(0%2Co)%2Ct%3De.slice(o))%2Cn%26%26(i%26%26-1!%3D%3Di.indexOf(%22%3F%22)%3Fi%2B%3D%22%26%22%2Bn%3Ai%2B%3D%22%3F%22%2Bn)%2Ci%2Bt%7D(e%2C%22https%3A%2F%2Ftrace.mediago.io%2Fapi%2Flog%2Ftrack%22))%7Dcatch(t)%7B%7D%7Dfunction%20g(t%2Ce%2Cn)%7B(t%3Dt%3Ft.split(%22%3B%3B%3B%22)%3A%5B%5D).map(function(t)%7Btry%7B0%3C%3Dt.indexOf(%22%2Fapi%2Fbidder%2Ftrack%22)%26%26n%26%26(t%2B%3D%22%26inIframe%3D%22.concat(!(!self.frameElement%7C%7C%22IFRAME%22!%3Dself.frameElement.tagName)%7C%7Cwindow.frames.length!%3Dparent.frames.length%7C%7Cself!%3Dtop)%2Ct%2B%3D%22%26pos_x%3D%22.concat(n.left%2C%22%26pos_y%3D%22).concat(n.top%2C%22%26page_w%3D%22).concat(n.page_width%2C%22%26page_h%3D%22).concat(n.page_height))%7Dcatch(t)%7Bl(%7Btn%3As%2Cwinloss%3A1%2Cfe%3A2%2Cpos_err_c%3A1002%2Cpos_err_m%3At.toString()%7D)%7Dvar%20e%3Dnew%20Image%3Be.src%3Dt%2Ce.style.display%3D%22none%22%2Ce.style.visibility%3D%22hidden%22%2Ce.width%3D0%2Ce.height%3D0%2Cdocument.body.appendChild(e)%7D)%7Dvar%20d%3D%5B%22https%3A%2F%2Ftrace.mediago.io%2Fapi%2Fbidder%2Ftrack%3Ftn%3D39934c2bda4debbe4c680be1dd02f5d3%26price%3DdjUJcggeuWWfbm28q4WXHdgMFkO28DrGw49FnubQ0Bk%26evt%3D101%26rid%3D6e28cfaf115a354ea1ad8e1304d6d7b8%26campaignid%3D1339145%26impid%3D44-300x250-1%26offerid%3D24054386%26test%3D0%26time%3D1660789795%26cp%3DjZDh1xu6_QqJLlKVtCkiHIP_TER6gL9jeTrlHCBoxOM%26acid%3D599%26trackingid%3D99afea272c2b0e8626489674ddb7a0bb%26uid%3Da865b9ae-fa9e-4c09-8204-2db99ac7c8f7%26bm%3D2%26la%3Den%26cn%3Dus%26cid%3D3998296%26info%3DSi3oM-qfCbw2iZRYs01BkUWyH6c5CQWHrA8CQLE0VHcXAcf4ljY9dyLzQ4vAlTWd6-j_ou4ySor3e70Ll7wlKiiauQKaUkZqNoTizHm73C4FK8DYJSTP3VkhJV8RzrYk%26sid%3D128__110__1__12__28__38__163__96__58__24__47__99%26sp%3DdjUJcggeuWWfbm28q4WXHdgMFkO28DrGw49FnubQ0Bk%26scp%3DzK0DRYY1UV-syqSpmcMYBpOebtoQJV9ZEJT0JFqbTQg%26acu%3DUSD%26scu%3DUSD%26sgcp%3DzK0DRYY1UV-syqSpmcMYBpOebtoQJV9ZEJT0JFqbTQg%26gprice%3DdjUJcggeuWWfbm28q4WXHdgMFkO28DrGw49FnubQ0Bk%26gcp%3DzK0DRYY1UV-syqSpmcMYBpOebtoQJV9ZEJT0JFqbTQg%26ah%3D%26de%3Dwjh.popin.cc%26iv%3D0%22%2C%22%24%7BITRACKER2%7D%22%2C%22%24%7BITRACKER3%7D%22%2C%22%24%7BITRACKER4%7D%22%2C%22%24%7BITRACKER5%7D%22%2C%22%24%7BITRACKER6%7D%22%5D%2Cp%3D%5B%22https%3A%2F%2Ftrace.mediago.io%2Fapi%2Fbidder%2Ftrack%3Ftn%3D39934c2bda4debbe4c680be1dd02f5d3%26price%3DdjUJcggeuWWfbm28q4WXHdgMFkO28DrGw49FnubQ0Bk%26evt%3D104%26rid%3D6e28cfaf115a354ea1ad8e1304d6d7b8%26campaignid%3D1339145%26impid%3D44-300x250-1%26offerid%3D24054386%26test%3D0%26time%3D1660789795%26cp%3DjZDh1xu6_QqJLlKVtCkiHIP_TER6gL9jeTrlHCBoxOM%26acid%3D599%26trackingid%3D99afea272c2b0e8626489674ddb7a0bb%26uid%3Da865b9ae-fa9e-4c09-8204-2db99ac7c8f7%26sid%3D128__110__1__12__28__38__163__96__58__24__47__99%26format%3D%26crid%3Dff32b6f9b3bbc45c00b78b6674a2952e%26bm%3D2%26la%3Den%26cn%3Dus%26cid%3D3998296%26info%3DSi3oM-qfCbw2iZRYs01BkUWyH6c5CQWHrA8CQLE0VHcXAcf4ljY9dyLzQ4vAlTWd6-j_ou4ySor3e70Ll7wlKiiauQKaUkZqNoTizHm73C4FK8DYJSTP3VkhJV8RzrYk%26sp%3DdjUJcggeuWWfbm28q4WXHdgMFkO28DrGw49FnubQ0Bk%26scp%3DzK0DRYY1UV-syqSpmcMYBpOebtoQJV9ZEJT0JFqbTQg%26acu%3DUSD%26scu%3DUSD%26sgcp%3DzK0DRYY1UV-syqSpmcMYBpOebtoQJV9ZEJT0JFqbTQg%26gprice%3DdjUJcggeuWWfbm28q4WXHdgMFkO28DrGw49FnubQ0Bk%26gcp%3DzK0DRYY1UV-syqSpmcMYBpOebtoQJV9ZEJT0JFqbTQg%26ah%3D%26de%3Dwjh.popin.cc%26iv%3D0%22%2C%22%24%7BVTRACKER2%7D%22%2C%22%24%7BVTRACKER3%7D%22%2C%22%24%7BVTRACKER4%7D%22%2C%22%24%7BVTRACKER5%7D%22%2C%22%24%7BVTRACKER6%7D%22%5D%2Cs%3D%22f9f2b1ef23fe2759c2cad0953029a94b%22%2Cn%3Ddocument.getElementById(%22mgcontainer-99afea272c2b0e8626489674ddb7a0bb%22)%3Bn%26%26function()%7Bvar%20a%3Dn.getElementsByClassName(%22mediago-placement-track%22)%3Bif(a%26%26a.length)%7Bvar%20t%2Ce%3Dfunction(t)%7Bvar%20e%2Cn%2Co%2Ci%2Cc%2Cr%3B%22object%22%3D%3D%3Df(r%3Da%5Bt%5D)%26%26(e%3Dfunction(t)%7Btry%7Bvar%20e%3Dt.getBoundingClientRect()%2Cn%3De%26%26e.top%7C%7C-1%2Co%3De%26%26e.left%7C%7C-1%2Ci%3Ddocument.body.scrollWidth%7C%7C-1%2Ce%3Ddocument.body.scrollHeight%7C%7C-1%3Breturn%7Btop%3An.toFixed(0)%2Cleft%3Ao.toFixed(0)%2Cpage_width%3Ai%2Cpage_height%3Ae%7D%7Dcatch(o)%7Breturn%20l(%7Btn%3As%2Cwinloss%3A1%2Cfe%3A2%2Cpos_err_c%3A1001%2Cpos_err_m%3Ao.toString()%7D)%2C%7Btop%3A%22-1%22%2Cleft%3A%22-1%22%2Cpage_width%3A%22-1%22%2Cpage_height%3A%22-1%22%7D%7D%7D(r)%2C(n%3Dd%5Bt%5D)%26%26g(n%2C0%2Ce)%2Co%3Dp%5Bt%5D%2Ci%3D!1%2C(c%3Dfunction()%7BsetTimeout(function()%7Bvar%20t%2Ce%3B!i%26%26(t%3Dr%2Ce%3Dwindow.innerHeight%7C%7Cdocument.documentElement.clientHeight%7C%7Cdocument.body.clientHeight%2C(t.getBoundingClientRect()%26%26t.getBoundingClientRect().top)%3C%3De-.75*(t.offsetHeight%7C%7Ct.clientHeight))%3F(i%3D!0%2Co%26%26g(o))%3Ac()%7D%2C500)%7D)())%7D%3Bfor(t%20in%20a)e(t)%7D%7D()%7D()';
+    temp +=
+      '!function()%7B%22use%20strict%22%3Bfunction%20f(t)%7Breturn(f%3D%22function%22%3D%3Dtypeof%20Symbol%26%26%22symbol%22%3D%3Dtypeof%20Symbol.iterator%3Ffunction(t)%7Breturn%20typeof%20t%7D%3Afunction(t)%7Breturn%20t%26%26%22function%22%3D%3Dtypeof%20Symbol%26%26t.constructor%3D%3D%3DSymbol%26%26t!%3D%3DSymbol.prototype%3F%22symbol%22%3Atypeof%20t%7D)(t)%7Dfunction%20l(t)%7Bvar%20e%3D0%3Carguments.length%26%26void%200!%3D%3Dt%3Ft%3A%7B%7D%3Btry%7Be.random_t%3D(new%20Date).getTime()%2Cg(function(t)%7Bvar%20e%3D1%3Carguments.length%26%26void%200!%3D%3Darguments%5B1%5D%3Farguments%5B1%5D%3A%22%22%3Bif(%22object%22!%3D%3Df(t))return%20e%3Bvar%20n%3Dfunction(t)%7Bfor(var%20e%2Cn%3D%5B%5D%2Co%3D0%2Ci%3DObject.keys(t)%3Bo%3Ci.length%3Bo%2B%2B)e%3Di%5Bo%5D%2Cn.push(%22%22.concat(e%2C%22%3D%22).concat(t%5Be%5D))%3Breturn%20n%7D(t).join(%22%26%22)%2Co%3De.indexOf(%22%23%22)%2Ci%3De%2Ct%3D%22%22%3Breturn-1!%3D%3Do%26%26(i%3De.slice(0%2Co)%2Ct%3De.slice(o))%2Cn%26%26(i%26%26-1!%3D%3Di.indexOf(%22%3F%22)%3Fi%2B%3D%22%26%22%2Bn%3Ai%2B%3D%22%3F%22%2Bn)%2Ci%2Bt%7D(e%2C%22https%3A%2F%2Ftrace.mediago.io%2Fapi%2Flog%2Ftrack%22))%7Dcatch(t)%7B%7D%7Dfunction%20g(t%2Ce%2Cn)%7B(t%3Dt%3Ft.split(%22%3B%3B%3B%22)%3A%5B%5D).map(function(t)%7Btry%7B0%3C%3Dt.indexOf(%22%2Fapi%2Fbidder%2Ftrack%22)%26%26n%26%26(t%2B%3D%22%26inIframe%3D%22.concat(!(!self.frameElement%7C%7C%22IFRAME%22!%3Dself.frameElement.tagName)%7C%7Cwindow.frames.length!%3Dparent.frames.length%7C%7Cself!%3Dtop)%2Ct%2B%3D%22%26pos_x%3D%22.concat(n.left%2C%22%26pos_y%3D%22).concat(n.top%2C%22%26page_w%3D%22).concat(n.page_width%2C%22%26page_h%3D%22).concat(n.page_height))%7Dcatch(t)%7Bl(%7Btn%3As%2Cwinloss%3A1%2Cfe%3A2%2Cpos_err_c%3A1002%2Cpos_err_m%3At.toString()%7D)%7Dvar%20e%3Dnew%20Image%3Be.src%3Dt%2Ce.style.display%3D%22none%22%2Ce.style.visibility%3D%22hidden%22%2Ce.width%3D0%2Ce.height%3D0%2Cdocument.body.appendChild(e)%7D)%7Dvar%20d%3D%5B%22https%3A%2F%2Ftrace.mediago.io%2Fapi%2Fbidder%2Ftrack%3Ftn%3D39934c2bda4debbe4c680be1dd02f5d3%26price%3DdjUJcggeuWWfbm28q4WXHdgMFkO28DrGw49FnubQ0Bk%26evt%3D101%26rid%3D6e28cfaf115a354ea1ad8e1304d6d7b8%26campaignid%3D1339145%26impid%3D44-300x250-1%26offerid%3D24054386%26test%3D0%26time%3D1660789795%26cp%3DjZDh1xu6_QqJLlKVtCkiHIP_TER6gL9jeTrlHCBoxOM%26acid%3D599%26trackingid%3D99afea272c2b0e8626489674ddb7a0bb%26uid%3Da865b9ae-fa9e-4c09-8204-2db99ac7c8f7%26bm%3D2%26la%3Den%26cn%3Dus%26cid%3D3998296%26info%3DSi3oM-qfCbw2iZRYs01BkUWyH6c5CQWHrA8CQLE0VHcXAcf4ljY9dyLzQ4vAlTWd6-j_ou4ySor3e70Ll7wlKiiauQKaUkZqNoTizHm73C4FK8DYJSTP3VkhJV8RzrYk%26sid%3D128__110__1__12__28__38__163__96__58__24__47__99%26sp%3DdjUJcggeuWWfbm28q4WXHdgMFkO28DrGw49FnubQ0Bk%26scp%3DzK0DRYY1UV-syqSpmcMYBpOebtoQJV9ZEJT0JFqbTQg%26acu%3DUSD%26scu%3DUSD%26sgcp%3DzK0DRYY1UV-syqSpmcMYBpOebtoQJV9ZEJT0JFqbTQg%26gprice%3DdjUJcggeuWWfbm28q4WXHdgMFkO28DrGw49FnubQ0Bk%26gcp%3DzK0DRYY1UV-syqSpmcMYBpOebtoQJV9ZEJT0JFqbTQg%26ah%3D%26de%3Dwjh.popin.cc%26iv%3D0%22%2C%22%24%7BITRACKER2%7D%22%2C%22%24%7BITRACKER3%7D%22%2C%22%24%7BITRACKER4%7D%22%2C%22%24%7BITRACKER5%7D%22%2C%22%24%7BITRACKER6%7D%22%5D%2Cp%3D%5B%22https%3A%2F%2Ftrace.mediago.io%2Fapi%2Fbidder%2Ftrack%3Ftn%3D39934c2bda4debbe4c680be1dd02f5d3%26price%3DdjUJcggeuWWfbm28q4WXHdgMFkO28DrGw49FnubQ0Bk%26evt%3D104%26rid%3D6e28cfaf115a354ea1ad8e1304d6d7b8%26campaignid%3D1339145%26impid%3D44-300x250-1%26offerid%3D24054386%26test%3D0%26time%3D1660789795%26cp%3DjZDh1xu6_QqJLlKVtCkiHIP_TER6gL9jeTrlHCBoxOM%26acid%3D599%26trackingid%3D99afea272c2b0e8626489674ddb7a0bb%26uid%3Da865b9ae-fa9e-4c09-8204-2db99ac7c8f7%26sid%3D128__110__1__12__28__38__163__96__58__24__47__99%26format%3D%26crid%3Dff32b6f9b3bbc45c00b78b6674a2952e%26bm%3D2%26la%3Den%26cn%3Dus%26cid%3D3998296%26info%3DSi3oM-qfCbw2iZRYs01BkUWyH6c5CQWHrA8CQLE0VHcXAcf4ljY9dyLzQ4vAlTWd6-j_ou4ySor3e70Ll7wlKiiauQKaUkZqNoTizHm73C4FK8DYJSTP3VkhJV8RzrYk%26sp%3DdjUJcggeuWWfbm28q4WXHdgMFkO28DrGw49FnubQ0Bk%26scp%3DzK0DRYY1UV-syqSpmcMYBpOebtoQJV9ZEJT0JFqbTQg%26acu%3DUSD%26scu%3DUSD%26sgcp%3DzK0DRYY1UV-syqSpmcMYBpOebtoQJV9ZEJT0JFqbTQg%26gprice%3DdjUJcggeuWWfbm28q4WXHdgMFkO28DrGw49FnubQ0Bk%26gcp%3DzK0DRYY1UV-syqSpmcMYBpOebtoQJV9ZEJT0JFqbTQg%26ah%3D%26de%3Dwjh.popin.cc%26iv%3D0%22%2C%22%24%7BVTRACKER2%7D%22%2C%22%24%7BVTRACKER3%7D%22%2C%22%24%7BVTRACKER4%7D%22%2C%22%24%7BVTRACKER5%7D%22%2C%22%24%7BVTRACKER6%7D%22%5D%2Cs%3D%22f9f2b1ef23fe2759c2cad0953029a94b%22%2Cn%3Ddocument.getElementById(%22mgcontainer-99afea272c2b0e8626489674ddb7a0bb%22)%3Bn%26%26function()%7Bvar%20a%3Dn.getElementsByClassName(%22mediago-placement-track%22)%3Bif(a%26%26a.length)%7Bvar%20t%2Ce%3Dfunction(t)%7Bvar%20e%2Cn%2Co%2Ci%2Cc%2Cr%3B%22object%22%3D%3D%3Df(r%3Da%5Bt%5D)%26%26(e%3Dfunction(t)%7Btry%7Bvar%20e%3Dt.getBoundingClientRect()%2Cn%3De%26%26e.top%7C%7C-1%2Co%3De%26%26e.left%7C%7C-1%2Ci%3Ddocument.body.scrollWidth%7C%7C-1%2Ce%3Ddocument.body.scrollHeight%7C%7C-1%3Breturn%7Btop%3An.toFixed(0)%2Cleft%3Ao.toFixed(0)%2Cpage_width%3Ai%2Cpage_height%3Ae%7D%7Dcatch(o)%7Breturn%20l(%7Btn%3As%2Cwinloss%3A1%2Cfe%3A2%2Cpos_err_c%3A1001%2Cpos_err_m%3Ao.toString()%7D)%2C%7Btop%3A%22-1%22%2Cleft%3A%22-1%22%2Cpage_width%3A%22-1%22%2Cpage_height%3A%22-1%22%7D%7D%7D(r)%2C(n%3Dd%5Bt%5D)%26%26g(n%2C0%2Ce)%2Co%3Dp%5Bt%5D%2Ci%3D!1%2C(c%3Dfunction()%7BsetTimeout(function()%7Bvar%20t%2Ce%3B!i%26%26(t%3Dr%2Ce%3Dwindow.innerHeight%7C%7Cdocument.documentElement.clientHeight%7C%7Cdocument.body.clientHeight%2C(t.getBoundingClientRect()%26%26t.getBoundingClientRect().top)%3C%3De-.75*(t.offsetHeight%7C%7Ct.clientHeight))%3F(i%3D!0%2Co%26%26g(o))%3Ac()%7D%2C500)%7D)())%7D%3Bfor(t%20in%20a)e(t)%7D%7D()%7D()';
     temp += '%3B%3C%2Fscri';
     temp += 'pt%3E';
     adm += decodeURIComponent(temp);
@@ -101,13 +185,13 @@ describe('mediago:BidAdapterTests', function () {
                 cid: '1339145',
                 crid: 'ff32b6f9b3bbc45c00b78b6674a2952e',
                 w: 300,
-                h: 250,
-              },
-            ],
-          },
+                h: 250
+              }
+            ]
+          }
         ],
-        cur: 'USD',
-      },
+        cur: 'USD'
+      }
     };
 
     let bids = spec.interpretResponse(serverResponse);

--- a/test/spec/modules/mgidXBidAdapter_spec.js
+++ b/test/spec/modules/mgidXBidAdapter_spec.js
@@ -76,7 +76,10 @@ describe('MGIDXBidAdapter', function () {
 
   const bidderRequest = {
     uspConsent: '1---',
-    gdprConsent: 'COvFyGBOvFyGBAbAAAENAPCAAOAAAAAAAAAAAEEUACCKAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw',
+    gdprConsent: {
+      consentString: 'COvFyGBOvFyGBAbAAAENAPCAAOAAAAAAAAAAAEEUACCKAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw',
+      vendorData: {}
+    },
     refererInfo: {
       referer: 'https://test.com'
     }
@@ -131,7 +134,7 @@ describe('MGIDXBidAdapter', function () {
       expect(data.host).to.be.a('string');
       expect(data.page).to.be.a('string');
       expect(data.coppa).to.be.a('number');
-      expect(data.gdpr).to.be.a('string');
+      expect(data.gdpr).to.be.a('object');
       expect(data.ccpa).to.be.a('string');
       expect(data.tmax).to.be.a('number');
       expect(data.placements).to.have.lengthOf(3);
@@ -172,8 +175,10 @@ describe('MGIDXBidAdapter', function () {
       serverRequest = spec.buildRequests(bids, bidderRequest);
       let data = serverRequest.data;
       expect(data.gdpr).to.exist;
-      expect(data.gdpr).to.be.a('string');
-      expect(data.gdpr).to.equal(bidderRequest.gdprConsent);
+      expect(data.gdpr).to.be.a('object');
+      expect(data.gdpr).to.have.property('consentString');
+      expect(data.gdpr).to.not.have.property('vendorData');
+      expect(data.gdpr.consentString).to.equal(bidderRequest.gdprConsent.consentString);
       expect(data.ccpa).to.not.exist;
       delete bidderRequest.gdprConsent;
     });

--- a/test/spec/modules/minutemediaBidAdapter_spec.js
+++ b/test/spec/modules/minutemediaBidAdapter_spec.js
@@ -178,6 +178,16 @@ describe('minutemediaAdapter', function () {
       expect(request.data.bids[1].mediaType).to.equal(BANNER)
     });
 
+    it('should send the correct currency in bid request', function () {
+      const bid = utils.deepClone(bidRequests[0]);
+      bid.params = {
+        'currency': 'EUR'
+      };
+      const expectedCurrency = bid.params.currency;
+      const request = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.bids[0].currency).to.equal(expectedCurrency);
+    });
+
     it('should respect syncEnabled option', function() {
       config.setConfig({
         userSync: {

--- a/test/spec/modules/mygaruIdSystem_spec.js
+++ b/test/spec/modules/mygaruIdSystem_spec.js
@@ -1,0 +1,62 @@
+import { mygaruIdSubmodule } from 'modules/mygaruIdSystem.js';
+import { server } from '../../mocks/xhr';
+
+describe('MygaruID module', function () {
+  it('should respond with async callback and get valid id', async () => {
+    const callBackSpy = sinon.spy();
+    const expectedUrl = `https://ident.mygaru.com/v2/id?gdprApplies=0`;
+    const result = mygaruIdSubmodule.getId({});
+
+    expect(result.callback).to.be.an('function');
+    const promise = result.callback(callBackSpy);
+
+    const request = server.requests[0];
+    expect(request.url).to.be.eq(expectedUrl);
+
+    request.respond(
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({ iuid: '123' })
+    );
+    await promise;
+
+    expect(callBackSpy.calledOnce).to.be.true;
+    expect(callBackSpy.calledWith({mygaruId: '123'})).to.be.true;
+  });
+  it('should not fail on error', async () => {
+    const callBackSpy = sinon.spy();
+    const expectedUrl = `https://ident.mygaru.com/v2/id?gdprApplies=0`;
+    const result = mygaruIdSubmodule.getId({});
+
+    expect(result.callback).to.be.an('function');
+    const promise = result.callback(callBackSpy);
+
+    const request = server.requests[0];
+    expect(request.url).to.be.eq(expectedUrl);
+
+    request.respond(
+      500,
+      {},
+      ''
+    );
+    await promise;
+
+    expect(callBackSpy.calledOnce).to.be.true;
+    expect(callBackSpy.calledWith({mygaruId: undefined})).to.be.true;
+  });
+
+  it('should not modify while decoding', () => {
+    const id = '222';
+    const newId = mygaruIdSubmodule.decode(id)
+
+    expect(id).to.eq(newId);
+  })
+  it('should buildUrl with consent data', () => {
+    const result = mygaruIdSubmodule.getId({}, {
+      gdprApplies: true,
+      consentString: 'consentString'
+    });
+
+    expect(result.url).to.eq('https://ident.mygaru.com/v2/id?gdprApplies=1&gdprConsentString=consentString');
+  })
+});

--- a/test/spec/modules/nextMillenniumBidAdapter_spec.js
+++ b/test/spec/modules/nextMillenniumBidAdapter_spec.js
@@ -1,32 +1,510 @@
 import { expect } from 'chai';
-import { spec } from 'modules/nextMillenniumBidAdapter.js';
+import {
+  getImp,
+  replaceUsersyncMacros,
+  setConsentStrings,
+  setOrtb2Parameters,
+  setEids,
+  spec,
+} from 'modules/nextMillenniumBidAdapter.js';
 
-describe('nextMillenniumBidAdapterTests', function() {
-  const bidRequestData = [
-    {
-      adUnitCode: 'test-div',
-      bidId: 'bid1234',
-      auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
-      bidder: 'nextMillennium',
-      params: { placement_id: '-1' },
-      sizes: [[300, 250]],
-      uspConsent: '1---',
-      gdprConsent: {
-        consentString: 'kjfdniwjnifwenrif3',
-        gdprApplies: true
-      },
-      ortb2: {
-        device: {
-          w: 1500,
-          h: 1000
+describe('nextMillenniumBidAdapterTests', () => {
+  describe('function getImp', () => {
+    const dataTests = [
+      {
+        title: 'imp - banner',
+        data: {
+          id: '123',
+          bid: {
+            mediaTypes: {banner: {sizes: [[300, 250], [320, 250]]}},
+            adUnitCode: 'test-banner-1',
+          },
         },
-        site: {
-          domain: 'example.com',
-          page: 'http://example.com'
-        }
+
+        expected: {
+          id: 'test-banner-1',
+          ext: {prebid: {storedrequest: {id: '123'}}},
+          banner: {format: [{w: 300, h: 250}, {w: 320, h: 250}]},
+        },
+      },
+
+      {
+        title: 'imp - video',
+        data: {
+          id: '234',
+          bid: {
+            mediaTypes: {video: {playerSize: [400, 300]}},
+            adUnitCode: 'test-video-1',
+          },
+        },
+
+        expected: {
+          id: 'test-video-1',
+          ext: {prebid: {storedrequest: {id: '234'}}},
+          video: {w: 400, h: 300},
+        },
+      },
+    ];
+
+    for (let {title, data, expected} of dataTests) {
+      it(title, () => {
+        const {bid, id} = data;
+        const imp = getImp(bid, id);
+        expect(imp).to.deep.equal(expected);
+      });
+    }
+  });
+
+  describe('function setConsentStrings', () => {
+    const dataTests = [
+      {
+        title: 'full: uspConsent, gdprConsent and gppConsent',
+        data: {
+          postBody: {},
+          bidderRequest: {
+            uspConsent: '1---',
+            gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7]},
+            gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: true},
+            ortb2: {regs: {gpp: 'DSFHFHWEUYVDC', gpp_sid: [8, 9, 10]}},
+          },
+        },
+
+        expected: {
+          user: {ext: {consent: 'kjfdniwjnifwenrif3'}},
+          regs: {
+            gpp: 'DBACNYA~CPXxRfAPXxR',
+            gpp_sid: [7],
+            ext: {gdpr: 1, us_privacy: '1---'},
+          },
+        },
+      },
+
+      {
+        title: 'gdprConsent(false) and ortb2(gpp)',
+        data: {
+          postBody: {},
+          bidderRequest: {
+            gdprConsent: {consentString: 'ewtewbefbawyadexv', gdprApplies: false},
+            ortb2: {regs: {gpp: 'DSFHFHWEUYVDC', gpp_sid: [8, 9, 10]}},
+          },
+        },
+
+        expected: {
+          user: {ext: {consent: 'ewtewbefbawyadexv'}},
+          regs: {
+            gpp: 'DSFHFHWEUYVDC',
+            gpp_sid: [8, 9, 10],
+            ext: {gdpr: 0},
+          },
+        },
+      },
+
+      {
+        title: 'gdprConsent(false)',
+        data: {
+          postBody: {},
+          bidderRequest: {gdprConsent: {gdprApplies: false}},
+        },
+
+        expected: {
+          regs: {ext: {gdpr: 0}},
+        },
+      },
+
+      {
+        title: 'empty',
+        data: {
+          postBody: {},
+          bidderRequest: {},
+        },
+
+        expected: {},
+      },
+    ];
+
+    for (let {title, data, expected} of dataTests) {
+      it(title, () => {
+        const {postBody, bidderRequest} = data;
+        setConsentStrings(postBody, bidderRequest);
+        expect(postBody).to.deep.equal(expected);
+      });
+    }
+  });
+
+  describe('function replaceUsersyncMacros', () => {
+    const dataTests = [
+      {
+        title: 'url with all macroses - consents full: uspConsent, gdprConsent and gppConsent',
+        data: {
+          url: 'https://some.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&type={{.TYPE_PIXEL}}',
+          uspConsent: '1---',
+          gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7, 8]},
+          gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: true},
+          type: 'image',
+        },
+
+        expected: 'https://some.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8&type=image',
+      },
+
+      {
+        title: 'url with some macroses - consents full: uspConsent, gdprConsent and gppConsent',
+        data: {
+          url: 'https://some.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&type={{.TYPE_PIXEL}}',
+          uspConsent: '1---',
+          gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7, 8]},
+          gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: false},
+          type: 'iframe',
+        },
+
+        expected: 'https://some.url?gdpr=0&gdpr_consent=kjfdniwjnifwenrif3&type=iframe',
+      },
+
+      {
+        title: 'url without macroses - consents full: uspConsent, gdprConsent and gppConsent',
+        data: {
+          url: 'https://some.url?param1=value1&param2=value2',
+          uspConsent: '1---',
+          gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7, 8]},
+          gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: false},
+          type: 'iframe',
+        },
+
+        expected: 'https://some.url?param1=value1&param2=value2',
+      },
+
+      {
+        title: 'url with all macroses - consents are empty',
+        data: {
+          url: 'https://some.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&type={{.TYPE_PIXEL}}',
+        },
+
+        expected: 'https://some.url?gdpr=0&gdpr_consent=&us_privacy=&gpp=&gpp_sid=&type=',
+      },
+    ];
+
+    for (let {title, data, expected} of dataTests) {
+      it(title, () => {
+        const {url, gdprConsent, uspConsent, gppConsent, type} = data;
+        const newUrl = replaceUsersyncMacros(url, gdprConsent, uspConsent, gppConsent, type);
+        expect(newUrl).to.equal(expected);
+      });
+    }
+  });
+
+  describe('function spec.getUserSyncs', () => {
+    const dataTests = [
+      {
+        title: 'pixels from responses ({iframeEnabled: true, pixelEnabled: true})',
+        data: {
+          syncOptions: {iframeEnabled: true, pixelEnabled: true},
+          responses: [
+            {body: {ext: {sync: {
+              image: [
+                'https://some.1.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.2.url?us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.3.url?param=1234',
+              ],
+
+              iframe: [
+                'https://some.4.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.5.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}',
+              ],
+            }}}},
+
+            {body: {ext: {sync: {
+              iframe: [
+                'https://some.6.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.7.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}',
+              ],
+            }}}},
+
+            {body: {ext: {sync: {
+              image: [
+                'https://some.8.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+              ],
+            }}}},
+          ],
+
+          uspConsent: '1---',
+          gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7, 8]},
+          gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: true},
+        },
+
+        expected: [
+          {type: 'image', url: 'https://some.1.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8'},
+          {type: 'image', url: 'https://some.2.url?us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8'},
+          {type: 'image', url: 'https://some.3.url?param=1234'},
+          {type: 'iframe', url: 'https://some.4.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8'},
+          {type: 'iframe', url: 'https://some.5.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---'},
+          {type: 'iframe', url: 'https://some.6.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8'},
+          {type: 'iframe', url: 'https://some.7.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---'},
+          {type: 'image', url: 'https://some.8.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8'},
+        ],
+      },
+
+      {
+        title: 'pixels from responses ({iframeEnabled: true, pixelEnabled: false})',
+        data: {
+          syncOptions: {iframeEnabled: true, pixelEnabled: false},
+          responses: [
+            {body: {ext: {sync: {
+              image: [
+                'https://some.1.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.2.url?us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.3.url?param=1234',
+              ],
+
+              iframe: [
+                'https://some.4.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.5.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}',
+              ],
+            }}}},
+          ],
+
+          uspConsent: '1---',
+          gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7, 8]},
+          gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: true},
+        },
+
+        expected: [
+          {type: 'iframe', url: 'https://some.4.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8'},
+          {type: 'iframe', url: 'https://some.5.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---'},
+        ],
+      },
+
+      {
+        title: 'pixels from responses ({iframeEnabled: false, pixelEnabled: true})',
+        data: {
+          syncOptions: {iframeEnabled: false, pixelEnabled: true},
+          responses: [
+            {body: {ext: {sync: {
+              image: [
+                'https://some.1.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.2.url?us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.3.url?param=1234',
+              ],
+
+              iframe: [
+                'https://some.4.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.5.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}',
+              ],
+            }}}},
+          ],
+
+          uspConsent: '1---',
+          gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7, 8]},
+          gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: true},
+        },
+
+        expected: [
+          {type: 'image', url: 'https://some.1.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8'},
+          {type: 'image', url: 'https://some.2.url?us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8'},
+          {type: 'image', url: 'https://some.3.url?param=1234'},
+        ],
+      },
+
+      {
+        title: 'pixels - responses is empty ({iframeEnabled: true, pixelEnabled: true})',
+        data: {
+          syncOptions: {iframeEnabled: true, pixelEnabled: true},
+          responses: [],
+          uspConsent: '1---',
+          gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7, 8]},
+          gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: true},
+        },
+
+        expected: [
+          {type: 'image', url: 'https://cookies.nextmillmedia.com/sync?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8&type=image'},
+          {type: 'iframe', url: 'https://cookies.nextmillmedia.com/sync?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8&type=iframe'},
+        ],
+      },
+
+      {
+        title: 'pixels - responses is empty ({iframeEnabled: true, pixelEnabled: false})',
+        data: {
+          syncOptions: {iframeEnabled: true, pixelEnabled: false},
+          uspConsent: '1---',
+          gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7, 8]},
+          gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: true},
+        },
+
+        expected: [
+          {type: 'iframe', url: 'https://cookies.nextmillmedia.com/sync?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8&type=iframe'},
+        ],
+      },
+
+      {
+        title: 'pixels - responses is empty ({iframeEnabled: false, pixelEnabled: false})',
+        data: {
+          syncOptions: {iframeEnabled: false, pixelEnabled: false},
+          uspConsent: '1---',
+          gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7, 8]},
+          gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: true},
+        },
+
+        expected: [],
+      },
+    ];
+
+    for (let {title, data, expected} of dataTests) {
+      it(title, () => {
+        const {syncOptions, responses, gdprConsent, uspConsent, gppConsent} = data;
+        const pixels = spec.getUserSyncs(syncOptions, responses, gdprConsent, uspConsent, gppConsent);
+        expect(pixels).to.deep.equal(expected);
+      });
+    }
+  });
+
+  describe('function setOrtb2Parameters', () => {
+    const dataTests = [
+      {
+        title: 'site.pagecat, site.content.cat and site.content.language',
+        data: {
+          postBody: {},
+          ortb2: {site: {
+            pagecat: ['IAB2-11', 'IAB2-12', 'IAB2-14'],
+            content: {cat: ['IAB2-11', 'IAB2-12', 'IAB2-14'], language: 'EN'},
+          }},
+        },
+
+        expected: {site: {
+          pagecat: ['IAB2-11', 'IAB2-12', 'IAB2-14'],
+          content: {cat: ['IAB2-11', 'IAB2-12', 'IAB2-14'], language: 'EN'},
+        }},
+      },
+
+      {
+        title: 'only site.content.language',
+        data: {
+          postBody: {site: {domain: 'some.domain'}},
+          ortb2: {site: {
+            content: {language: 'EN'},
+          }},
+        },
+
+        expected: {site: {
+          domain: 'some.domain',
+          content: {language: 'EN'},
+        }},
+      },
+
+      {
+        title: 'object ortb2 is empty',
+        data: {
+          postBody: {imp: []},
+        },
+
+        expected: {imp: []},
+      },
+    ];
+
+    for (let {title, data, expected} of dataTests) {
+      it(title, () => {
+        const {postBody, ortb2} = data;
+        setOrtb2Parameters(postBody, ortb2);
+        expect(postBody).to.deep.equal(expected);
+      });
+    };
+  });
+
+  describe('function setEids', () => {
+    const dataTests = [
+      {
+        title: 'setEids - userIdAsEids is empty',
+        data: {
+          postBody: {},
+          bid: {
+            userIdAsEids: undefined,
+          },
+        },
+
+        expected: {},
+      },
+
+      {
+        title: 'setEids - userIdAsEids - array is empty',
+        data: {
+          postBody: {},
+          bid: {
+            userIdAsEids: [],
+          },
+        },
+
+        expected: {},
+      },
+
+      {
+        title: 'setEids - userIdAsEids is',
+        data: {
+          postBody: {},
+          bid: {
+            userIdAsEids: [
+              {
+                source: '33across.com',
+                uids: [{id: 'some-random-id-value', atype: 1}],
+              },
+
+              {
+                source: 'utiq.com',
+                uids: [{id: 'some-random-id-value', atype: 1}],
+              },
+            ],
+          },
+        },
+
+        expected: {
+          user: {
+            eids: [
+              {
+                source: '33across.com',
+                uids: [{id: 'some-random-id-value', atype: 1}],
+              },
+
+              {
+                source: 'utiq.com',
+                uids: [{id: 'some-random-id-value', atype: 1}],
+              },
+            ],
+          },
+        },
+      },
+    ];
+
+    for (let { title, data, expected } of dataTests) {
+      it(title, () => {
+        const { postBody, bid } = data;
+        setEids(postBody, bid);
+        expect(postBody).to.deep.equal(expected);
+      });
+    }
+  });
+
+  const bidRequestData = [{
+    adUnitCode: 'test-div',
+    bidId: 'bid1234',
+    auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+    bidder: 'nextMillennium',
+    params: { placement_id: '-1' },
+    sizes: [[300, 250]],
+    uspConsent: '1---',
+    gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7]},
+    gdprConsent: {
+      consentString: 'kjfdniwjnifwenrif3',
+      gdprApplies: true
+    },
+
+    ortb2: {
+      device: {
+        w: 1500,
+        h: 1000
+      },
+
+      site: {
+        domain: 'example.com',
+        page: 'http://example.com'
       }
     }
-  ];
+  }];
 
   const serverResponse = {
     body: {
@@ -49,7 +527,7 @@ describe('nextMillenniumBidAdapterTests', function() {
       cur: 'USD',
       ext: {
         sync: {
-          image: ['urlA?gdpr={{.GDPR}}'],
+          image: ['urlA?gdpr={{.GDPR}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}'],
           iframe: ['urlB'],
         }
       }
@@ -117,61 +595,6 @@ describe('nextMillenniumBidAdapterTests', function() {
     },
   ];
 
-  it('Request params check with GDPR and USP Consent', function () {
-    const request = spec.buildRequests(bidRequestData, bidRequestData[0]);
-    expect(JSON.parse(request[0].data).user.ext.consent).to.equal('kjfdniwjnifwenrif3');
-    expect(JSON.parse(request[0].data).regs.ext.us_privacy).to.equal('1---');
-    expect(JSON.parse(request[0].data).regs.ext.gdpr).to.equal(1);
-  });
-
-  it('Test getUserSyncs function', function () {
-    const syncOptions = {
-      'iframeEnabled': false,
-      'pixelEnabled': true
-    }
-    let userSync = spec.getUserSyncs(syncOptions, [serverResponse], bidRequestData[0].gdprConsent, bidRequestData[0].uspConsent);
-    expect(userSync).to.be.an('array').with.lengthOf(1);
-    expect(userSync[0].type).to.equal('image');
-    expect(userSync[0].url).to.equal('urlA?gdpr=1');
-
-    syncOptions.iframeEnabled = true;
-    syncOptions.pixelEnabled = false;
-    userSync = spec.getUserSyncs(syncOptions, [serverResponse], bidRequestData[0].gdprConsent, bidRequestData[0].uspConsent);
-    expect(userSync).to.be.an('array').with.lengthOf(1);
-    expect(userSync[0].type).to.equal('iframe');
-    expect(userSync[0].url).to.equal('urlB');
-  });
-
-  it('Test getUserSyncs with no response', function () {
-    const syncOptions = {
-      'iframeEnabled': true,
-      'pixelEnabled': false
-    }
-    let userSync = spec.getUserSyncs(syncOptions, [], bidRequestData[0].gdprConsent, bidRequestData[0].uspConsent);
-    expect(userSync).to.be.an('array')
-    expect(userSync[0].type).to.equal('iframe')
-    expect(userSync[0].url).to.equal('https://cookies.nextmillmedia.com/sync?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---&type=iframe')
-  })
-
-  it('Test getUserSyncs function if GDPR is undefined', function () {
-    const syncOptions = {
-      'iframeEnabled': false,
-      'pixelEnabled': true
-    }
-
-    let userSync = spec.getUserSyncs(syncOptions, [serverResponse], undefined, bidRequestData[0].uspConsent);
-    expect(userSync).to.be.an('array').with.lengthOf(1);
-    expect(userSync[0].type).to.equal('image');
-    expect(userSync[0].url).to.equal('urlA?gdpr=0');
-  });
-
-  it('Request params check without GDPR Consent', function () {
-    delete bidRequestData[0].gdprConsent
-    const request = spec.buildRequests(bidRequestData, bidRequestData[0]);
-    expect(JSON.parse(request[0].data).regs.ext.gdpr).to.be.undefined;
-    expect(JSON.parse(request[0].data).regs.ext.us_privacy).to.equal('1---');
-  });
-
   it('validate_generated_params', function() {
     const request = spec.buildRequests(bidRequestData, {bidderRequestId: 'mock-uuid'});
     expect(request[0].bidId).to.equal('bid1234');
@@ -190,7 +613,7 @@ describe('nextMillenniumBidAdapterTests', function() {
 
   it('Check if refresh_count param is incremented', function() {
     const request = spec.buildRequests(bidRequestData);
-    expect(JSON.parse(request[0].data).ext.nextMillennium.refresh_count).to.equal(3);
+    expect(JSON.parse(request[0].data).ext.nextMillennium.refresh_count).to.equal(1);
   });
 
   it('Check if domain was added', function() {

--- a/test/spec/modules/nobidAnalyticsAdapter_spec.js
+++ b/test/spec/modules/nobidAnalyticsAdapter_spec.js
@@ -466,8 +466,8 @@ describe('NoBid Prebid Analytic', function () {
       const previousRetention = nobidAnalytics.retentionSeconds;
       nobidAnalytics.retentionSeconds = 3;
       nobidAnalytics.processServerResponse(JSON.stringify({carbonizer_active: true}));
-      const stored = nobidCarbonizer.getStoredLocalData();
-      expect(stored).to.contain(`{"carbonizer_active":true,"ts":`);
+      let stored = nobidCarbonizer.getStoredLocalData();
+      expect(stored[nobidAnalytics.ANALYTICS_DATA_NAME]).to.contain(`{"carbonizer_active":true,"ts":`);
       clock.tick(5000);
       active = nobidCarbonizer.isActive(adunits, true);
       expect(active).to.equal(false);
@@ -486,6 +486,10 @@ describe('NoBid Prebid Analytic', function () {
         }
       ]
       nobidCarbonizer.carbonizeAdunits(adunits, true);
+      stored = nobidCarbonizer.getStoredLocalData();
+      expect(stored[nobidAnalytics.ANALYTICS_DATA_NAME]).to.contain('{"carbonizer_active":true,"ts":');
+      expect(stored[nobidAnalytics.ANALYTICS_OPT_NAME]).to.contain('{"bidder1":1,"bidder2":1}');
+      clock.tick(5000);
       expect(adunits[0].bids.length).to.equal(0);
 
       done();

--- a/test/spec/modules/pangleBidAdapter_spec.js
+++ b/test/spec/modules/pangleBidAdapter_spec.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { spec } from 'modules/pangleBidAdapter.js';
-import { logInfo } from '../../../src/utils';
 
 const REQUEST = [{
   adUnitCode: 'adUnitCode1',
@@ -84,6 +83,7 @@ const RESPONSE = {
             'cat': [],
             'w': 300,
             'h': 250,
+            'mtype': 1,
             'ext': {
               'prebid': {
                 'type': 'banner'
@@ -186,26 +186,6 @@ describe('pangle bid adapter', function () {
       expect(deviceType).to.equal(2);
     });
   });
-
-  // describe('video', function () {
-  //   it('video config', function() {
-  //     logInfo(spec.buildRequests(VIDEO_REQUEST, DEFAULT_OPTIONS)[0].data, 'spec.buildRequests(videoConfig, DEFAULT_OPTIONS)[0].data.imp[0]');
-  //     const request = spec.buildRequests(VIDEO_REQUEST, DEFAULT_OPTIONS)[0];
-
-  //     expect(request).to.exist.and.to.be.a('object');
-  //     const payload = request.data;
-  //     expect(payload).to.exist.and.to.be.a('object');
-  //     const video = payload.imp[0].video;
-  //     expect(video).to.exist.and.to.be.a('object');
-  //     // console.log(video, 'video???')
-  //     // expect(url).to.equal('https://pangle.pangleglobal.com/api/ad/union/web_js/common/get_ads');
-  //     // assert.deepEqual(video, {
-  //     //   h: 380,
-  //     //   mimes: ['video/mp4'],
-  //     //   w: 240
-  //     // })
-  //   })
-  // })
 });
 
 describe('Pangle Adapter with video', function() {
@@ -247,6 +227,7 @@ describe('Pangle Adapter with video', function() {
               ],
               'w': 640,
               'h': 640,
+              'mtype': 1,
               'ext': {
                 'pangle': {
                   'adtype': 8
@@ -292,4 +273,115 @@ describe('Pangle Adapter with video', function() {
       }
     });
   });
+});
+
+describe('pangle multi-format ads', function () {
+  const bidderRequest = {
+    refererInfo: {
+      referer: 'https://example.com'
+    }
+  };
+  const multiRequest = [
+    {
+      bidId: '2820132fe18114',
+      mediaTypes: { banner: { sizes: [[300, 250]] }, video: { context: 'outstream', playerSize: [[300, 250]] } },
+      params: { token: 'test-token' }
+    }
+  ];
+  const videoResponse = {
+    'headers': null,
+    'body': {
+      'id': '233f1693-68d1-470a-ad85-c156c3faaf6f',
+      'seatbid': [
+        {
+          'bid': [
+            {
+              'id': '2820132fe18114',
+              'impid': '2820132fe18114',
+              'price': 0.03294,
+              'nurl': 'https://api16-event-sg2.pangle.io/api/ad/union/openrtb/win/?req_id=233f1693-68d1-470a-ad85-c156c3faaf6fu1450&ttdsp_adx_index=256&rit=980589944&extra=oqveoB%2Bg4%2ByNz9L8wwu%2Fy%2FwKxQsGaKsJHuB4NMK77uqZ9%2FJKpnsVZculJX8%2FxrRBAtaktU1DRN%2Fy6TKAqibCbj%2FM3%2BZ6biAKQG%2BCyt4eIV0KVvri9jCCnaajbkN7YNJWJJw2lW6cJ6Va3SuJG9H7a%2FAJd2PMbhK7fXWhoW72TwgOcKHKBgjM6sNDISBKbWlZyY3L1PhKSX%2FM8LOvL6qahsb%2FDpEObIx24vhQLNWp28XY1L4UqeibuRjam3eCvN7nXoQq74KkJ45QQsTgvV4j6I6EbLOdjOi%2FURhWMDjUD1VCMpqUT%2B6L8ZROgrX9Tp53eJ3bFOczmSTOmDSazKMHa%2B3uZZ7JHcSx32eoY4hfYc99NOJmYBKXNKCmoXyJvS3PCM3PlAz97hKrDMGnVv1wAQ7QGDCbittF0vZwtsRAvvx2mWINNIB3%2FUB2PjhxFsoDA%2BWE2urVZwEdyu%2FJrCznJsMwenXjcbMD5jmUF5vDkkLS%2B7TMDIEawJPJKZ62pK35enrwGxCs6ePXi21rJJkA0bF8tgAdl4mU1illBIVO4kCL%2ByRASskHPjgg%2FcdFe9HP%2Fi8byjAprH%2BhRerN%2FRKFxC3xv8b75x2pb1g7dY%2FTj9IjT0evsBSPVwFNqtKmPId35IcY%2FSXiqPHh%2FrAHZzr5BPsTT19P49SlNMR9UZYTzViX1iJpcCL1UFjuDdrdff%2BhHCviXxo%2FkRmufEF3umHZwxbdDOPAghuZ0DtRCY6S1rnb%2FK9BbpsVKSndOtgfCwMHFwiPmdw1XjEXGc1eOWXY6qfSp90PIfL6WS7Neh3ba2qMv6WxG3HSOBYvrcCqVTsNxk4UdVm3qb1J0CMVByweTMo45usSkCTdvX3JuEB7tVA6%2BrEk57b3XJd5Phf2AN8hon%2F7lmcXE41kwMQuXq89ViwQmW0G247UFWOQx4t1cmBqFiP6qNA%2F%2BunkZDno1pmAsGnTv7Mz9xtpOaIqKl8BKrVQSTopZ9WcUVzdBUutF19mn1f43BvyA9gIEhcDJHOj&win_price=${AUCTION_PRICE}&auction_mwb=${AUCTION_BID_TO_WIN}&use_pb=1',
+              'lurl': 'https://api16-event-sg2.pangle.io/api/ad/union/openrtb/loss/?req_id=233f1693-68d1-470a-ad85-c156c3faaf6fu1450&ttdsp_adx_index=256&rit=980589944&extra=oqveoB%2Bg4%2ByNz9L8wwu%2Fy%2FwKxQsGaKsJHuB4NMK77uqZ9%2FJKpnsVZculJX8%2FxrRBAtaktU1DRN%2Fy6TKAqibCbj%2FM3%2BZ6biAKQG%2BCyt4eIV0KVvri9jCCnaajbkN7YNJWJJw2lW6cJ6Va3SuJG9H7a%2FAJd2PMbhK7fXWhoW72TwgOcKHKBgjM6sNDISBKbWlZyY3L1PhKSX%2FM8LOvL6qahsb%2FDpEObIx24vhQLNWp28XY1L4UqeibuRjam3eCvN7nXoQq74KkJ45QQsTgvV4j6I6EbLOdjOi%2FURhWMDjUD1VCMpqUT%2B6L8ZROgrX9Tp53eJ3bFOczmSTOmDSazKMHa%2B3uZZ7JHcSx32eoY4hfYc99NOJmYBKXNKCmoXyJvS3PCM3PlAz97hKrDMGnVv1wAQ7QGDCbittF0vZwtsRAvvx2mWINNIB3%2FUB2PjhxFsoDA%2BWE2urVZwEdyu%2FJrCznJsMwenXjcbMD5jmUF5vDkkLS%2B7TMDIEawJPJKZ62pK35enrwGxCs6ePXi21rJJkA0bF8tgAdl4mU1illBIVO4kCL%2ByRASskHPjgg%2FcdFe9HP%2Fi8byjAprH%2BhRerN%2FRKFxC3xv8b75x2pb1g7dY%2FTj9IjT0evsBSPVwFNqtKmPId35IcY%2FSXiqPHh%2FrAHZzr5BPsTT19P49SlNMR9UZYTzViX1iJpcCL1UFjuDdrdff%2BhHCviXxo%2FkRmufEF3umHZwxbdDOPAghuZ0DtRCY6S1rnb%2FK9BbpsVKSndOtgfCwMHFwiPmdw1XjEXGc1eOWXY6qfSp90PIfL6WS7Neh3ba2qMv6WxG3HSOBYvrcCqVTsNxk4UdVm3qb1J0CMVByweTMo45usSkCTdvX3JuEB7tVA6%2BrEk57b3XJd5Phf2AN8hon%2F7lmcXE41kwMQuXq89ViwQmW0G247UFWOQx4t1cmBqFiP6qNA%2F%2BunkZDno1pmAsGnTv7Mz9xtpOaIqKl8BKrVQSTopZ9WcUVzdBUutF19mn1f43BvyA9gIEhcDJHOj&reason=${AUCTION_LOSS}&ad_slot_type=8&auction_mwb=${AUCTION_PRICE}&use_pb=1',
+              'adm': '<VAST version="2.0"></VAST>',
+              'adid': '1780626232977441',
+              'adomain': [
+                'swi.esxcmnb.com'
+              ],
+              'iurl': 'https://p16-ttam-va.ibyteimg.com/origin/ad-site-i18n-sg/202310245d0d598b3ff5993c4f129a8b',
+              'cid': '1780626232977441',
+              'crid': '1780626232977441',
+              'attr': [
+                4
+              ],
+              'w': 640,
+              'h': 640,
+              'mtype': 2,
+              'ext': {
+                'pangle': {
+                  'adtype': 8
+                },
+                'event_notification_token': {
+                  'payload': '980589944:8:1450:7492'
+                }
+              }
+            }
+          ],
+          'seat': 'pangle'
+        }
+      ]
+    }
+  };
+  const bannerResponse = {
+    'headers': null,
+    'body': {
+      'id': '233f1693-68d1-470a-ad85-c156c3faaf6f',
+      'seatbid': [
+        {
+          'bid': [
+            {
+              'id': '2820132fe18114',
+              'impid': '2820132fe18114',
+              'price': 0.03294,
+              'nurl': 'https://api16-event-sg2.pangle.io/api/ad/union/openrtb/win/?req_id=233f1693-68d1-470a-ad85-c156c3faaf6fu1450&ttdsp_adx_index=256&rit=980589944&extra=oqveoB%2Bg4%2ByNz9L8wwu%2Fy%2FwKxQsGaKsJHuB4NMK77uqZ9%2FJKpnsVZculJX8%2FxrRBAtaktU1DRN%2Fy6TKAqibCbj%2FM3%2BZ6biAKQG%2BCyt4eIV0KVvri9jCCnaajbkN7YNJWJJw2lW6cJ6Va3SuJG9H7a%2FAJd2PMbhK7fXWhoW72TwgOcKHKBgjM6sNDISBKbWlZyY3L1PhKSX%2FM8LOvL6qahsb%2FDpEObIx24vhQLNWp28XY1L4UqeibuRjam3eCvN7nXoQq74KkJ45QQsTgvV4j6I6EbLOdjOi%2FURhWMDjUD1VCMpqUT%2B6L8ZROgrX9Tp53eJ3bFOczmSTOmDSazKMHa%2B3uZZ7JHcSx32eoY4hfYc99NOJmYBKXNKCmoXyJvS3PCM3PlAz97hKrDMGnVv1wAQ7QGDCbittF0vZwtsRAvvx2mWINNIB3%2FUB2PjhxFsoDA%2BWE2urVZwEdyu%2FJrCznJsMwenXjcbMD5jmUF5vDkkLS%2B7TMDIEawJPJKZ62pK35enrwGxCs6ePXi21rJJkA0bF8tgAdl4mU1illBIVO4kCL%2ByRASskHPjgg%2FcdFe9HP%2Fi8byjAprH%2BhRerN%2FRKFxC3xv8b75x2pb1g7dY%2FTj9IjT0evsBSPVwFNqtKmPId35IcY%2FSXiqPHh%2FrAHZzr5BPsTT19P49SlNMR9UZYTzViX1iJpcCL1UFjuDdrdff%2BhHCviXxo%2FkRmufEF3umHZwxbdDOPAghuZ0DtRCY6S1rnb%2FK9BbpsVKSndOtgfCwMHFwiPmdw1XjEXGc1eOWXY6qfSp90PIfL6WS7Neh3ba2qMv6WxG3HSOBYvrcCqVTsNxk4UdVm3qb1J0CMVByweTMo45usSkCTdvX3JuEB7tVA6%2BrEk57b3XJd5Phf2AN8hon%2F7lmcXE41kwMQuXq89ViwQmW0G247UFWOQx4t1cmBqFiP6qNA%2F%2BunkZDno1pmAsGnTv7Mz9xtpOaIqKl8BKrVQSTopZ9WcUVzdBUutF19mn1f43BvyA9gIEhcDJHOj&win_price=${AUCTION_PRICE}&auction_mwb=${AUCTION_BID_TO_WIN}&use_pb=1',
+              'lurl': 'https://api16-event-sg2.pangle.io/api/ad/union/openrtb/loss/?req_id=233f1693-68d1-470a-ad85-c156c3faaf6fu1450&ttdsp_adx_index=256&rit=980589944&extra=oqveoB%2Bg4%2ByNz9L8wwu%2Fy%2FwKxQsGaKsJHuB4NMK77uqZ9%2FJKpnsVZculJX8%2FxrRBAtaktU1DRN%2Fy6TKAqibCbj%2FM3%2BZ6biAKQG%2BCyt4eIV0KVvri9jCCnaajbkN7YNJWJJw2lW6cJ6Va3SuJG9H7a%2FAJd2PMbhK7fXWhoW72TwgOcKHKBgjM6sNDISBKbWlZyY3L1PhKSX%2FM8LOvL6qahsb%2FDpEObIx24vhQLNWp28XY1L4UqeibuRjam3eCvN7nXoQq74KkJ45QQsTgvV4j6I6EbLOdjOi%2FURhWMDjUD1VCMpqUT%2B6L8ZROgrX9Tp53eJ3bFOczmSTOmDSazKMHa%2B3uZZ7JHcSx32eoY4hfYc99NOJmYBKXNKCmoXyJvS3PCM3PlAz97hKrDMGnVv1wAQ7QGDCbittF0vZwtsRAvvx2mWINNIB3%2FUB2PjhxFsoDA%2BWE2urVZwEdyu%2FJrCznJsMwenXjcbMD5jmUF5vDkkLS%2B7TMDIEawJPJKZ62pK35enrwGxCs6ePXi21rJJkA0bF8tgAdl4mU1illBIVO4kCL%2ByRASskHPjgg%2FcdFe9HP%2Fi8byjAprH%2BhRerN%2FRKFxC3xv8b75x2pb1g7dY%2FTj9IjT0evsBSPVwFNqtKmPId35IcY%2FSXiqPHh%2FrAHZzr5BPsTT19P49SlNMR9UZYTzViX1iJpcCL1UFjuDdrdff%2BhHCviXxo%2FkRmufEF3umHZwxbdDOPAghuZ0DtRCY6S1rnb%2FK9BbpsVKSndOtgfCwMHFwiPmdw1XjEXGc1eOWXY6qfSp90PIfL6WS7Neh3ba2qMv6WxG3HSOBYvrcCqVTsNxk4UdVm3qb1J0CMVByweTMo45usSkCTdvX3JuEB7tVA6%2BrEk57b3XJd5Phf2AN8hon%2F7lmcXE41kwMQuXq89ViwQmW0G247UFWOQx4t1cmBqFiP6qNA%2F%2BunkZDno1pmAsGnTv7Mz9xtpOaIqKl8BKrVQSTopZ9WcUVzdBUutF19mn1f43BvyA9gIEhcDJHOj&reason=${AUCTION_LOSS}&ad_slot_type=8&auction_mwb=${AUCTION_PRICE}&use_pb=1',
+              'adm': '<img src="" />',
+              'adid': '1780626232977441',
+              'adomain': [
+                'swi.esxcmnb.com'
+              ],
+              'iurl': 'https://p16-ttam-va.ibyteimg.com/origin/ad-site-i18n-sg/202310245d0d598b3ff5993c4f129a8b',
+              'cid': '1780626232977441',
+              'crid': '1780626232977441',
+              'attr': [
+                4
+              ],
+              'w': 640,
+              'h': 640,
+              'mtype': 1,
+              'ext': {
+                'pangle': {
+                  'adtype': 8
+                },
+                'event_notification_token': {
+                  'payload': '980589944:8:1450:7492'
+                }
+              }
+            }
+          ],
+          'seat': 'pangle'
+        }
+      ]
+    }
+  };
+  it('should set mediaType to banner', function() {
+    const request = spec.buildRequests(multiRequest, bidderRequest)[0];
+    const interpretedResponse = spec.interpretResponse(bannerResponse, request);
+    const bid = interpretedResponse[0];
+    expect(bid.mediaType).to.equal('banner');
+  })
+  it('should set mediaType to video', function() {
+    const request = spec.buildRequests(multiRequest, bidderRequest)[0];
+    const interpretedResponse = spec.interpretResponse(videoResponse, request);
+    const bid = interpretedResponse[0];
+    expect(bid.mediaType).to.equal('video');
+  })
 });

--- a/test/spec/modules/pgamsspBidAdapter_spec.js
+++ b/test/spec/modules/pgamsspBidAdapter_spec.js
@@ -145,6 +145,7 @@ describe('PGAMBidAdapter', function () {
         expect(placement.schain).to.be.an('object');
         expect(placement.bidfloor).to.exist.and.to.equal(0);
         expect(placement.type).to.exist.and.to.equal('publisher');
+        expect(placement.eids).to.exist.and.to.be.an('array');
 
         if (placement.adFormat === BANNER) {
           expect(placement.sizes).to.be.an('array');

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -12,7 +12,7 @@ import {
   isFloorsDataValid,
   addBidResponseHook,
   fieldMatchingFunctions,
-  allowedFields, parseFloorData, normalizeDefault, getFloorDataFromAdUnits
+  allowedFields, parseFloorData, normalizeDefault, getFloorDataFromAdUnits, updateAdUnitsForAuction, createFloorsDataForAuction
 } from 'modules/priceFloors.js';
 import * as events from 'src/events.js';
 import * as mockGpt from '../integration/faker/googletag.js';
@@ -648,6 +648,90 @@ describe('the price floors module', function () {
       });
     });
   });
+
+  describe('updateAdUnitsForAuction', function() {
+    let inputFloorData;
+    let adUnits;
+
+    beforeEach(function() {
+      adUnits = [getAdUnitMock()];
+      inputFloorData = utils.deepClone(minFloorConfigLow);
+      inputFloorData.skipRate = 0.5;
+    });
+
+    it('should set the skipRate to the skipRate from the data property before using the skipRate from floorData directly', function() {
+      utils.deepSetValue(inputFloorData, 'data', {
+        skipRate: 0.7
+      });
+      updateAdUnitsForAuction(adUnits, inputFloorData, 'id');
+
+      const skipRate = utils.deepAccess(adUnits, '0.bids.0.floorData.skipRate');
+      expect(skipRate).to.equal(0.7);
+    });
+
+    it('should set the skipRate to the skipRate from floorData directly if it does not exist in the data property of floorData', function() {
+      updateAdUnitsForAuction(adUnits, inputFloorData, 'id');
+
+      const skipRate = utils.deepAccess(adUnits, '0.bids.0.floorData.skipRate');
+      expect(skipRate).to.equal(0.5);
+    });
+
+    it('should set the skipRate in the bid floorData to undefined if both skipRate and skipRate in the data property are undefined', function() {
+      inputFloorData.skipRate = undefined;
+      utils.deepSetValue(inputFloorData, 'data', {
+        skipRate: undefined,
+      });
+      updateAdUnitsForAuction(adUnits, inputFloorData, 'id');
+
+      const skipRate = utils.deepAccess(adUnits, '0.bids.0.floorData.skipRate');
+      expect(skipRate).to.equal(undefined);
+    });
+  });
+
+  describe('createFloorsDataForAuction', function() {
+    let adUnits;
+    let floorConfig;
+
+    beforeEach(function() {
+      adUnits = [getAdUnitMock()];
+      floorConfig = utils.deepClone(basicFloorConfig);
+    });
+
+    it('should return skipRate as 0 if both skipRate and skipRate in the data property are undefined', function() {
+      floorConfig.skipRate = undefined;
+      floorConfig.data.skipRate = undefined;
+      handleSetFloorsConfig(floorConfig);
+
+      const floorData = createFloorsDataForAuction(adUnits, 'id');
+
+      expect(floorData.skipRate).to.equal(0);
+      expect(floorData.skipped).to.equal(false);
+    });
+
+    it('should properly set skipRate if it is available in the data property', function() {
+      // this will force skipped to be true
+      floorConfig.skipRate = 101;
+      floorConfig.data.skipRate = 201;
+      handleSetFloorsConfig(floorConfig);
+
+      const floorData = createFloorsDataForAuction(adUnits, 'id');
+
+      expect(floorData.data.skipRate).to.equal(201);
+      expect(floorData.skipped).to.equal(true);
+    });
+
+    it('should should use the skipRate if its not available in the data property ', function() {
+      // this will force skipped to be true
+      floorConfig.skipRate = 101;
+      handleSetFloorsConfig(floorConfig);
+
+      const floorData = createFloorsDataForAuction(adUnits, 'id');
+
+      expect(floorData.skipRate).to.equal(101);
+      expect(floorData.skipped).to.equal(true);
+    });
+  });
+
   describe('pre-auction tests', function () {
     let exposedAdUnits;
     const validateBidRequests = (getFloorExpected, FloorDataExpected) => {
@@ -688,6 +772,124 @@ describe('the price floors module', function () {
         fetchStatus: undefined,
         floorProvider: undefined
       });
+    });
+    it('should not do floor stuff if floors.data is defined by noFloorSignalBidders[]', function() {
+      handleSetFloorsConfig({
+        ...basicFloorConfig,
+        data: {
+          ...basicFloorDataLow,
+          noFloorSignalBidders: ['someBidder', 'someOtherBidder']
+        }});
+      runStandardAuction();
+      validateBidRequests(false, {
+        skipped: false,
+        floorMin: undefined,
+        modelVersion: 'basic model',
+        modelWeight: 10,
+        modelTimestamp: undefined,
+        location: 'setConfig',
+        skipRate: 0,
+        fetchStatus: undefined,
+        floorProvider: undefined,
+        noFloorSignaled: true
+      })
+    });
+    it('should not do floor stuff if floors.enforcement is defined by noFloorSignalBidders[]', function() {
+      handleSetFloorsConfig({ ...basicFloorConfig,
+        enforcement: {
+          enforceJS: true,
+          noFloorSignalBidders: ['someBidder', 'someOtherBidder']
+        },
+        data: basicFloorDataLow
+      });
+      runStandardAuction();
+      validateBidRequests(false, {
+        skipped: false,
+        floorMin: undefined,
+        modelVersion: 'basic model',
+        modelWeight: 10,
+        modelTimestamp: undefined,
+        location: 'setConfig',
+        skipRate: 0,
+        fetchStatus: undefined,
+        floorProvider: undefined,
+        noFloorSignaled: true
+      })
+    });
+    it('should not do floor stuff and use first floors.data.noFloorSignalBidders if its defined betwen enforcement.noFloorSignalBidders', function() {
+      handleSetFloorsConfig({ ...basicFloorConfig,
+        enforcement: {
+          enforceJS: true,
+          noFloorSignalBidders: ['someBidder']
+        },
+        data: {
+          ...basicFloorDataLow,
+          noFloorSignalBidders: ['someBidder', 'someOtherBidder']
+        }
+      });
+      runStandardAuction();
+      validateBidRequests(false, {
+        skipped: false,
+        floorMin: undefined,
+        modelVersion: 'basic model',
+        modelWeight: 10,
+        modelTimestamp: undefined,
+        location: 'setConfig',
+        skipRate: 0,
+        fetchStatus: undefined,
+        floorProvider: undefined,
+        noFloorSignaled: true
+      })
+    });
+    it('it shouldn`t return floor stuff for bidder in the noFloorSignalBidders list', function() {
+      handleSetFloorsConfig({ ...basicFloorConfig,
+        enforcement: {
+          enforceJS: true,
+        },
+        data: {
+          ...basicFloorDataLow,
+          noFloorSignalBidders: ['someBidder']
+        }
+      });
+      runStandardAuction()
+      const bidRequestData = exposedAdUnits[0].bids.find(bid => bid.bidder === 'someBidder');
+      expect(bidRequestData.hasOwnProperty('getFloor')).to.equal(false);
+      sinon.assert.match(bidRequestData.floorData, {
+        skipped: false,
+        floorMin: undefined,
+        modelVersion: 'basic model',
+        modelWeight: 10,
+        modelTimestamp: undefined,
+        location: 'setConfig',
+        skipRate: 0,
+        fetchStatus: undefined,
+        floorProvider: undefined,
+        noFloorSignaled: true
+      });
+    })
+    it('it should return floor stuff if we defined wrong bidder name in data.noFloorSignalBidders', function() {
+      handleSetFloorsConfig({ ...basicFloorConfig,
+        enforcement: {
+          enforceJS: true,
+        },
+        data: {
+          ...basicFloorDataLow,
+          noFloorSignalBidders: ['randomBiider']
+        }
+      });
+      runStandardAuction();
+      validateBidRequests(true, {
+        skipped: false,
+        floorMin: undefined,
+        modelVersion: 'basic model',
+        modelWeight: 10,
+        modelTimestamp: undefined,
+        location: 'setConfig',
+        skipRate: 0,
+        fetchStatus: undefined,
+        floorProvider: undefined,
+        noFloorSignaled: false
+      })
     });
     it('should use adUnit level data if not setConfig or fetch has occured', function () {
       handleSetFloorsConfig({

--- a/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
@@ -1,4 +1,4 @@
-import pubmaticAnalyticsAdapter, {getMetadata} from 'modules/pubmaticAnalyticsAdapter.js';
+import pubmaticAnalyticsAdapter, { getMetadata } from 'modules/pubmaticAnalyticsAdapter.js';
 import adapterManager from 'src/adapterManager.js';
 import CONSTANTS from 'src/constants.json';
 import { config } from 'src/config.js';
@@ -316,6 +316,208 @@ describe('pubmatic analytics adapter', function () {
     expect(utils.logError.called).to.equal(true);
   });
 
+  describe('OW S2S', function() {
+    this.beforeEach(function() {
+      pubmaticAnalyticsAdapter.enableAnalytics({
+        options: {
+          publisherId: 9999,
+          profileId: 1111,
+          profileVersionId: 20
+        }
+      });
+      config.setConfig({
+        s2sConfig: {
+          accountId: '1234',
+          bidders: ['pubmatic'],
+          defaultVendor: 'openwrap',
+          timeout: 500
+        }
+      });
+    });
+
+    this.afterEach(function() {
+      pubmaticAnalyticsAdapter.disableAnalytics();
+    });
+
+    it('Pubmatic Won: No tracker fired', function() {
+      this.timeout(5000)
+
+      sandbox.stub($$PREBID_GLOBAL$$, 'getHighestCpmBids').callsFake((key) => {
+        return [MOCK.BID_RESPONSE[0], MOCK.BID_RESPONSE[1]]
+      });
+
+      config.setConfig({
+        testGroupId: 15
+      });
+
+      events.emit(AUCTION_INIT, MOCK.AUCTION_INIT);
+      events.emit(BID_REQUESTED, MOCK.BID_REQUESTED);
+      events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[0]);
+      events.emit(BIDDER_DONE, MOCK.BIDDER_DONE);
+      events.emit(AUCTION_END, MOCK.AUCTION_END);
+      events.emit(SET_TARGETING, MOCK.SET_TARGETING);
+      events.emit(BID_WON, MOCK.BID_WON[0]);
+
+      clock.tick(2000 + 1000);
+      expect(requests.length).to.equal(1); // only logger is fired
+      let request = requests[0];
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      let data = getLoggerJsonFromRequest(request.requestBody);
+      expect(data.pubid).to.equal('9999');
+      expect(data.pid).to.equal('1111');
+      expect(data.pdvid).to.equal('20');
+    });
+
+    it('Non-pubmatic won: logger, tracker fired', function() {
+      const APPNEXUS_BID = Object.assign({}, BID, {
+        'bidder': 'appnexus',
+        'adserverTargeting': {
+          'hb_bidder': 'appnexus',
+          'hb_adid': '2ecff0db240757',
+          'hb_pb': 1.20,
+          'hb_size': '640x480',
+          'hb_source': 'server'
+        }
+      });
+
+      const MOCK_AUCTION_INIT_APPNEXUS = {
+        'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
+        'timestamp': 1519767010567,
+        'auctionStatus': 'inProgress',
+        'adUnits': [ {
+          'code': '/19968336/header-bid-tag-1',
+          'sizes': [[640, 480]],
+          'bids': [ {
+            'bidder': 'appnexus',
+            'params': {
+              'publisherId': '1001'
+            }
+          } ],
+          'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014'
+        }
+        ],
+        'adUnitCodes': ['/19968336/header-bid-tag-1'],
+        'bidderRequests': [ {
+          'bidderCode': 'appnexus',
+          'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
+          'bidderRequestId': '1be65d7958826a',
+          'bids': [ {
+            'bidder': 'appnexus',
+            'params': {
+              'publisherId': '1001',
+              'kgpv': 'this-is-a-kgpv'
+            },
+            'mediaTypes': {
+              'banner': {
+                'sizes': [[640, 480]]
+              }
+            },
+            'adUnitCode': '/19968336/header-bid-tag-1',
+            'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
+            'sizes': [[640, 480]],
+            'bidId': '2ecff0db240757',
+            'bidderRequestId': '1be65d7958826a',
+            'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
+            'src': 'client',
+            'bidRequestsCount': 1
+          }
+          ],
+          'timeout': 3000,
+          'refererInfo': {
+            'topmostLocation': 'http://www.test.com/page.html', 'reachedTop': true, 'numIframes': 0, 'stack': ['http://www.test.com/page.html']
+          }
+        }
+        ],
+        'bidsReceived': [],
+        'winningBids': [],
+        'timeout': 3000
+      };
+
+      const MOCK_BID_REQUESTED_APPNEXUS = {
+        'bidder': 'appnexus',
+        'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
+        'bidderRequestId': '1be65d7958826a',
+        'bids': [
+          {
+            'bidder': 'appnexus',
+            'adapterCode': 'appnexus',
+            'bidderCode': 'appnexus',
+            'params': {
+              'publisherId': '1001',
+              'video': {
+                'minduration': 30,
+                'skippable': true
+              }
+            },
+            'mediaType': 'video',
+            'adUnitCode': '/19968336/header-bid-tag-0',
+            'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
+            'sizes': [[640, 480]],
+            'bidId': '2ecff0db240757',
+            'bidderRequestId': '1be65d7958826a',
+            'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa'
+          }
+        ],
+        'auctionStart': 1519149536560,
+        'timeout': 5000,
+        'start': 1519149562216,
+        'refererInfo': {
+          'topmostLocation': 'http://www.test.com/page.html', 'reachedTop': true, 'numIframes': 0, 'stack': ['http://www.test.com/page.html']
+        },
+        'gdprConsent': {
+          'consentString': 'here-goes-gdpr-consent-string',
+          'gdprApplies': true
+        }
+      };
+
+      this.timeout(5000)
+
+      sandbox.stub($$PREBID_GLOBAL$$, 'getHighestCpmBids').callsFake((key) => {
+        return [APPNEXUS_BID]
+      });
+
+      events.emit(AUCTION_INIT, MOCK_AUCTION_INIT_APPNEXUS);
+      events.emit(BID_REQUESTED, MOCK_BID_REQUESTED_APPNEXUS);
+      events.emit(BID_RESPONSE, APPNEXUS_BID);
+      events.emit(BIDDER_DONE, {
+        'bidderCode': 'appnexus',
+        'bids': [
+          APPNEXUS_BID,
+          Object.assign({}, APPNEXUS_BID, {
+            'serverResponseTimeMs': 42,
+          })
+        ]
+      });
+      events.emit(AUCTION_END, MOCK.AUCTION_END);
+      events.emit(SET_TARGETING, {
+        [APPNEXUS_BID.adUnitCode]: APPNEXUS_BID.adserverTargeting,
+      });
+      events.emit(BID_WON, Object.assign({}, APPNEXUS_BID, {
+        'status': 'rendered'
+      }));
+
+      clock.tick(2000 + 1000);
+      expect(requests.length).to.equal(2); // logger as well as tracker is fired
+      let request = requests[1]; // logger is executed late, trackers execute first
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      let data = getLoggerJsonFromRequest(request.requestBody);
+      expect(data.pubid).to.equal('9999');
+      expect(data.pid).to.equal('1111');
+      expect(data.pdvid).to.equal('20');
+
+      let firstTracker = requests[0].url;
+      expect(firstTracker.split('?')[0]).to.equal('https://t.pubmatic.com/wt');
+      firstTracker.split('?')[1].split('&').map(e => e.split('=')).forEach(e => data[e[0]] = e[1]);
+      expect(data.pubid).to.equal('9999');
+      expect(decodeURIComponent(data.purl)).to.equal('http://www.test.com/page.html');
+
+      expect(data.s).to.be.an('array');
+      expect(data.s.length).to.equal(1);
+      expect(data.s[0].ps[0].pn).to.equal('appnexus');
+      expect(data.s[0].ps[0].bc).to.equal('appnexus');
+    })
+  });
+
   describe('when handling events', function() {
     beforeEach(function () {
       pubmaticAnalyticsAdapter.enableAnalytics({
@@ -374,10 +576,14 @@ describe('pubmatic analytics adapter', function () {
       // slot 1
       expect(data.s[0].sn).to.equal('/19968336/header-bid-tag-0');
       expect(data.s[0].fskp).to.equal(0);
+      expect(data.s[0].sid).not.to.be.undefined;
+      expect(data.s[0].ffs).to.equal(1);
+      expect(data.s[0].fsrc).to.equal(2);
+      expect(data.s[0].fp).to.equal('pubmatic');
       expect(data.s[0].sz).to.deep.equal(['640x480']);
       expect(data.s[0].ps).to.be.an('array');
-	  expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
-	  expect(data.s[0].ps.length).to.equal(1);
+      expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
+      expect(data.s[0].ps.length).to.equal(1);
       expect(data.s[0].ps[0].pn).to.equal('pubmatic');
       expect(data.s[0].ps[0].bc).to.equal('pubmatic');
       expect(data.s[0].ps[0].bidid).to.equal('2ecff0db240757');
@@ -390,8 +596,8 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[0].ps[0].en).to.equal(1.23);
       expect(data.s[0].ps[0].di).to.equal('-1');
       expect(data.s[0].ps[0].dc).to.equal('');
-	  expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].l1).to.equal(944);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[0].ps[0].l2).to.equal(0);
       expect(data.s[0].ps[0].ss).to.equal(1);
       expect(data.s[0].ps[0].t).to.equal(0);
@@ -403,6 +609,10 @@ describe('pubmatic analytics adapter', function () {
       // slot 2
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].fskp).to.equal(0);
+      expect(data.s[1].sid).not.to.be.undefined;
+      expect(data.s[1].ffs).to.equal(1);
+      expect(data.s[1].fsrc).to.equal(2);
+      expect(data.s[1].fp).to.equal('pubmatic');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
@@ -421,7 +631,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(0);
@@ -459,7 +669,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.af).to.equal('video');
     });
 
-    it('Logger: do not log floor fields when prebids floor shows noData in location property', function() {
+    it('Logger : do not log floor fields when prebids floor shows noData in location property', function() {
       const BID_REQUESTED_COPY = utils.deepClone(MOCK.BID_REQUESTED);
       BID_REQUESTED_COPY['bids'][1]['floorData']['location'] = 'noData';
 
@@ -583,9 +793,13 @@ describe('pubmatic analytics adapter', function () {
       // slot 1
       expect(data.s[0].sn).to.equal('/19968336/header-bid-tag-0');
       expect(data.s[0].fskp).to.equal(0);
+      expect(data.s[0].sid).not.to.be.undefined;
+      expect(data.s[0].ffs).to.equal(1);
+      expect(data.s[0].fsrc).to.equal(2);
+      expect(data.s[0].fp).to.equal('pubmatic');
       expect(data.s[0].sz).to.deep.equal(['640x480']);
       expect(data.s[0].ps).to.be.an('array');
-	  expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
+      expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
       expect(data.s[0].ps.length).to.equal(1);
       expect(data.s[0].ps[0].pn).to.equal('pubmatic');
       expect(data.s[0].ps[0].bc).to.equal('pubmatic');
@@ -659,7 +873,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[0].sz).to.deep.equal(['640x480']);
       expect(data.s[0].ps).to.be.an('array');
       expect(data.s[0].ps.length).to.equal(1);
-	  expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
+      expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
       expect(data.s[0].ps[0].pn).to.equal('pubmatic');
       expect(data.s[0].ps[0].bc).to.equal('pubmatic');
       expect(data.s[0].ps[0].bidid).to.equal('2ecff0db240757');
@@ -702,6 +916,13 @@ describe('pubmatic analytics adapter', function () {
       expect(data.tgid).to.equal(0);// test group id should be an INT between 0-15 else set to 0
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].fskp).to.equal(0);
+
+      expect(data.s[1].sid).not.to.be.undefined;
+
+      expect(data.s[1].ffs).to.equal(1);
+      expect(data.s[1].fsrc).to.equal(2);
+      expect(data.s[1].fp).to.equal('pubmatic');
+
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
@@ -784,6 +1005,10 @@ describe('pubmatic analytics adapter', function () {
       let data = getLoggerJsonFromRequest(request.requestBody);
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].fskp).to.equal(0);
+      expect(data.s[1].sid).not.to.be.undefined;
+      expect(data.s[1].ffs).to.equal(1);
+      expect(data.s[1].fsrc).to.equal(2);
+      expect(data.s[1].fp).to.equal('pubmatic');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
@@ -800,8 +1025,8 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].dc).to.equal('PMP');
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
-	  expect(data.s[0].ps[0].l1).to.equal(0);
-	  expect(data.s[0].ps[0].ol1).to.equal(0);
+      expect(data.s[0].ps[0].l1).to.equal(0);
+      expect(data.s[0].ps[0].ol1).to.equal(0);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(1);
@@ -846,6 +1071,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
       expect(data.s[1].ps).to.be.an('array');
+      expect(data.s[1].sid).not.to.be.undefined;
       expect(data.s[1].ps.length).to.equal(1);
       expect(data.s[1].ps[0].pn).to.equal('pubmatic');
       expect(data.s[1].ps[0].bc).to.equal('pubmatic');
@@ -861,7 +1087,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(0);
@@ -893,6 +1119,10 @@ describe('pubmatic analytics adapter', function () {
       let data = getLoggerJsonFromRequest(request.requestBody);
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].fskp).to.equal(0);
+      expect(data.s[1].sid).not.to.be.undefined;
+      expect(data.s[1].ffs).to.equal(1);
+      expect(data.s[1].fsrc).to.equal(2);
+      expect(data.s[1].fp).to.equal('pubmatic');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
@@ -910,7 +1140,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(0);
@@ -952,6 +1182,7 @@ describe('pubmatic analytics adapter', function () {
       let data = getLoggerJsonFromRequest(request.requestBody);
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
+      expect(data.s[1].sid).not.to.be.undefined;
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
       expect(data.s[1].ps[0].pn).to.equal('pubmatic');
@@ -968,7 +1199,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(0);
@@ -1006,6 +1237,10 @@ describe('pubmatic analytics adapter', function () {
       let data = getLoggerJsonFromRequest(request.requestBody);
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].fskp).to.equal(0);
+      expect(data.s[1].sid).not.to.be.undefined;
+      expect(data.s[1].ffs).to.equal(1);
+      expect(data.s[1].fsrc).to.equal(2);
+      expect(data.s[1].fp).to.equal('pubmatic');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
@@ -1023,7 +1258,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(0);
@@ -1063,6 +1298,7 @@ describe('pubmatic analytics adapter', function () {
       let data = getLoggerJsonFromRequest(request.requestBody);
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
+      expect(data.s[1].sid).not.to.be.undefined;
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
       expect(data.s[1].ps[0].pn).to.equal('pubmatic');
@@ -1079,7 +1315,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(0);
@@ -1121,7 +1357,11 @@ describe('pubmatic analytics adapter', function () {
       // Testing only for rejected bid as other scenarios will be covered under other TCs
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].fskp).to.equal(0);
+      expect(data.s[1].ffs).to.equal(1);
+      expect(data.s[1].fsrc).to.equal(2);
+      expect(data.s[1].fp).to.equal('pubmatic');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
+      expect(data.s[1].sid).not.to.be.undefined;
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
       expect(data.s[1].ps[0].pn).to.equal('pubmatic');
@@ -1139,7 +1379,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(0);
@@ -1196,9 +1436,13 @@ describe('pubmatic analytics adapter', function () {
       // slot 1
       expect(data.s[0].sn).to.equal('/19968336/header-bid-tag-0');
       expect(data.s[0].fskp).to.equal(0);
+      expect(data.s[0].ffs).to.equal(1);
+      expect(data.s[0].fsrc).to.equal(2);
+      expect(data.s[0].fp).to.equal('pubmatic');
       expect(data.s[0].sz).to.deep.equal(['640x480']);
+      expect(data.s[0].sid).not.to.be.undefined;
       expect(data.s[0].ps).to.be.an('array');
-	    expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
+      expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
       expect(data.s[0].ps.length).to.equal(1);
       expect(data.s[0].ps[0].pn).to.equal('pubmatic');
       expect(data.s[0].ps[0].bc).to.equal('pubmatic_alias');
@@ -1213,7 +1457,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[0].ps[0].di).to.equal('-1');
       expect(data.s[0].ps[0].dc).to.equal('');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[0].ps[0].l2).to.equal(0);
       expect(data.s[0].ps[0].ss).to.equal(0);
       expect(data.s[0].ps[0].t).to.equal(0);
@@ -1226,7 +1470,11 @@ describe('pubmatic analytics adapter', function () {
       // slot 2
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].fskp).to.equal(0);
+      expect(data.s[1].ffs).to.equal(1);
+      expect(data.s[1].fsrc).to.equal(2);
+      expect(data.s[1].fp).to.equal('pubmatic');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
+      expect(data.s[1].sid).not.to.be.undefined;
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
       expect(data.s[1].ps[0].pn).to.equal('pubmatic');
@@ -1243,8 +1491,8 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].dc).to.equal('PMP');
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
-	  expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].l1).to.equal(944);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(0);
@@ -1318,9 +1566,13 @@ describe('pubmatic analytics adapter', function () {
       // slot 1
       expect(data.s[0].sn).to.equal('/19968336/header-bid-tag-0');
       expect(data.s[0].fskp).to.equal(0);
+      expect(data.s[0].ffs).to.equal(1);
+      expect(data.s[0].fsrc).to.equal(2);
+      expect(data.s[0].fp).to.equal('pubmatic');
       expect(data.s[0].sz).to.deep.equal(['640x480']);
+      expect(data.s[0].sid).not.to.be.undefined;
       expect(data.s[0].ps).to.be.an('array');
-	    expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
+      expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
       expect(data.s[0].ps.length).to.equal(1);
       expect(data.s[0].ps[0].pn).to.equal('pubmatic');
       expect(data.s[0].ps[0].bc).to.equal('groupm');
@@ -1335,7 +1587,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[0].ps[0].di).to.equal('-1');
       expect(data.s[0].ps[0].dc).to.equal('');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[0].ps[0].l2).to.equal(0);
       expect(data.s[0].ps[0].ss).to.equal(0);
       expect(data.s[0].ps[0].t).to.equal(0);
@@ -1348,6 +1600,7 @@ describe('pubmatic analytics adapter', function () {
       // slot 2
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
+      expect(data.s[1].sid).not.to.be.undefined;
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
       expect(data.s[1].ps[0].pn).to.equal('pubmatic');
@@ -1365,7 +1618,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(0);

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -104,6 +104,7 @@ describe('PubMatic adapter', function () {
         params: {
           publisherId: '5890',
           adSlot: 'Div1@0x0', // ad_id or tagid
+          wiid: 'new-unique-wiid',
           video: {
             mimes: ['video/mp4', 'video/x-flv'],
             skippable: true,
@@ -154,6 +155,7 @@ describe('PubMatic adapter', function () {
         params: {
           publisherId: '5890',
           adSlot: 'Div1@640x480', // ad_id or tagid
+          wiid: '1234567890',
           video: {
             mimes: ['video/mp4', 'video/x-flv'],
             skippable: true,
@@ -213,6 +215,7 @@ describe('PubMatic adapter', function () {
       params: {
         publisherId: '5670',
         adSlot: '/43743431/NativeAutomationPrebid@1x1',
+        wiid: 'new-unique-wiid'
       },
       bidId: '2a5571261281d4',
       requestId: 'B68287E1-DC39-4B38-9790-FE4F179739D6',
@@ -278,6 +281,7 @@ describe('PubMatic adapter', function () {
       params: {
         publisherId: '5670',
         adSlot: '/43743431/NativeAutomationPrebid@1x1',
+        wiid: 'new-unique-wiid'
       },
       bidId: '2a5571261281d4',
       requestId: 'B68287E1-DC39-4B38-9790-FE4F179739D6',
@@ -304,6 +308,7 @@ describe('PubMatic adapter', function () {
       params: {
         publisherId: '5670',
         adSlot: '/43743431/NativeAutomationPrebid@1x1',
+        wiid: 'new-unique-wiid'
       }
     }];
 
@@ -344,6 +349,7 @@ describe('PubMatic adapter', function () {
       params: {
         publisherId: '5670',
         adSlot: '/43743431/NativeAutomationPrebid@1x1',
+        wiid: 'new-unique-wiid'
       }
     }];
 
@@ -502,6 +508,7 @@ describe('PubMatic adapter', function () {
         params: {
           publisherId: '301',
           adSlot: '/15671365/DMDemo@300x250:0',
+          wiid: 'new-unique-wiid',
           video: {
             mimes: ['video/mp4', 'video/x-flv'],
             skippable: true,
@@ -572,6 +579,7 @@ describe('PubMatic adapter', function () {
         params: {
           publisherId: '301',
           adSlot: '/15671365/DMDemo@300x250:0',
+          wiid: 'new-unique-wiid',
           video: {
             mimes: ['video/mp4', 'video/x-flv'],
             skippable: true,
@@ -1912,6 +1920,15 @@ describe('PubMatic adapter', function () {
           const request = spec.buildRequests(bidRequests, {ortb2});
           let data = JSON.parse(request.data);
           expect(data.user.yob).to.equal(1985);
+        });
+
+        it('ortb2.badv should be merged in the request', function() {
+          const ortb2 = {
+            badv: ['example.com']
+          };
+          const request = spec.buildRequests(bidRequests, {ortb2});
+          let data = JSON.parse(request.data);
+          expect(data.badv).to.deep.equal(['example.com']);
         });
 
         describe('ortb2Imp', function() {

--- a/test/spec/modules/r2b2BidAdapter_spec.js
+++ b/test/spec/modules/r2b2BidAdapter_spec.js
@@ -1,0 +1,689 @@
+import {expect} from 'chai';
+import {spec, internal as r2b2, internal} from 'modules/r2b2BidAdapter.js';
+import * as utils from '../../../src/utils';
+import 'modules/schain.js';
+import 'modules/userId/index.js';
+
+function encodePlacementIds (ids) {
+  return btoa(JSON.stringify(ids));
+}
+
+describe('R2B2 adapter', function () {
+  let serverResponse, requestForInterpretResponse;
+  let bidderRequest;
+  let bids = [];
+  let gdprConsent = {
+    gdprApplies: true,
+    consentString: 'consent-string',
+  };
+  let schain = {
+    ver: '1.0',
+    complete: 1,
+    nodes: [{
+      asi: 'example.com',
+      sid: '00001',
+      hp: 1
+    }]
+  };
+  const usPrivacyString = '1YNN';
+  const impId = 'impID';
+  const price = 10.6;
+  const ad = 'adm';
+  const creativeId = 'creativeID';
+  const cid = 41849;
+  const cdid = 595121;
+  const unitCode = 'unitCode';
+  const bidId1 = '1';
+  const bidId2 = '2';
+  const bidId3 = '3';
+  const bidId4 = '4';
+  const bidId5 = '5';
+  const bidWonUrl = 'url1';
+  const setTargetingUrl = 'url2';
+  const bidder = 'r2b2';
+  const foreignBidder = 'differentBidder';
+  const id1 = { pid: 'd/g/p' };
+  const id1Object = { d: 'd', g: 'g', p: 'p', m: 0 };
+  const id2 = { pid: 'd/g/p/1' };
+  const id2Object = { d: 'd', g: 'g', p: 'p', m: 1 };
+  const badId = { pid: 'd/g/' };
+  const bid1 = { bidId: bidId1, bidder, params: [ id1 ] };
+  const bid2 = { bidId: bidId2, bidder, params: [ id2 ] };
+  const bidWithBadSetup = { bidId: bidId3, bidder, params: [ badId ] };
+  const bidForeign1 = { bidId: bidId4, bidder: foreignBidder, params: [ { id: 'abc' } ] };
+  const bidForeign2 = { bidId: bidId5, bidder: foreignBidder, params: [ { id: 'xyz' } ] };
+  const fakeTime = 1234567890;
+  const cacheBusterRegex = /[\?&]cb=([^&]+)/;
+  let bidStub, time;
+
+  beforeEach(function () {
+    bids = [{
+      bidder: 'r2b2',
+      params: {
+        pid: 'example.com/generic/300x250/1'
+      },
+      mediaTypes: {
+        banner: {
+          sizes: [
+            [300, 250]
+          ]
+        }
+      },
+      adUnitCode: unitCode,
+      transactionId: '29c408b9-65ce-48b1-9167-18a57791f908',
+      sizes: [
+        [300, 250]
+      ],
+      bidId: '20917a54ee9858',
+      bidderRequestId: '15270d403778d',
+      auctionId: '36acef1b-f635-4f57-b693-5cc55ee16346',
+      src: 'client',
+      ortb2: {
+        regs: {
+          ext: {
+            gdpr: 1,
+            us_privacy: '1YYY'
+          }
+        },
+        user: {
+          ext: {
+            consent: 'consent-string'
+          }
+        },
+        site: {},
+        device: {}
+      },
+      schain
+    }, {
+      bidder: 'r2b2',
+      params: {
+        pid: 'example.com/generic/300x600/0'
+      },
+      mediaTypes: {
+        banner: {
+          sizes: [
+            [300, 600]
+          ]
+        }
+      },
+      adUnitCode: unitCode,
+      transactionId: '29c408b9-65ce-48b1-9167-18a57791f908',
+      sizes: [
+        [300, 600]
+      ],
+      bidId: '3dd53d30c691fe',
+      bidderRequestId: '15270d403778d',
+      auctionId: '36acef1b-f635-4f57-b693-5cc55ee16346',
+      src: 'client',
+      ortb2: {
+        regs: {
+          ext: {
+            gdpr: 1,
+            us_privacy: '1YYY'
+          }
+        },
+        user: {
+          ext: {
+            consent: 'consent-string'
+          }
+        },
+        site: {},
+        device: {}
+      },
+      schain
+    }];
+    bidderRequest = {
+      bidderCode: 'r2b2',
+      auctionId: '36acef1b-f635-4f57-b693-5cc55ee16346',
+      bidderRequestId: '15270d403778d',
+      bids: bids,
+      ortb2: {
+        regs: {
+          ext: {
+            gdpr: 1,
+            us_privacy: '1YYY'
+          }
+        },
+        user: {
+          ext: {
+            consent: 'consent-string'
+          }
+        },
+        site: {},
+        device: {}
+      },
+      gdprConsent: {
+        consentString: 'consent-string',
+        vendorData: {},
+        gdprApplies: true,
+        apiVersion: 2
+      },
+      uspConsent: '1YYY',
+    };
+    serverResponse = {
+      id: 'a66a6e32-2a7d-4ed3-bb13-6f3c9bdcf6a1',
+      seatbid: [{
+        bid: [{
+          id: '4756cc9e9b504fd0bd39fdd594506545',
+          impid: impId,
+          price: price,
+          adm: ad,
+          crid: creativeId,
+          w: 300,
+          h: 250,
+          ext: {
+            prebid: {
+              meta: {
+                adaptercode: 'r2b2'
+              },
+              type: 'banner'
+            },
+            r2b2: {
+              cdid: cdid,
+              cid: cid,
+              useRenderer: true
+            }
+          }
+        }],
+        seat: 'seat'
+      }]
+    };
+    requestForInterpretResponse = {
+      data: {
+        imp: [
+          {id: impId}
+        ]
+      },
+      bids
+    };
+  });
+
+  describe('isBidRequestValid', function () {
+    let bid = {};
+
+    it('should return false when missing required "pid" param', function () {
+      bid.params = {random: 'param'};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+      bid.params = {d: 'd', g: 'g', p: 'p', m: 1};
+      expect(spec.isBidRequestValid(bid)).to.equal(false)
+    });
+
+    it('should return false when "pid" is malformed', function () {
+      bid.params = {pid: 'pid'};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+      bid.params = {pid: '///'};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+      bid.params = {pid: '/g/p/m'};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+      bid.params = {pid: 'd//p/m'};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+      bid.params = {pid: 'd/g//m'};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+      bid.params = {pid: 'd/p/'};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+      bid.params = {pid: 'd/g/p/m/t'};
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return true when "pid" is a correct dgpm', function () {
+      bid.params = {pid: 'd/g/p/m'};
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+    it('should return true when type is blank', function () {
+      bid.params = {pid: 'd/g/p/'};
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+    it('should return true when type is missing', function () {
+      bid.params = {pid: 'd/g/p'};
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+    it('should return true when "pid" is a number', function () {
+      bid.params = {pid: 12356};
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+    it('should return true when "pid" is a numeric string', function () {
+      bid.params = {pid: '12356'};
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+    it('should return true for selfpromo unit', function () {
+      bid.params = {pid: 'selfpromo'};
+      expect(spec.isBidRequestValid(bid)).to.equal(true)
+    });
+  });
+
+  describe('buildRequests', function () {
+    beforeEach(function () {
+      r2b2.placementsToSync = [];
+      r2b2.mappedParams = {};
+    });
+
+    it('should set correct request method and url and pass bids', function () {
+      let requests = spec.buildRequests([bids[0]], bidderRequest);
+      expect(requests).to.be.an('array').that.has.lengthOf(1);
+      let request = requests[0]
+      expect(request.method).to.equal('POST');
+      expect(request.url).to.equal('https://hb.r2b2.cz/openrtb2/bid');
+      expect(request.data).to.be.an('object');
+      expect(request.bids).to.deep.equal(bids);
+    });
+
+    it('should pass correct parameters', function () {
+      let requests = spec.buildRequests([bids[0]], bidderRequest);
+      let {data} = requests[0];
+      let {imp, device, site, source, ext, cur, test} = data;
+      expect(imp).to.be.an('array').that.has.lengthOf(1);
+      expect(device).to.be.an('object');
+      expect(site).to.be.an('object');
+      expect(source).to.be.an('object');
+      expect(cur).to.deep.equal(['USD']);
+      expect(ext.version).to.equal('1.0.0');
+      expect(test).to.equal(0);
+    });
+
+    it('should pass correct imp', function () {
+      let requests = spec.buildRequests([bids[0]], bidderRequest);
+      let {data} = requests[0];
+      let {imp} = data;
+      expect(imp).to.be.an('array').that.has.lengthOf(1);
+      expect(imp[0]).to.be.an('object');
+      let bid = imp[0];
+      expect(bid.id).to.equal('20917a54ee9858');
+      expect(bid.banner).to.deep.equal({topframe: 0, format: [{w: 300, h: 250}]});
+      expect(bid.ext).to.be.an('object');
+      expect(bid.ext.r2b2).to.deep.equal({d: 'example.com', g: 'generic', p: '300x250', m: 1});
+    });
+
+    it('should map type correctly', function () {
+      let result, bid;
+      let requestWithId = function(id) {
+        let b = bids[0];
+        b.params.pid = id;
+        let passedBids = [b];
+        bidderRequest.bids = passedBids;
+        return spec.buildRequests(passedBids, bidderRequest);
+      };
+
+      result = requestWithId('example.com/generic/300x250/mobile');
+      bid = result[0].data.imp[0];
+      expect(bid.ext.r2b2.m).to.be.a('number').that.is.equal(1);
+
+      result = requestWithId('example.com/generic/300x250/desktop');
+      bid = result[0].data.imp[0];
+      expect(bid.ext.r2b2.m).to.be.a('number').that.is.equal(0);
+
+      result = requestWithId('example.com/generic/300x250/1');
+      bid = result[0].data.imp[0];
+      expect(bid.ext.r2b2.m).to.be.a('number').that.is.equal(1);
+
+      result = requestWithId('example.com/generic/300x250/0');
+      bid = result[0].data.imp[0];
+      expect(bid.ext.r2b2.m).to.be.a('number').that.is.equal(0);
+
+      result = requestWithId('example.com/generic/300x250/m');
+      bid = result[0].data.imp[0];
+      expect(bid.ext.r2b2.m).to.be.a('number').that.is.equal(1);
+
+      result = requestWithId('example.com/generic/300x250');
+      bid = result[0].data.imp[0];
+      expect(bid.ext.r2b2.m).to.be.a('number').that.is.equal(0);
+    });
+
+    it('should pass correct parameters for test ad', function () {
+      let testAdBid = bids[0];
+      testAdBid.params = {pid: 'selfpromo'};
+      let requests = spec.buildRequests([testAdBid], bidderRequest);
+      let {data} = requests[0];
+      let {imp} = data;
+      expect(imp).to.be.an('array').that.has.lengthOf(1);
+      expect(imp[0]).to.be.an('object');
+      let bid = imp[0];
+      expect(bid.ext).to.be.an('object');
+      expect(bid.ext.r2b2).to.deep.equal({d: 'test', g: 'test', p: 'selfpromo', m: 0, 'selfpromo': 1});
+    });
+
+    it('should pass multiple bids', function () {
+      let requests = spec.buildRequests(bids, bidderRequest);
+      expect(requests).to.be.an('array').that.has.lengthOf(1);
+      let {data} = requests[0];
+      let {imp} = data;
+      expect(imp).to.be.an('array').that.has.lengthOf(bids.length);
+      let bid1 = imp[0];
+      expect(bid1.ext.r2b2).to.deep.equal({d: 'example.com', g: 'generic', p: '300x250', m: 1});
+      let bid2 = imp[1];
+      expect(bid2.ext.r2b2).to.deep.equal({d: 'example.com', g: 'generic', p: '300x600', m: 0});
+    });
+
+    it('should set up internal variables', function () {
+      let requests = spec.buildRequests(bids, bidderRequest);
+      let bid1Id = bids[0].bidId;
+      let bid2Id = bids[1].bidId;
+      expect(r2b2.placementsToSync).to.be.an('array').that.has.lengthOf(2);
+      expect(r2b2.mappedParams).to.have.property(bid1Id);
+      expect(r2b2.mappedParams[bid1Id]).to.deep.equal({d: 'example.com', g: 'generic', p: '300x250', m: 1, pid: 'example.com/generic/300x250/1'});
+      expect(r2b2.mappedParams).to.have.property(bid2Id);
+      expect(r2b2.mappedParams[bid2Id]).to.deep.equal({d: 'example.com', g: 'generic', p: '300x600', m: 0, pid: 'example.com/generic/300x600/0'});
+    });
+
+    it('should pass gdpr properties', function () {
+      let requests = spec.buildRequests(bids, bidderRequest);
+      let {data} = requests[0];
+      let {user, regs} = data;
+      expect(user).to.be.an('object').that.has.property('ext');
+      expect(regs).to.be.an('object').that.has.property('ext');
+      expect(user.ext.consent).to.equal('consent-string');
+      expect(regs.ext.gdpr).to.equal(1);
+    });
+
+    it('should pass us privacy properties', function () {
+      let requests = spec.buildRequests(bids, bidderRequest);
+      let {data} = requests[0];
+      let {regs} = data;
+      expect(regs).to.be.an('object').that.has.property('ext');
+      expect(regs.ext.us_privacy).to.equal('1YYY');
+    });
+
+    it('should pass supply chain', function () {
+      let requests = spec.buildRequests(bids, bidderRequest);
+      let {data} = requests[0];
+      let {source} = data;
+      expect(source).to.be.an('object').that.has.property('ext');
+      expect(source.ext.schain).to.deep.equal({
+        complete: 1,
+        nodes: [
+          {asi: 'example.com', hp: 1, sid: '00001'}
+        ],
+        ver: '1.0'
+      })
+    });
+
+    it('should pass extended ids', function () {
+      let eidsArray = [
+        {
+          source: 'adserver.org',
+          uids: [
+            {
+              atype: 1,
+              ext: {
+                rtiPartner: 'TDID',
+              },
+              id: 'TTD_ID_FROM_USER_ID_MODULE',
+            },
+          ],
+        },
+        {
+          source: 'pubcid.org',
+          uids: [
+            {
+              atype: 1,
+              id: 'pubCommonId_FROM_USER_ID_MODULE',
+            },
+          ],
+        },
+      ];
+      bids[0].userIdAsEids = eidsArray;
+      let requests = spec.buildRequests(bids, bidderRequest);
+      let request = requests[0];
+      let eids = request.data.user.ext.eids;
+
+      expect(eids).to.deep.equal(eidsArray);
+    });
+  });
+
+  describe('interpretResponse', function () {
+    it('should respond with empty response when there are no bids', function () {
+      let result = spec.interpretResponse({ body: {} }, {});
+      expect(result).to.be.an('array').that.has.lengthOf(0);
+      result = spec.interpretResponse({ body: { seatbid: [] } }, {});
+      expect(result).to.be.an('array').that.has.lengthOf(0);
+      result = spec.interpretResponse({ body: { seatbid: [ {} ] } }, {});
+      expect(result).to.be.an('array').that.has.lengthOf(0);
+      result = spec.interpretResponse({ body: { seatbid: [ { bids: [] } ] } }, {});
+      expect(result).to.be.an('array').that.has.lengthOf(0);
+    });
+
+    it('should map params correctly', function () {
+      let result = spec.interpretResponse({ body: serverResponse }, requestForInterpretResponse);
+      expect(result).to.be.an('array').that.has.lengthOf(1);
+      let bid = result[0];
+      expect(bid.requestId).to.equal(impId);
+      expect(bid.cpm).to.equal(price);
+      expect(bid.ad).to.equal(ad);
+      expect(bid.currency).to.equal('USD');
+      expect(bid.mediaType).to.equal('banner');
+      expect(bid.width).to.equal(300);
+      expect(bid.height).to.equal(250);
+      expect(bid.netRevenue).to.equal(true);
+      expect(bid.ttl).to.equal(360);
+      expect(bid.creativeId).to.equal(creativeId);
+    });
+
+    it('should set up renderer on bid', function () {
+      let result = spec.interpretResponse({ body: serverResponse }, requestForInterpretResponse);
+      expect(result).to.be.an('array').that.has.lengthOf(1);
+      let bid = result[0];
+      expect(bid.renderer).to.be.an('object');
+      expect(bid.renderer).to.have.property('render').that.is.a('function');
+      expect(bid.renderer).to.have.property('url').that.is.a('string');
+    });
+
+    it('should map ext params correctly', function() {
+      let dgpm = {something: 'something'};
+      r2b2.mappedParams = {};
+      r2b2.mappedParams[impId] = dgpm;
+      let result = spec.interpretResponse({ body: serverResponse }, requestForInterpretResponse);
+      expect(result).to.be.an('array').that.has.lengthOf(1);
+      let bid = result[0];
+      expect(bid.ext).to.be.an('object');
+      let { ext } = bid;
+      expect(ext.dgpm).to.deep.equal(dgpm);
+      expect(ext.cid).to.equal(cid);
+      expect(ext.cdid).to.equal(cdid);
+      expect(ext.adUnit).to.equal(unitCode);
+      expect(ext.mediaType).to.deep.equal({
+        type: 'banner',
+        settings: {
+          chd: null,
+          width: 300,
+          height: 250,
+          ad: {
+            type: 'content',
+            data: ad
+          }
+        }
+      });
+    });
+
+    it('should handle multiple bids', function() {
+      const impId2 = '123456';
+      const price2 = 12;
+      const ad2 = 'gaeouho';
+      const w2 = 300;
+      const h2 = 600;
+      let b = serverResponse.seatbid[0].bid[0];
+      let b2 = Object.assign({}, b);
+      b2.impid = impId2;
+      b2.price = price2;
+      b2.adm = ad2;
+      b2.w = w2;
+      b2.h = h2;
+      serverResponse.seatbid[0].bid.push(b2);
+      requestForInterpretResponse.data.imp.push({id: impId2});
+      let result = spec.interpretResponse({ body: serverResponse }, requestForInterpretResponse);
+      expect(result).to.be.an('array').that.has.lengthOf(2);
+      let firstBid = result[0];
+      let secondBid = result[1];
+      expect(firstBid.requestId).to.equal(impId);
+      expect(firstBid.ad).to.equal(ad);
+      expect(firstBid.cpm).to.equal(price);
+      expect(firstBid.width).to.equal(300);
+      expect(firstBid.height).to.equal(250);
+      expect(secondBid.requestId).to.equal(impId2);
+      expect(secondBid.ad).to.equal(ad2);
+      expect(secondBid.cpm).to.equal(price2);
+      expect(secondBid.width).to.equal(w2);
+      expect(secondBid.height).to.equal(h2);
+    });
+  });
+
+  describe('getUserSyncs', function() {
+    const syncOptions = {
+      iframeEnabled: true,
+      pixelEnabled: true
+    };
+
+    it('should return an array with a sync for all bids', function() {
+      r2b2.placementsToSync = [id1Object, id2Object];
+      const expectedEncodedIds = encodePlacementIds(r2b2.placementsToSync);
+      const syncs = spec.getUserSyncs(syncOptions);
+      expect(syncs).to.be.an('array').that.has.lengthOf(1);
+      const sync = syncs[0];
+      expect(sync).to.be.an('object');
+      expect(sync.type).to.equal('iframe');
+      expect(sync.url).to.include(`?p=${expectedEncodedIds}`);
+    });
+
+    it('should return the sync and include gdpr and usp parameters in the url', function() {
+      r2b2.placementsToSync = [id1Object, id2Object];
+      const syncs = spec.getUserSyncs(syncOptions, {}, gdprConsent, usPrivacyString);
+      const sync = syncs[0];
+      expect(sync).to.be.an('object');
+      expect(sync.url).to.include(`&gdpr=1`);
+      expect(sync.url).to.include(`&gdpr_consent=${gdprConsent.consentString}`);
+      expect(sync.url).to.include(`&us_privacy=${usPrivacyString}`);
+    });
+  });
+
+  describe('events', function() {
+    beforeEach(function() {
+      time = sinon.useFakeTimers(fakeTime);
+      sinon.stub(utils, 'triggerPixel');
+      r2b2.mappedParams = {};
+      r2b2.mappedParams[bidId1] = id1Object;
+      r2b2.mappedParams[bidId2] = id2Object;
+      bidStub = {
+        adserverTargeting: { hb_bidder: bidder, hb_pb: '10.00', hb_size: '300x300' },
+        cpm: 10,
+        currency: 'USD',
+        ext: {
+          dgpm: { d: 'r2b2.cz', g: 'generic', m: 1, p: '300x300', pid: 'r2b2.cz/generic/300x300/1' }
+        },
+        params: [ { pid: 'r2b2.cz/generic/300x300/1' } ],
+      };
+    });
+    afterEach(function() {
+      utils.triggerPixel.restore();
+      time.restore();
+    });
+
+    describe('onBidWon', function () {
+      it('exists and is a function', () => {
+        expect(spec.onBidWon).to.exist.and.to.be.a('function');
+      });
+      it('should return nothing and trigger a pixel with passed url', function () {
+        bidStub.ext.events = {
+          onBidWon: bidWonUrl,
+          onSetTargeting: setTargetingUrl
+        };
+        const response = spec.onBidWon(bidStub);
+        expect(response).to.be.an('undefined');
+        expect(utils.triggerPixel.called).to.equal(true);
+        expect(utils.triggerPixel.callCount).to.equal(1);
+        expect(utils.triggerPixel.calledWithMatch(bidWonUrl)).to.equal(true);
+      });
+      it('should not trigger a pixel if url is not available', function () {
+        bidStub.ext.events = null;
+        spec.onBidWon(bidStub);
+        expect(utils.triggerPixel.callCount).to.equal(0);
+        bidStub.ext.events = {
+          onBidWon: '',
+          onSetTargeting: '',
+        };
+        spec.onBidWon(bidStub);
+        expect(utils.triggerPixel.callCount).to.equal(0);
+      });
+    });
+
+    describe('onSetTargeting', function () {
+      it('exists and is a function', () => {
+        expect(spec.onSetTargeting).to.exist.and.to.be.a('function');
+      });
+      it('should return nothing and trigger a pixel with passed url', function () {
+        bidStub.ext.events = {
+          onBidWon: bidWonUrl,
+          onSetTargeting: setTargetingUrl
+        };
+        const response = spec.onSetTargeting(bidStub);
+        expect(response).to.be.an('undefined');
+        expect(utils.triggerPixel.called).to.equal(true);
+        expect(utils.triggerPixel.callCount).to.equal(1);
+        expect(utils.triggerPixel.calledWithMatch(setTargetingUrl)).to.equal(true);
+      });
+      it('should not trigger a pixel if url is not available', function () {
+        bidStub.ext.events = null;
+        spec.onSetTargeting(bidStub);
+        expect(utils.triggerPixel.callCount).to.equal(0);
+        bidStub.ext.events = {
+          onBidWon: '',
+          onSetTargeting: '',
+        };
+        spec.onSetTargeting(bidStub);
+        expect(utils.triggerPixel.callCount).to.equal(0);
+      });
+    });
+
+    describe('onTimeout', function () {
+      it('exists and is a function', () => {
+        expect(spec.onTimeout).to.exist.and.to.be.a('function');
+      });
+      it('should return nothing and trigger a pixel', function () {
+        const bids = [bid1, bid2];
+        const response = spec.onTimeout(bids);
+        expect(response).to.be.an('undefined');
+        expect(utils.triggerPixel.callCount).to.equal(1);
+      });
+      it('should not trigger a pixel if no bids available', function () {
+        const bids = [];
+        spec.onTimeout(bids);
+        expect(utils.triggerPixel.callCount).to.equal(0);
+      });
+      it('should trigger a pixel with correct ids and a cache buster', function () {
+        const bids = [bid1, bidForeign1, bidForeign2, bid2, bidWithBadSetup];
+        const expectedIds = [id1Object, id2Object];
+        const expectedEncodedIds = encodePlacementIds(expectedIds);
+        spec.onTimeout(bids);
+        expect(utils.triggerPixel.callCount).to.equal(1);
+        const triggeredUrl = utils.triggerPixel.args[0][0];
+        expect(triggeredUrl).to.include(`p=${expectedEncodedIds}`);
+        expect(triggeredUrl.match(cacheBusterRegex)).to.exist;
+      });
+    });
+
+    describe('onBidderError', function () {
+      it('exists and is a function', () => {
+        expect(spec.onBidderError).to.exist.and.to.be.a('function');
+      });
+      it('should return nothing and trigger a pixel', function () {
+        const bidderRequest = { bids: [bid1, bid2] };
+        const response = spec.onBidderError({ bidderRequest });
+        expect(response).to.be.an('undefined')
+        expect(utils.triggerPixel.callCount).to.equal(1);
+      });
+      it('should not trigger a pixel if no bids available', function () {
+        const bidderRequest = { bids: [] };
+        spec.onBidderError({ bidderRequest });
+        expect(utils.triggerPixel.callCount).to.equal(0);
+      });
+      it('should call triggerEvent with correct ids and a cache buster', function () {
+        const bids = [bid1, bid2, bidWithBadSetup]
+        const bidderRequest = { bids };
+        const expectedIds = [id1Object, id2Object];
+        const expectedEncodedIds = encodePlacementIds(expectedIds);
+        spec.onBidderError({ bidderRequest });
+        expect(utils.triggerPixel.callCount).to.equal(1);
+        const triggeredUrl = utils.triggerPixel.args[0][0];
+        expect(triggeredUrl).to.include(`p=${expectedEncodedIds}`);
+        expect(triggeredUrl.match(cacheBusterRegex)).to.exist;
+      });
+    });
+  });
+});

--- a/test/spec/modules/richaudienceBidAdapter_spec.js
+++ b/test/spec/modules/richaudienceBidAdapter_spec.js
@@ -4,6 +4,8 @@ import {
   spec
 } from 'modules/richaudienceBidAdapter.js';
 import {config} from 'src/config.js';
+import * as utils from 'src/utils.js';
+import sinon from 'sinon';
 
 describe('Richaudience adapter tests', function () {
   var DEFAULT_PARAMS_NEW_SIZES = [{
@@ -63,6 +65,30 @@ describe('Richaudience adapter tests', function () {
     transactionId: '29df2112-348b-4961-8863-1b33684d95e6',
     user: {}
   }];
+
+  var DEFAULT_PARAMS_VIDEO_TIMEOUT = [{
+    adUnitCode: 'test-div',
+    bidId: '2c7c8e9c900244',
+    mediaTypes: {
+      video: {
+        context: 'instream',
+        playerSize: [640, 480],
+        mimes: ['video/mp4']
+      }
+    },
+    bidder: 'richaudience',
+    params: [{
+      bidfloor: 0.5,
+      pid: 'ADb1f40rmi',
+      supplyType: 'site'
+    }],
+    timeout: 3000,
+    auctionId: '0cb3144c-d084-4686-b0d6-f5dbe917c563',
+    bidRequestsCount: 1,
+    bidderRequestId: '1858b7382993ca',
+    transactionId: '29df2112-348b-4961-8863-1b33684d95e6',
+    user: {}
+  }]
 
   var DEFAULT_PARAMS_VIDEO_IN = [{
     adUnitCode: 'test-div',
@@ -878,6 +904,24 @@ describe('Richaudience adapter tests', function () {
     const requestContent = JSON.parse(request[0].data);
     expect(requestContent).to.have.property('gpid').and.to.equal('/19968336/header-bid-tag-1#example-2');
   })
+
+  describe('onTimeout', function () {
+    beforeEach(function() {
+      sinon.stub(utils, 'triggerPixel');
+    });
+
+    afterEach(function() {
+      utils.triggerPixel.restore();
+    });
+    it('onTimeout exist as a function', () => {
+      expect(spec.onTimeout).to.exist.and.to.be.a('function');
+    });
+    it('should send timeout', function () {
+      spec.onTimeout(DEFAULT_PARAMS_VIDEO_TIMEOUT);
+      expect(utils.triggerPixel.called).to.equal(true);
+      expect(utils.triggerPixel.firstCall.args[0]).to.equal('https://s.richaudience.com/err/?ec=6&ev=3000&pla=ADb1f40rmi&int=PREBID&pltfm=&node=&dm=localhost:9876');
+    });
+  });
 
   describe('userSync', function () {
     it('Verifies user syncs iframe include', function () {

--- a/test/spec/modules/riseBidAdapter_spec.js
+++ b/test/spec/modules/riseBidAdapter_spec.js
@@ -22,6 +22,12 @@ describe('riseAdapter', function () {
     });
   });
 
+  describe('bid adapter', function () {
+    it('should have aliases', function () {
+      expect(spec.aliases).to.be.an('array').that.is.not.empty;
+    });
+  });
+
   describe('isBidRequestValid', function () {
     const bid = {
       'bidder': spec.code,
@@ -53,7 +59,7 @@ describe('riseAdapter', function () {
         'adUnitCode': 'adunit-code',
         'sizes': [[640, 480]],
         'params': {
-          'org': 'jdye8weeyirk00000001'
+          'org': 'jdye8weeyirk00000001',
         },
         'bidId': '299ffc8cca0b87',
         'loop': 1,
@@ -193,6 +199,16 @@ describe('riseAdapter', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.bids[0].mediaType).to.equal(VIDEO)
       expect(request.data.bids[1].mediaType).to.equal(BANNER)
+    });
+
+    it('should send the correct currency in bid request', function () {
+      const bid = utils.deepClone(bidRequests[0]);
+      bid.params = {
+        'currency': 'EUR'
+      };
+      const expectedCurrency = bid.params.currency;
+      const request = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.bids[0].currency).to.equal(expectedCurrency);
     });
 
     it('should respect syncEnabled option', function() {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -2381,16 +2381,6 @@ describe('the rubicon adapter', function () {
             bidderRequest = createVideoBidderRequest();
             delete bidderRequest.bids[0].mediaTypes.video.linearity;
             expect(spec.isBidRequestValid(bidderRequest.bids[0])).to.equal(false);
-
-            // change api to an string, no good
-            bidderRequest = createVideoBidderRequest();
-            bidderRequest.bids[0].mediaTypes.video.api = 'string';
-            expect(spec.isBidRequestValid(bidderRequest.bids[0])).to.equal(false);
-
-            // delete api, no good
-            bidderRequest = createVideoBidderRequest();
-            delete bidderRequest.bids[0].mediaTypes.video.api;
-            expect(spec.isBidRequestValid(bidderRequest.bids[0])).to.equal(false);
           });
 
           it('bid request is valid when video context is outstream', function () {

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -2,9 +2,23 @@ import { expect } from 'chai';
 import { spec, getTimeoutUrl } from 'modules/seedtagBidAdapter.js';
 import * as utils from 'src/utils.js';
 import { config } from '../../../src/config.js';
+import * as mockGpt from 'test/spec/integration/faker/googletag.js';
 
 const PUBLISHER_ID = '0000-0000-01';
 const ADUNIT_ID = '000000';
+
+const adUnitCode = '/19968336/header-bid-tag-0'
+
+// create a default adunit
+const slot = document.createElement('div');
+slot.id = adUnitCode;
+slot.style.width = '300px'
+slot.style.height = '250px'
+slot.style.position = 'absolute'
+slot.style.top = '10px'
+slot.style.left = '20px'
+
+document.body.appendChild(slot);
 
 function getSlotConfigs(mediaTypes, params) {
   return {
@@ -25,7 +39,7 @@ function getSlotConfigs(mediaTypes, params) {
         tid: 'd704d006-0d6e-4a09-ad6c-179e7e758096',
       }
     },
-    adUnitCode: 'adunit-code',
+    adUnitCode: adUnitCode,
   };
 }
 
@@ -46,6 +60,13 @@ const createBannerSlotConfig = (placement, mediatypes) => {
 };
 
 describe('Seedtag Adapter', function () {
+  beforeEach(function () {
+    mockGpt.reset();
+  });
+
+  afterEach(function () {
+    mockGpt.enable();
+  });
   describe('isBidRequestValid method', function () {
     describe('returns true', function () {
       describe('when banner slot config has all mandatory params', () => {
@@ -277,7 +298,7 @@ describe('Seedtag Adapter', function () {
       expect(data.auctionStart).to.be.greaterThanOrEqual(now);
       expect(data.ttfb).to.be.greaterThanOrEqual(0);
 
-      expect(data.bidRequests[0].adUnitCode).to.equal('adunit-code');
+      expect(data.bidRequests[0].adUnitCode).to.equal(adUnitCode);
     });
 
     describe('GDPR params', function () {
@@ -374,6 +395,35 @@ describe('Seedtag Adapter', function () {
         expect(videoBid.sizes[1][1]).to.equal(600);
         expect(videoBid.requestCount).to.equal(1);
       });
+
+      it('should have geom parameters if slot is available', function() {
+        const request = spec.buildRequests(validBidRequests, bidderRequest);
+        const data = JSON.parse(request.data);
+        const bidRequests = data.bidRequests;
+        const bannerBid = bidRequests[0];
+
+        // on some CI, the DOM is not initialized, so we need to check if the slot is available
+        const slot = document.getElementById(adUnitCode)
+        if (slot) {
+          expect(bannerBid).to.have.property('geom')
+
+          const params = [['width', 300], ['height', 250], ['top', 10], ['left', 20], ['scrollY', 0]]
+          params.forEach(([param, value]) => {
+            expect(bannerBid.geom).to.have.property(param)
+            expect(bannerBid.geom[param]).to.be.a('number')
+            expect(bannerBid.geom[param]).to.be.equal(value)
+          })
+
+          expect(bannerBid.geom).to.have.property('viewport')
+          const viewportParams = ['width', 'height']
+          viewportParams.forEach(param => {
+            expect(bannerBid.geom.viewport).to.have.property(param)
+            expect(bannerBid.geom.viewport[param]).to.be.a('number')
+          })
+        } else {
+          expect(bannerBid).to.not.have.property('geom')
+        }
+      })
     });
 
     describe('COPPA param', function () {

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -588,6 +588,43 @@ describe('sharethrough adapter spec', function () {
         });
       });
 
+      describe('cookie deprecation', () => {
+        it('should not add cdep if we do not get it in an impression request', () => {
+          const builtRequests = spec.buildRequests(bidRequests, {
+            auctionId: 'new-auction-id',
+            ortb2: {
+              device: {
+                ext: {
+                  propThatIsNotCdep: 'value-we-dont-care-about',
+                },
+              },
+            },
+          });
+          const noCdep = builtRequests.every((builtRequest) => {
+            const ourCdepValue = builtRequest.data.device?.ext?.cdep;
+            return ourCdepValue === undefined;
+          });
+          expect(noCdep).to.be.true;
+        });
+
+        it('should add cdep if we DO get it in an impression request', () => {
+          const builtRequests = spec.buildRequests(bidRequests, {
+            auctionId: 'new-auction-id',
+            ortb2: {
+              device: {
+                ext: {
+                  cdep: 'cdep-value',
+                },
+              },
+            },
+          });
+          const cdepPresent = builtRequests.every((builtRequest) => {
+            return builtRequest.data.device.ext.cdep === 'cdep-value';
+          });
+          expect(cdepPresent).to.be.true;
+        });
+      });
+
       describe('first party data', () => {
         const firstPartyData = {
           site: {

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -786,7 +786,7 @@ describe('Smart bid adapter tests', function () {
         expect(request[0]).to.have.property('method').and.to.equal('POST');
         const requestContent = JSON.parse(request[0].data);
         expect(requestContent).to.have.property('videoData');
-        expect(requestContent.videoData).to.have.property('videoProtocol').and.to.equal(null);
+        expect(requestContent.videoData).not.to.have.property('videoProtocol').eq(true);
         expect(requestContent.videoData).to.have.property('adBreak').and.to.equal(2);
       });
 
@@ -832,6 +832,73 @@ describe('Smart bid adapter tests', function () {
         expect(requestContent).to.have.property('videoData');
         expect(requestContent.videoData).to.have.property('videoProtocol').and.to.equal(6);
         expect(requestContent.videoData).to.have.property('adBreak').and.to.equal(3);
+      });
+
+      it('should pass additional parameters', function () {
+        const request = spec.buildRequests([{
+          bidder: 'smartadserver',
+          mediaTypes: {
+            video: {
+              context: 'instream',
+              api: [1, 2, 3],
+              maxbitrate: 50,
+              minbitrate: 20,
+              maxduration: 30,
+              minduration: 5,
+              placement: 3,
+              playbackmethod: [2, 4],
+              playerSize: [[640, 480]],
+              plcmt: 1,
+              skip: 0
+            }
+          },
+          params: {
+            siteId: '123'
+          }
+        }]);
+        const requestContent = JSON.parse(request[0].data);
+
+        expect(requestContent.videoData).to.have.property('iabframeworks').and.to.equal('1,2,3');
+        expect(requestContent.videoData).not.to.have.property('skip');
+        expect(requestContent.videoData).to.have.property('vbrmax').and.to.equal(50);
+        expect(requestContent.videoData).to.have.property('vbrmin').and.to.equal(20);
+        expect(requestContent.videoData).to.have.property('vdmax').and.to.equal(30);
+        expect(requestContent.videoData).to.have.property('vdmin').and.to.equal(5);
+        expect(requestContent.videoData).to.have.property('vplcmt').and.to.equal(1);
+        expect(requestContent.videoData).to.have.property('vpmt').and.to.have.lengthOf(2);
+        expect(requestContent.videoData.vpmt[0]).to.equal(2);
+        expect(requestContent.videoData.vpmt[1]).to.equal(4);
+        expect(requestContent.videoData).to.have.property('vpt').and.to.equal(3);
+      });
+
+      it('should not pass not valuable parameters', function () {
+        const request = spec.buildRequests([{
+          bidder: 'smartadserver',
+          mediaTypes: {
+            video: {
+              context: 'instream',
+              maxbitrate: 20,
+              minbitrate: null,
+              maxduration: 0,
+              playbackmethod: [],
+              playerSize: [[640, 480]],
+              plcmt: 1
+            }
+          },
+          params: {
+            siteId: '123'
+          }
+        }]);
+        const requestContent = JSON.parse(request[0].data);
+
+        expect(requestContent.videoData).not.to.have.property('iabframeworks');
+        expect(requestContent.videoData).to.have.property('vbrmax').and.to.equal(20);
+        expect(requestContent.videoData).not.to.have.property('vbrmin');
+        expect(requestContent.videoData).not.to.have.property('vdmax');
+        expect(requestContent.videoData).not.to.have.property('vdmin');
+        expect(requestContent.videoData).to.have.property('vplcmt').and.to.equal(1);
+        expect(requestContent.videoData).not.to.have.property('vpmt');
+        expect(requestContent.videoData).not.to.have.property('vpt');
       });
     });
   });
@@ -1029,7 +1096,7 @@ describe('Smart bid adapter tests', function () {
       expect(request[0]).to.have.property('method').and.to.equal('POST');
       const requestContent = JSON.parse(request[0].data);
       expect(requestContent).to.have.property('videoData');
-      expect(requestContent.videoData).to.have.property('videoProtocol').and.to.equal(null);
+      expect(requestContent.videoData).not.to.have.property('videoProtocol').eq(true);
       expect(requestContent.videoData).to.have.property('adBreak').and.to.equal(2);
     });
 
@@ -1391,6 +1458,43 @@ describe('Smart bid adapter tests', function () {
       const requestContent = JSON.parse(request[0].data);
 
       expect(requestContent).to.have.property('gpid').and.to.equal(gpid);
+    });
+  });
+
+  describe('#getValuableProperty method', function () {
+    it('should return an object when calling with a number value', () => {
+      const obj = spec.getValuableProperty('prop', 3);
+      expect(obj).to.deep.equal({ prop: 3 });
+    });
+
+    it('should return an empty object when calling with a string value', () => {
+      const obj = spec.getValuableProperty('prop', 'str');
+      expect(obj).to.deep.equal({});
+    });
+
+    it('should return an empty object when calling with a number property', () => {
+      const obj = spec.getValuableProperty(7, 'str');
+      expect(obj).to.deep.equal({});
+    });
+
+    it('should return an empty object when calling with a null value', () => {
+      const obj = spec.getValuableProperty('prop', null);
+      expect(obj).to.deep.equal({});
+    });
+
+    it('should return an empty object when calling with an object value', () => {
+      const obj = spec.getValuableProperty('prop', {});
+      expect(obj).to.deep.equal({});
+    });
+
+    it('should return an empty object when calling with a 0 value', () => {
+      const obj = spec.getValuableProperty('prop', 0);
+      expect(obj).to.deep.equal({});
+    });
+
+    it('should return an empty object when calling without the value argument', () => {
+      const obj = spec.getValuableProperty('prop');
+      expect(obj).to.deep.equal({});
     });
   });
 });

--- a/test/spec/modules/sovrnAnalyticsAdapter_spec.js
+++ b/test/spec/modules/sovrnAnalyticsAdapter_spec.js
@@ -12,7 +12,7 @@ let constants = require('src/constants.json');
 
 /**
  * Emit analytics events
- * @param {array} eventArr - array of objects to define the events that will fire
+ * @param {Array} eventArr - array of objects to define the events that will fire
  *    @param {object} eventObj - key is eventType, value is event
  * @param {string} auctionId - the auction id to attached to the events
  */

--- a/test/spec/modules/sovrnBidAdapter_spec.js
+++ b/test/spec/modules/sovrnBidAdapter_spec.js
@@ -318,6 +318,41 @@ describe('sovrnBidAdapter', function() {
       expect(data.regs.ext['us_privacy']).to.equal(bidderRequest.uspConsent)
     })
 
+    it('should not set coppa when coppa is undefined', function () {
+      const bidderRequest = {
+        ...baseBidderRequest,
+        bidderCode: 'sovrn',
+        auctionId: '1d1a030790a475',
+        bidderRequestId: '22edbae2733bf6',
+        timeout: 3000,
+        bids: [baseBidRequest],
+        gdprConsent: {
+          consentString: 'BOJ8RZsOJ8RZsABAB8AAAAAZ+A==',
+          gdprApplies: true
+        },
+      }
+      const {regs} = JSON.parse(spec.buildRequests([baseBidRequest], bidderRequest).data)
+      expect(regs.coppa).to.be.undefined
+    })
+
+    it('should set coppa to 1 when coppa is provided with value true', function () {
+      const bidderRequest = {
+        ...baseBidderRequest,
+        ortb2: {
+          regs: {
+            coppa: true
+          }
+        },
+        bidderCode: 'sovrn',
+        auctionId: '1d1a030790a475',
+        bidderRequestId: '22edbae2733bf6',
+        timeout: 3000,
+        bids: [baseBidRequest]
+      }
+      const {regs} = JSON.parse(spec.buildRequests([baseBidRequest], bidderRequest).data)
+      expect(regs.coppa).to.equal(1)
+    })
+
     it('should send gpp info in OpenRTB 2.6 location when gppConsent defined', function () {
       const bidderRequest = {
         ...baseBidderRequest,

--- a/test/spec/modules/sparteoBidAdapter_spec.js
+++ b/test/spec/modules/sparteoBidAdapter_spec.js
@@ -6,6 +6,7 @@ const CURRENCY = 'EUR';
 const TTL = 60;
 const HTTP_METHOD = 'POST';
 const REQUEST_URL = 'https://bid.sparteo.com/auction';
+const USER_SYNC_URL_IFRAME = 'https://sync.sparteo.com/sync/iframe.html?from=prebidjs';
 
 const VALID_BID_BANNER = {
   bidder: 'sparteo',
@@ -323,7 +324,12 @@ describe('SparteoAdapter', function () {
             'price': 5,
             'ext': {
               'prebid': {
-                'type': 'video'
+                'type': 'video',
+                'cache': {
+                  'vastXml': {
+                    'url': 'https://pbs.tet.com/cache?uuid=1234'
+                  }
+                }
               }
             },
             'adm': 'tag',
@@ -368,7 +374,8 @@ describe('SparteoAdapter', function () {
             ttl: TTL,
             mediaType: 'video',
             meta: {},
-            vastUrl: 'https://t.bidder.sparteo.com/img',
+            nurl: 'https://t.bidder.sparteo.com/img',
+            vastUrl: 'https://pbs.tet.com/cache?uuid=1234',
             vastXml: 'tag'
           });
         }
@@ -429,6 +436,31 @@ describe('SparteoAdapter', function () {
         bids.forEach(function(bid) {
           expect(adapter.onBidWon.bind(adapter, bid)).to.not.throw();
         });
+      });
+    });
+  });
+
+  describe('getUserSyncs', function() {
+    describe('Check methods succeed', function () {
+      it('should return the sync url', function() {
+        const syncOptions = {
+          'iframeEnabled': true,
+          'pixelEnabled': false
+        };
+        const gdprConsent = {
+          gdprApplies: 1,
+          consentString: 'tcfv2'
+        };
+        const uspConsent = {
+          consentString: '1Y---'
+        };
+
+        const syncUrls = [{
+          type: 'iframe',
+          url: USER_SYNC_URL_IFRAME + '&gdpr=1&gdpr_consent=tcfv2&usp_consent=1Y---'
+        }];
+
+        expect(adapter.getUserSyncs(syncOptions, null, gdprConsent, uspConsent)).to.deep.equal(syncUrls);
       });
     });
   });

--- a/test/spec/modules/stvBidAdapter_spec.js
+++ b/test/spec/modules/stvBidAdapter_spec.js
@@ -71,6 +71,24 @@ describe('stvAdapter', function() {
               'hp': 1
             }
           ]
+        },
+        'userId': {
+          'id5id': {
+            'uid': '1234',
+            'ext': {
+              'linkType': 'abc'
+            }
+          },
+          'netId': '2345',
+          'uid2': {
+            'id': '3456',
+          },
+          'sharedid': {
+            'id': '4567',
+          },
+          'idl_env': '5678',
+          'criteoId': '6789',
+          'utiq': '7890',
         }
       },
       {
@@ -84,7 +102,27 @@ describe('stvAdapter', function() {
         ],
         'bidId': '30b31c1838de1e2',
         'bidderRequestId': '22edbae2733bf62',
-        'auctionId': '1d1a030790a476'
+        'auctionId': '1d1a030790a476',
+        'userId': { // with other utiq variant
+          'id5id': {
+            'uid': '1234',
+            'ext': {
+              'linkType': 'abc'
+            }
+          },
+          'netId': '2345',
+          'uid2': {
+            'id': '3456',
+          },
+          'sharedid': {
+            'id': '4567',
+          },
+          'idl_env': '5678',
+          'criteoId': '6789',
+          'utiq': {
+            'id': '7890'
+          },
+        }
       }, {
         'bidder': 'stv',
         'params': {
@@ -181,7 +219,7 @@ describe('stvAdapter', function() {
       expect(request1.method).to.equal('GET');
       expect(request1.url).to.equal(ENDPOINT_URL);
       let data = request1.data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid').replace(/pbver=.*?&/g, 'pbver=test&');
-      expect(data).to.equal('_f=html&alternative=prebid_js&_ps=6682&srw=300&srh=250&idt=100&bid_id=30b31c1838de1e1&pbver=test&schain=1.0,0!reseller.com,aaaaa,1,BidRequest4,,,&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bgeo%5D%5Bcountry%5D=DE&gdpr_consent=BOJ%2FP2HOJ%2FP2HABABMAAAAAZ%2BA%3D%3D&gdpr=true&bcat=IAB2%2CIAB4&dvt=desktop&pbcode=testDiv1&media_types%5Bbanner%5D=300x250');
+      expect(data).to.equal('_f=html&alternative=prebid_js&_ps=6682&srw=300&srh=250&idt=100&bid_id=30b31c1838de1e1&pbver=test&schain=1.0,0!reseller.com,aaaaa,1,BidRequest4,,&uids=id5%3A1234,id5_linktype%3Aabc,netid%3A2345,uid2%3A3456,sharedid%3A4567,liverampid%3A5678,criteoid%3A6789,utiq%3A7890&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bgeo%5D%5Bcountry%5D=DE&gdpr_consent=BOJ%2FP2HOJ%2FP2HABABMAAAAAZ%2BA%3D%3D&gdpr=true&bcat=IAB2%2CIAB4&dvt=desktop&pbcode=testDiv1&media_types%5Bbanner%5D=300x250');
     });
 
     var request2 = spec.buildRequests([bidRequests[1]], bidderRequest)[0];
@@ -189,7 +227,7 @@ describe('stvAdapter', function() {
       expect(request2.method).to.equal('GET');
       expect(request2.url).to.equal(ENDPOINT_URL);
       let data = request2.data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid').replace(/pbver=.*?&/g, 'pbver=test&');
-      expect(data).to.equal('_f=html&alternative=prebid_js&_ps=101&srw=300&srh=250&idt=100&bid_id=30b31c1838de1e2&pbver=test&gdpr_consent=BOJ%2FP2HOJ%2FP2HABABMAAAAAZ%2BA%3D%3D&gdpr=true&prebidDevMode=1&media_types%5Bbanner%5D=300x250');
+      expect(data).to.equal('_f=html&alternative=prebid_js&_ps=101&srw=300&srh=250&idt=100&bid_id=30b31c1838de1e2&pbver=test&uids=id5%3A1234,id5_linktype%3Aabc,netid%3A2345,uid2%3A3456,sharedid%3A4567,liverampid%3A5678,criteoid%3A6789,utiq%3A7890&gdpr_consent=BOJ%2FP2HOJ%2FP2HABABMAAAAAZ%2BA%3D%3D&gdpr=true&prebidDevMode=1&media_types%5Bbanner%5D=300x250');
     });
 
     // Without gdprConsent

--- a/test/spec/modules/teadsBidAdapter_spec.js
+++ b/test/spec/modules/teadsBidAdapter_spec.js
@@ -1,6 +1,7 @@
 import {expect} from 'chai';
 import {spec, storage} from 'modules/teadsBidAdapter.js';
 import {newBidder} from 'src/adapters/bidderFactory.js';
+import { off } from '../../../src/events';
 
 const ENDPOINT = 'https://a.teads.tv/hb/bid-request';
 const AD_SCRIPT = '<script type="text/javascript" class="teads" async="true" src="https://a.teads.tv/hb/getAdSettings"></script>"';
@@ -252,6 +253,63 @@ describe('teadsBidAdapter', () => {
 
       expect(payload.pageReferrer).to.exist;
       expect(payload.pageReferrer).to.deep.equal(document.referrer);
+    });
+
+    it('should add screenOrientation info to payload', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequestDefault);
+      const payload = JSON.parse(request.data);
+      const screenOrientation = window.top.screen.orientation?.type
+
+      if (screenOrientation) {
+        expect(payload.screenOrientation).to.exist;
+        expect(payload.screenOrientation).to.deep.equal(screenOrientation);
+      } else expect(payload.screenOrientation).to.not.exist;
+    });
+
+    it('should add historyLength info to payload', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequestDefault);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.historyLength).to.exist;
+      expect(payload.historyLength).to.deep.equal(window.top.history.length);
+    });
+
+    it('should add viewportHeight info to payload', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequestDefault);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.viewportHeight).to.exist;
+      expect(payload.viewportHeight).to.deep.equal(window.top.visualViewport.height);
+    });
+
+    it('should add viewportWidth info to payload', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequestDefault);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.viewportWidth).to.exist;
+      expect(payload.viewportWidth).to.deep.equal(window.top.visualViewport.width);
+    });
+
+    it('should add hardwareConcurrency info to payload', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequestDefault);
+      const payload = JSON.parse(request.data);
+      const hardwareConcurrency = window.top.navigator?.hardwareConcurrency
+
+      if (hardwareConcurrency) {
+        expect(payload.hardwareConcurrency).to.exist;
+        expect(payload.hardwareConcurrency).to.deep.equal(hardwareConcurrency);
+      } else expect(payload.hardwareConcurrency).to.not.exist
+    });
+
+    it('should add deviceMemory info to payload', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequestDefault);
+      const payload = JSON.parse(request.data);
+      const deviceMemory = window.top.navigator.deviceMemory
+
+      if (deviceMemory) {
+        expect(payload.deviceMemory).to.exist;
+        expect(payload.deviceMemory).to.deep.equal(deviceMemory);
+      } else expect(payload.deviceMemory).to.not.exist;
     });
 
     describe('pageTitle', function () {

--- a/test/spec/modules/theAdxBidAdapter_spec.js
+++ b/test/spec/modules/theAdxBidAdapter_spec.js
@@ -446,6 +446,78 @@ describe('TheAdxAdapter', function () {
       expect(processedBid.currency).to.equal(responseCurrency);
     });
 
+    it('returns a valid deal bid response on sucessful banner request with deal', function () {
+      let incomingRequestId = 'XXtestingXX';
+      let responsePrice = 3.14
+
+      let responseCreative = 'sample_creative&{FOR_COVARAGE}';
+
+      let responseCreativeId = '274';
+      let responseCurrency = 'TRY';
+
+      let responseWidth = 300;
+      let responseHeight = 250;
+      let responseTtl = 213;
+      let dealId = 'theadx_deal_id';
+
+      let sampleResponse = {
+        id: '66043f5ca44ecd8f8769093b1615b2d9',
+        seatbid: [{
+          bid: [{
+            id: 'c21bab0e-7668-4d8f-908a-63e094c09197',
+            dealid: 'theadx_deal_id',
+            impid: '1',
+            price: responsePrice,
+            adid: responseCreativeId,
+            crid: responseCreativeId,
+            adm: responseCreative,
+            adomain: [
+              'www.domain.com'
+            ],
+            cid: '274',
+            attr: [],
+            w: responseWidth,
+            h: responseHeight,
+            ext: {
+              ttl: responseTtl
+            }
+          }],
+          seat: '201',
+          group: 0
+        }],
+        bidid: 'c21bab0e-7668-4d8f-908a-63e094c09197',
+        cur: responseCurrency
+      };
+
+      let sampleRequest = {
+        bidId: incomingRequestId,
+        mediaTypes: {
+          banner: {}
+        },
+        requestId: incomingRequestId,
+        deals: [{id: dealId}]
+      };
+      let serverResponse = {
+        body: sampleResponse
+      }
+      let result = spec.interpretResponse(serverResponse, sampleRequest);
+
+      expect(result.length).to.equal(1);
+
+      let processedBid = result[0];
+
+      // expect(processedBid.requestId).to.equal(incomingRequestId);
+      expect(processedBid.cpm).to.equal(responsePrice);
+      expect(processedBid.width).to.equal(responseWidth);
+      expect(processedBid.height).to.equal(responseHeight);
+      expect(processedBid.ad).to.equal(responseCreative);
+      expect(processedBid.ttl).to.equal(responseTtl);
+      expect(processedBid.creativeId).to.equal(responseCreativeId);
+      expect(processedBid.netRevenue).to.equal(true);
+      expect(processedBid.currency).to.equal(responseCurrency);
+      expect(processedBid.dealId).to.equal(dealId);
+    });
+
     it('returns an valid bid response on sucessful video request', function () {
       let incomingRequestId = 'XXtesting-275XX';
       let responsePrice = 6

--- a/test/spec/modules/ucfunnelBidAdapter_spec.js
+++ b/test/spec/modules/ucfunnelBidAdapter_spec.js
@@ -30,7 +30,7 @@ const validBannerBidReq = {
   params: {
     adid: 'ad-34BBD2AA24B678BBFD4E7B9EE3B872D'
   },
-  sizes: [[300, 250]],
+  sizes: [[300, 250], [336, 280]],
   bidId: '263be71e91dd9d',
   auctionId: '9ad1fa8d-2297-4660-a018-b39945054746',
   ortb2Imp: {
@@ -180,15 +180,15 @@ describe('ucfunnel Adapter', function () {
       expect(data.schain).to.equal('1.0,1!exchange1.com,1234,1,bid-request-1,publisher,publisher.com');
     });
 
-    it('must parse bid size from a nested array', function () {
-      const width = 640;
-      const height = 480;
-      const bid = deepClone(validBannerBidReq);
-      bid.sizes = [[ width, height ]];
-      const requests = spec.buildRequests([ bid ], bidderRequest);
+    it('should support multiple size', function () {
+      const sizes = [[300, 250], [336, 280]];
+      const format = '300,250;336,280';
+      validBannerBidReq.sizes = sizes;
+      const requests = spec.buildRequests([ validBannerBidReq ], bidderRequest);
       const data = requests[0].data;
-      expect(data.w).to.equal(width);
-      expect(data.h).to.equal(height);
+      expect(data.w).to.equal(sizes[0][0]);
+      expect(data.h).to.equal(sizes[0][1]);
+      expect(data.format).to.equal(format);
     });
 
     it('should set bidfloor if configured', function() {

--- a/test/spec/modules/uid2IdSystem_spec.js
+++ b/test/spec/modules/uid2IdSystem_spec.js
@@ -476,37 +476,33 @@ describe(`UID2 module`, function () {
           })
 
           describe('When the storedToken is expired and can be refreshed ', function() {
-            it('it should calls refresh API', function() {
-              testApiSuccessAndFailure(async function(apiSucceeds) {
-                const refreshedIdentity = apiHelpers.makeTokenResponse(refreshedToken, true, true);
-                const moduleCookie = {originalIdentity: makeOriginalIdentity('test@test.com'), latestToken: refreshedIdentity};
-                coreStorage.setCookie(moduleCookieName, JSON.stringify(moduleCookie), cookieHelpers.getFutureCookieExpiry());
-                config.setConfig(makePrebidConfig({ ...cstgConfigParams, email: 'test@test.com' }));
-                apiHelpers.respondAfterDelay(auctionDelayMs / 10, server);
+            testApiSuccessAndFailure(async function(apiSucceeds) {
+              const refreshedIdentity = apiHelpers.makeTokenResponse(refreshedToken, true, true);
+              const moduleCookie = {originalIdentity: makeOriginalIdentity('test@test.com'), latestToken: refreshedIdentity};
+              coreStorage.setCookie(moduleCookieName, JSON.stringify(moduleCookie), cookieHelpers.getFutureCookieExpiry());
+              config.setConfig(makePrebidConfig({ ...cstgConfigParams, email: 'test@test.com' }));
+              apiHelpers.respondAfterDelay(auctionDelayMs / 10, server);
 
-                const bid = await runAuction();
+              const bid = await runAuction();
 
-                if (apiSucceeds) expectToken(bid, refreshedToken);
-                else expectNoIdentity(bid);
-              }, refreshApiUrl, 'it should use refreshed token in the auction', 'the auction should have no uid2');
-            });
+              if (apiSucceeds) expectToken(bid, refreshedToken);
+              else expectNoIdentity(bid);
+            }, refreshApiUrl, 'it should use refreshed token in the auction', 'the auction should have no uid2');
           })
 
           describe('When the storedToken is expired for refresh', function() {
-            it('it should calls CSTG API and not use the stored token', function() {
-              testApiSuccessAndFailure(async function(apiSucceeds) {
-                const refreshedIdentity = apiHelpers.makeTokenResponse(refreshedToken, true, true, true);
-                const moduleCookie = {originalIdentity: makeOriginalIdentity('test@test.com'), latestToken: refreshedIdentity};
-                coreStorage.setCookie(moduleCookieName, JSON.stringify(moduleCookie), cookieHelpers.getFutureCookieExpiry());
-                config.setConfig(makePrebidConfig({ ...cstgConfigParams, email: 'test@test.com' }));
-                apiHelpers.respondAfterDelay(auctionDelayMs / 10, server);
+            testApiSuccessAndFailure(async function(apiSucceeds) {
+              const refreshedIdentity = apiHelpers.makeTokenResponse(refreshedToken, true, true, true);
+              const moduleCookie = {originalIdentity: makeOriginalIdentity('test@test.com'), latestToken: refreshedIdentity};
+              coreStorage.setCookie(moduleCookieName, JSON.stringify(moduleCookie), cookieHelpers.getFutureCookieExpiry());
+              config.setConfig(makePrebidConfig({ ...cstgConfigParams, email: 'test@test.com' }));
+              apiHelpers.respondAfterDelay(auctionDelayMs / 10, server);
 
-                const bid = await runAuction();
+              const bid = await runAuction();
 
-                if (apiSucceeds) expectToken(bid, clientSideGeneratedToken);
-                else expectNoIdentity(bid);
-              }, cstgApiUrl, 'it should use generated token in the auction', 'the auction should have no uid2', false, clientSideGeneratedToken);
-            });
+              if (apiSucceeds) expectToken(bid, clientSideGeneratedToken);
+              else expectNoIdentity(bid);
+            }, cstgApiUrl, 'it should use generated token in the auction', 'the auction should have no uid2', false, clientSideGeneratedToken);
           })
         })
 

--- a/test/spec/modules/unrulyBidAdapter_spec.js
+++ b/test/spec/modules/unrulyBidAdapter_spec.js
@@ -517,7 +517,8 @@ describe('UnrulyAdapter', function () {
               'bidderRequestId': '12e00d17dff07b'
             }
           ],
-          'invalidBidsCount': 0
+          'invalidBidsCount': 0,
+          'prebidVersion': '$prebid.version$'
         }
       };
 
@@ -591,7 +592,8 @@ describe('UnrulyAdapter', function () {
               'bidderRequestId': '12e00d17dff07b',
             }
           ],
-          'invalidBidsCount': 0
+          'invalidBidsCount': 0,
+          'prebidVersion': '$prebid.version$'
         }
       };
 
@@ -682,7 +684,8 @@ describe('UnrulyAdapter', function () {
               'bidderRequestId': '12e00d17dff07b',
             }
           ],
-          'invalidBidsCount': 0
+          'invalidBidsCount': 0,
+          'prebidVersion': '$prebid.version$'
         }
       };
 
@@ -1095,7 +1098,7 @@ describe('UnrulyAdapter', function () {
                 'adUnitCode': 'video2',
                 'transactionId': 'a89619e3-137d-4cc5-9ed4-58a0b2a0bbc2',
                 'bidId': bidId,
-                'bidderRequestId': '12e00d17dff07b',
+                'bidderRequestId': '12e00d17dff07b'
               }
             ]
           }

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -448,7 +448,25 @@ describe('User ID', function () {
             ]
           }
         ])
-      })
+      });
+
+      it('when merging with pubCommonId, should not alter its eids', () => {
+        const uid = {
+          pubProvidedId: [
+            {
+              source: 'mock1Source',
+              uids: [
+                {id: 'uid2'}
+              ]
+            }
+          ],
+          mockId1: 'uid1',
+        };
+        const eids = createEidsArray(uid);
+        expect(eids).to.have.length(1);
+        expect(eids[0].uids.map(u => u.id)).to.have.members(['uid1', 'uid2']);
+        expect(uid.pubProvidedId[0].uids).to.eql([{id: 'uid2'}]);
+      });
     })
 
     it('pbjs.getUserIds', function (done) {

--- a/test/spec/modules/viantOrtbBidAdapter_spec.js
+++ b/test/spec/modules/viantOrtbBidAdapter_spec.js
@@ -109,6 +109,49 @@ describe('viantOrtbBidAdapter', function () {
         });
       });
     });
+
+    describe('native', function () {
+      describe('and request config uses mediaTypes', () => {
+        function makeBid() {
+          return {
+            'bidder': 'viant',
+            'params': {
+              'unit': '12345678',
+              'delDomain': 'test-del-domain',
+              'publisherId': '464',
+              'placementId': 'some-PlacementId_2'
+            },
+            'mediaTypes': {
+              'video': {
+                'context': 'instream',
+                'playerSize': [[640, 480]],
+                'mimes': ['video/mp4'],
+                'protocols': [1, 2, 3, 4, 5, 6, 7, 8],
+                'api': [1, 3],
+                'skip': 1,
+                'skipafter': 5,
+                'minduration': 10,
+                'maxduration': 30
+              }
+            },
+            'adUnitCode': 'adunit-code',
+            'bidId': '30b31c1838de1e',
+            'bidderRequestId': '22edbae2733bf6',
+            'auctionId': '1d1a030790a475',
+            'transactionId': '4008d88a-8137-410b-aa35-fbfdabcb478e'
+          }
+        }
+        it('should return true when required params found', function () {
+          expect(spec.isBidRequestValid(makeBid())).to.equal(true);
+        });
+
+        it('should return false when required params are not passed', function () {
+          let nativeBidWithMediaTypes = Object.assign({}, makeBid());
+          nativeBidWithMediaTypes.params = {};
+          expect(spec.isBidRequestValid(nativeBidWithMediaTypes)).to.equal(false);
+        });
+      });
+    });
   });
 
   describe('buildRequests-banner', function () {
@@ -172,7 +215,7 @@ describe('viantOrtbBidAdapter', function () {
     });
     it('sends bid requests to the correct endpoint', function () {
       const url = testBuildRequests(baseBannerBidRequests, baseBidderRequest)[0].url;
-      expect(url).to.equal('https://bidders-us-east-1.adelphic.net/d/rtb/v25/prebid/bidder_test');
+      expect(url).to.equal('https://bidders-us-east-1.adelphic.net/d/rtb/v25/prebid/bidder');
     });
 
     it('sends site', function () {

--- a/test/spec/modules/yandexBidAdapter_spec.js
+++ b/test/spec/modules/yandexBidAdapter_spec.js
@@ -1,6 +1,6 @@
 import { assert, expect } from 'chai';
 import { spec, NATIVE_ASSETS } from 'modules/yandexBidAdapter.js';
-import { parseUrl } from 'src/utils.js';
+import * as utils from 'src/utils.js';
 import { BANNER, NATIVE } from '../../../src/mediaTypes';
 import { config } from '../../../src/config';
 
@@ -71,7 +71,7 @@ describe('Yandex adapter', function () {
 
       expect(method).to.equal('POST');
 
-      const parsedRequestUrl = parseUrl(url);
+      const parsedRequestUrl = utils.parseUrl(url);
       const { search: query } = parsedRequestUrl
 
       expect(parsedRequestUrl.hostname).to.equal('bs.yandex.ru');
@@ -100,25 +100,43 @@ describe('Yandex adapter', function () {
       const bannerRequest = getBidRequest();
       const requests = spec.buildRequests([bannerRequest], bidderRequest);
       const { url } = requests[0];
-      const parsedRequestUrl = parseUrl(url);
+      const parsedRequestUrl = utils.parseUrl(url);
       const { search: query } = parsedRequestUrl
 
       expect(query['ssp-cur']).to.equal('USD');
     });
 
-    it('should send eids if defined', function() {
-      const bannerRequest = getBidRequest({
+    it('should send eids and ortb2 user data if defined', function() {
+      const bidRequestExtra = {
         userIdAsEids: [{
           source: 'sharedid.org',
-          uids: [
-            {
-              id: '01',
-              atype: 1
-            }
-          ]
-        }]
-      });
+          uids: [{ id: '01', atype: 1 }],
+        }],
+        ortb2: {
+          user: {
+            data: [
+              {
+                ext: { segtax: 600, segclass: '1' },
+                name: 'example.com',
+                segment: [{ id: '243' }],
+              },
+              {
+                ext: { segtax: 600, segclass: '1' },
+                name: 'ads.example.org',
+                segment: [{ id: '243' }],
+              },
+            ],
+          },
+        },
+      };
+      const expected = {
+        ext: {
+          eids: bidRequestExtra.userIdAsEids,
+        },
+        data: bidRequestExtra.ortb2.user.data,
+      };
 
+      const bannerRequest = getBidRequest(bidRequestExtra);
       const requests = spec.buildRequests([bannerRequest], bidderRequest);
 
       expect(requests).to.have.lengthOf(1);
@@ -128,17 +146,7 @@ describe('Yandex adapter', function () {
       const { data } = request;
 
       expect(data.user).to.exist;
-      expect(data.user).to.deep.equal({
-        ext: {
-          eids: [{
-            source: 'sharedid.org',
-            uids: [{
-              id: '01',
-              atype: 1,
-            }],
-          }],
-        }
-      });
+      expect(data.user).to.deep.equal(expected);
     });
 
     describe('banner', () => {
@@ -478,6 +486,55 @@ describe('Yandex adapter', function () {
       });
     });
   });
+
+  describe('onBidWon', function() {
+    beforeEach(function() {
+      sinon.stub(utils, 'triggerPixel');
+    });
+    afterEach(function() {
+      utils.triggerPixel.restore();
+    });
+
+    it('Should not trigger pixel if bid does not contain nurl', function() {
+      const result = spec.onBidWon({});
+      expect(utils.triggerPixel.callCount).to.equal(0)
+    })
+
+    it('Should trigger pixel if bid has nurl', function() {
+      const result = spec.onBidWon({
+        nurl: 'https://example.com/some-tracker',
+        timeToRespond: 378,
+      });
+      expect(utils.triggerPixel.callCount).to.equal(1)
+      expect(utils.triggerPixel.getCall(0).args[0]).to.equal('https://example.com/some-tracker?rtt=378')
+    })
+
+    it('Should trigger pixel if bid has nurl with path & params', function() {
+      const result = spec.onBidWon({
+        nurl: 'https://example.com/some-tracker/abcdxyz?param1=1&param2=2',
+        timeToRespond: 378,
+      });
+      expect(utils.triggerPixel.callCount).to.equal(1)
+      expect(utils.triggerPixel.getCall(0).args[0]).to.equal('https://example.com/some-tracker/abcdxyz?param1=1&param2=2&rtt=378')
+    })
+
+    it('Should trigger pixel if bid has nurl with path & params and rtt macros', function() {
+      const result = spec.onBidWon({
+        nurl: 'https://example.com/some-tracker/abcdxyz?param1=1&param2=2&custom-rtt=${RTT}',
+        timeToRespond: 378,
+      });
+      expect(utils.triggerPixel.callCount).to.equal(1)
+      expect(utils.triggerPixel.getCall(0).args[0]).to.equal('https://example.com/some-tracker/abcdxyz?param1=1&param2=2&custom-rtt=378')
+    })
+
+    it('Should trigger pixel if bid has nurl and there is no timeToRespond param, but has rtt macros in nurl', function() {
+      const result = spec.onBidWon({
+        nurl: 'https://example.com/some-tracker/abcdxyz?param1=1&param2=2&custom-rtt=${RTT}',
+      });
+      expect(utils.triggerPixel.callCount).to.equal(1)
+      expect(utils.triggerPixel.getCall(0).args[0]).to.equal('https://example.com/some-tracker/abcdxyz?param1=1&param2=2&custom-rtt=-1')
+    })
+  })
 });
 
 function getBidConfig() {

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -47,7 +47,7 @@ describe('YieldmoAdapter', function () {
       video: {
         playerSize: [640, 480],
         context: 'instream',
-        mimes: ['video/mp4']
+        mimes: ['video/mp4'],
       },
     },
     params: {
@@ -61,11 +61,11 @@ describe('YieldmoAdapter', function () {
         api: [2, 3],
         skipppable: true,
         playbackmethod: [1, 2],
-        ...videoParams
-      }
+        ...videoParams,
+      },
     },
     transactionId: '54a58774-7a41-494e-8cbc-fa7b79164f0c',
-    ...rootParams
+    ...rootParams,
   });
 
   const mockBidderRequest = (params = {}, bids = [mockBannerBid()]) => ({
@@ -458,6 +458,16 @@ describe('YieldmoAdapter', function () {
       it('should add mediaTypes.video.mimes prop to the imp.video', function () {
         utils.deepAccess(videoBid, 'mediaTypes.video')['minduration'] = ['video/mp4'];
         expect(buildVideoBidAndGetVideoParam().minduration).to.deep.equal(['video/mp4']);
+      });
+
+      it('should add plcmt value to the imp.video', function () {
+        const videoBid = mockVideoBid({}, {}, { plcmt: 1 });
+        expect(utils.deepAccess(videoBid, 'params.video')['plcmt']).to.equal(1);
+      });
+
+      it('should add start delay if plcmt value is not 1', function () {
+        const videoBid = mockVideoBid({}, {}, { plcmt: 2 });
+        expect(build([videoBid])[0].data.imp[0].video.startdelay).to.equal(0);
       });
 
       it('should override mediaTypes.video.mimes prop if params.video.mimes is present', function () {

--- a/test/spec/modules/zeta_global_sspBidAdapter_spec.js
+++ b/test/spec/modules/zeta_global_sspBidAdapter_spec.js
@@ -124,7 +124,24 @@ describe('Zeta Ssp Bid Adapter', function () {
     uspConsent: 'someCCPAString',
     params: params,
     userIdAsEids: eids,
-    timeout: 500
+    timeout: 500,
+    ortb2: {
+      user: {
+        data: [
+          {
+            ext: {
+              segtax: 600,
+              segclass: 'classifier_v1'
+            },
+            segment: [
+              { id: '3' },
+              { id: '44' },
+              { id: '59' }
+            ]
+          }
+        ]
+      }
+    }
   }];
 
   const bannerWithFewSizesRequest = [{
@@ -605,5 +622,14 @@ describe('Zeta Ssp Bid Adapter', function () {
     expect(bidResponse[0].mediaType).to.eql(BANNER);
     expect(bidResponse[0].ad).to.eql(zetaResponse.body.seatbid[0].bid[0].adm);
     expect(bidResponse[0].vastXml).to.be.undefined;
+  });
+
+  it('Test provide segments into the request', function () {
+    const request = spec.buildRequests(bannerRequest, bannerRequest[0]);
+    const payload = JSON.parse(request.data);
+    expect(payload.user.data[0].segment.length).to.eql(3);
+    expect(payload.user.data[0].segment[0].id).to.eql('3');
+    expect(payload.user.data[0].segment[1].id).to.eql('44');
+    expect(payload.user.data[0].segment[2].id).to.eql('59');
   });
 });

--- a/test/spec/unit/core/events_spec.js
+++ b/test/spec/unit/core/events_spec.js
@@ -1,5 +1,6 @@
 import {config} from 'src/config.js';
-import {emit, clearEvents, getEvents} from '../../../../src/events.js';
+import {emit, clearEvents, getEvents, on, off} from '../../../../src/events.js';
+import * as utils from '../../../../src/utils.js'
 
 describe('events', () => {
   let clock;
@@ -26,5 +27,19 @@ describe('events', () => {
     config.setConfig({eventHistoryTTL: 1000});
     clock.tick(10000);
     expect(getEvents().length).to.eql(1);
-  })
+  });
+
+  it('should include the eventString if a callback fails', () => {
+    const logErrorStub = sinon.stub(utils, 'logError');
+    const eventString = 'bidWon';
+    let fn = function() { throw new Error('Test error'); };
+    on(eventString, fn);
+
+    emit(eventString, {});
+
+    sinon.assert.calledWith(logErrorStub, 'Error executing handler:', 'events.js', sinon.match.instanceOf(Error), eventString);
+
+    off(eventString, fn);
+    logErrorStub.restore();
+  });
 })

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -2728,6 +2728,13 @@ describe('Unit: Prebid Module', function () {
       events.on.restore();
     });
 
+    it('should emit event BID_ACCEPTED when invoked', function () {
+      var callback = sinon.spy();
+      $$PREBID_GLOBAL$$.onEvent('bidAccepted', callback);
+      events.emit(CONSTANTS.EVENTS.BID_ACCEPTED);
+      sinon.assert.calledOnce(callback);
+    });
+
     describe('beforeRequestBids', function () {
       let bidRequestedHandler;
       let beforeRequestBidsHandler;


### PR DESCRIPTION
issue: https://github.com/voyagegroup/fluct_tag_manager/issues/2134
v8.26.0 -> v8.32.0

関連のある変更
- GeoEdge RTD module: collect CPM and curency from the winning bid
- Teads Bid Adapter: add new window features to request
- Adagio Bid Adapter: remove useless adrequest fields
- Unruly Bid Adapter : include Prebid.js version in request 
- Criteo Bid Adapter: Add support for app.publisher.id in bid request
- PubMatic Bid Adapter : passing a unique wiid to pubmatic ssp and logger call 
- GumGum Bid Adapter : added gpid to video requests 
- Pangle Bid Adapter : add multi format support
- Criteo bid adapter: add device object to backend request
- Discovery Bid Adapter : add title, description, keywords
- Unicorn Bid Adapter : support id5