### PR TITLE
fluct Bid Adapter: add device.ext.vpw/vph viewport size signals

### DIFF
--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -10,7 +10,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 
 const BIDDER_CODE = 'fluct';
 const END_POINT = 'https://hb.adingo.jp/prebid/';
-const VERSION = '1.5';
+const VERSION = '1.6';
 const NET_REVENUE = true;
 const TTL = 300;
 const DEFAULT_CURRENCY = 'JPY';
@@ -227,6 +227,13 @@ export const spec = {
         if (ortb2Device.h) data.device.h = ortb2Device.h;
         if (ortb2Device.language) data.device.language = ortb2Device.language;
         if (ortb2Device.devicetype) data.device.devicetype = ortb2Device.devicetype;
+        const vpw = ortb2Device.ext?.vpw;
+        const vph = ortb2Device.ext?.vph;
+        if (vpw != null || vph != null) {
+          data.device.ext = {};
+          if (vpw != null) data.device.ext.vpw = vpw;
+          if (vph != null) data.device.ext.vph = vph;
+        }
       }
 
       // Set top-level bidfloor to the highest floor across all sizes

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -567,6 +567,57 @@ describe('fluctAdapter', function () {
       expect(request.data.device).to.eql({ sua });
     });
 
+    it('includes device.ext.vpw and device.ext.vph from ortb2.device.ext', function () {
+      const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
+        ortb2: {
+          device: {
+            w: 1920,
+            h: 1080,
+            ext: { vpw: 1280, vph: 720 },
+          },
+        },
+      }))[0];
+      expect(request.data.device).to.eql({
+        w: 1920,
+        h: 1080,
+        ext: { vpw: 1280, vph: 720 },
+      });
+    });
+
+    it('includes device.ext.vpw only when vph is absent', function () {
+      const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
+        ortb2: {
+          device: {
+            ext: { vpw: 375 },
+          },
+        },
+      }))[0];
+      expect(request.data.device).to.eql({ ext: { vpw: 375 } });
+    });
+
+    it('includes device.ext.vph only when vpw is absent', function () {
+      const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
+        ortb2: {
+          device: {
+            ext: { vph: 667 },
+          },
+        },
+      }))[0];
+      expect(request.data.device).to.eql({ ext: { vph: 667 } });
+    });
+
+    it('does not set device.ext when neither vpw nor vph is present', function () {
+      const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
+        ortb2: {
+          device: {
+            w: 1920,
+            h: 1080,
+          },
+        },
+      }))[0];
+      expect(request.data.device.ext).to.eql(undefined);
+    });
+
     it('includes no data.imp by default', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.data.imp).to.eql(undefined);


### PR DESCRIPTION
## Summary

- `device.ext.vpw` / `device.ext.vph` をビューポートサイズシグナルとして fluct サーバーへ送信するよう追加
- 取得元: `bidderRequest.ortb2.device.ext.vpw` / `.vph`
- ビューアビリティ予測に利用されるビューポートサイズは DSP の入札単価に直接影響する。既存の画面サイズ (`w`, `h`) と区別してビューポートサイズを送信することで DSP 側のターゲティング精度が向上する

## Changes

- `modules/fluctBidAdapter.js`: VERSION 1.5 → 1.6、`device.ext.vpw` / `device.ext.vph` の送信を追加
- `test/spec/modules/fluctBidAdapter_spec.js`: vpw/vph に対するユニットテストを 4 件追加

## Test Results

`gulp test --nolint --file test/spec/modules/fluctBidAdapter_spec.js`

```
✔ 65 tests completed
```
