### PR TITLE
fluct Bid Adapter: allow wrapper to inject its name via x-fluct-prebid-wrapper header

### DIFF
--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -39,6 +39,14 @@ export const spec = {
     const serverRequests = [];
     const page = bidderRequest.refererInfo.page;
     const wrapperName = config.getConfig('fluct')?.wrapperName;
+    const customHeaders = {
+      'x-fluct-app': 'prebid/fluctBidAdapter',
+      'x-fluct-version': VERSION,
+      'x-openrtb-version': 2.5,
+    };
+    if (wrapperName) {
+      customHeaders['x-fluct-prebid-wrapper'] = wrapperName;
+    }
 
     _each(validBidRequests, (request) => {
       const impExt = request.ortb2Imp?.ext;
@@ -104,15 +112,6 @@ export const spec = {
         tagId: request.params.tagId,
         groupId: request.params.groupId,
       });
-
-      const customHeaders = {
-        'x-fluct-app': 'prebid/fluctBidAdapter',
-        'x-fluct-version': VERSION,
-        'x-openrtb-version': 2.5,
-      };
-      if (wrapperName) {
-        customHeaders['x-fluct-prebid-wrapper'] = wrapperName;
-      }
 
       serverRequests.push({
         method: 'POST',

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -38,6 +38,7 @@ export const spec = {
   buildRequests: (validBidRequests, bidderRequest) => {
     const serverRequests = [];
     const page = bidderRequest.refererInfo.page;
+    const wrapperName = config.getConfig('fluct')?.wrapperName;
 
     _each(validBidRequests, (request) => {
       const impExt = request.ortb2Imp?.ext;
@@ -104,17 +105,22 @@ export const spec = {
         groupId: request.params.groupId,
       });
 
+      const customHeaders = {
+        'x-fluct-app': 'prebid/fluctBidAdapter',
+        'x-fluct-version': VERSION,
+        'x-openrtb-version': 2.5,
+      };
+      if (wrapperName) {
+        customHeaders['x-fluct-prebid-wrapper'] = wrapperName;
+      }
+
       serverRequests.push({
         method: 'POST',
         url: END_POINT + '?' + searchParams.toString(),
         options: {
           contentType: 'application/json',
           withCredentials: true,
-          customHeaders: {
-            'x-fluct-app': 'prebid/fluctBidAdapter',
-            'x-fluct-version': VERSION,
-            'x-openrtb-version': 2.5
-          }
+          customHeaders,
         },
         data: data
       });

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -192,6 +192,18 @@ describe('fluctAdapter', function () {
       expect(request.data.regs).to.eql(undefined);
     });
 
+    it('does not include x-fluct-prebid-wrapper header by default', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.options.customHeaders['x-fluct-prebid-wrapper']).to.be.undefined;
+    });
+
+    it('includes x-fluct-prebid-wrapper header when fluct.wrapperName is configured', function () {
+      sb.stub(config, 'getConfig').withArgs('fluct').returns({ wrapperName: 'boost' });
+
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.options.customHeaders['x-fluct-prebid-wrapper']).to.equal('boost');
+    });
+
     it('includes filtered user.eids if any exists', function () {
       const bidRequests2 = bidRequests.map(
         (bidReq) => Object.assign({}, bidReq, {


### PR DESCRIPTION
## 概要

fluct bidder がどの Prebid.js wrapper からのリクエストかを識別できるよう、`fluctBidAdapter.js` に HTTP ヘッダー `x-fluct-prebid-wrapper` を付与する仕組みを追加します。

関連 issue:
- voyagegroup/fluct_programmatic#584
- voyagegroup/fluct_programmatic#577
- voyagegroup/fluct_tag_manager#3807

## 背景

fluct bidder 側で BID STRAP Wrapper からのリクエストと他 wrapper からのリクエストを区別する必要が生じました。BID STRAP（`fluct_tag_manager`）では既に `x-fluct-prebid-wrapper: boost` ヘッダーの送信が実装・リリース済みです。

本家 Prebid.js の `fluctBidAdapter.js` は不特定多数の wrapper が使うため、値をハードコードするのではなく、**wrapper 側が名前を設定から注入できる**形で実装します。

## 変更内容

### `modules/fluctBidAdapter.js`

`buildRequests` 内で `config.getConfig('fluct')?.wrapperName` を読み取り、設定されている場合のみ `x-fluct-prebid-wrapper` ヘッダーを付与します。

```js
// wrapper 側での設定例（BID STRAP の場合）
pbjs.setConfig({
  fluct: { wrapperName: 'boost' }
});
```

未設定の場合はヘッダーを送信しないため、既存の動作に影響はありません。

### `test/spec/modules/fluctBidAdapter_spec.js`

- `fluct.wrapperName` 未設定時はヘッダーが存在しないことを確認するテスト追加
- `fluct.wrapperName: 'boost'` 設定時にヘッダーが正しく付与されることを確認するテスト追加

## 確認事項

- `gulp lint` : 成功（出力なし）
- `gulp test --file test/spec/modules/fluctBidAdapter_spec.js` : 35 tests completed ✔