### PR TITLE
Fluct Bid Adapter: send autoplay capability as a signal

### DIFF
--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -1,6 +1,7 @@
 import { _each, deepAccess, deepSetValue, isEmpty, isFn, isPlainObject } from '../src/utils.js';
 import { config } from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { isAutoplayEnabled } from '../libraries/autoplayDetection/autoplay.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -241,6 +242,10 @@ export const spec = {
 
       const pos = deepAccess(request, 'mediaTypes.banner.pos') ?? deepAccess(request, 'ortb2Imp.ext.data.pos');
       if (pos != null) data.pos = pos;
+
+      // Forward the device autoplay capability as a raw signal so the bidder can
+      // avoid autoplay-dependent (e.g. video) inventory when autoplay is blocked.
+      data.autoplay = isAutoplayEnabled() ? 1 : 0;
 
       const ortb2Device = bidderRequest.ortb2?.device;
       if (ortb2Device) {

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { spec } from 'modules/fluctBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 import { config } from 'src/config';
+import * as autoplay from 'libraries/autoplayDetection/autoplay.js';
 
 describe('fluctAdapter', function () {
   const adapter = newBidder(spec);
@@ -950,6 +951,20 @@ describe('fluctAdapter', function () {
     it('does not include data.user.ext when ortb2.user.ext.data is absent', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.data.user.ext).to.eql(undefined);
+    });
+
+    describe('autoplay signal', function () {
+      it('sends data.autoplay = 1 when autoplay is enabled', function () {
+        sb.stub(autoplay, 'isAutoplayEnabled').returns(true);
+        const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+        expect(request.data.autoplay).to.equal(1);
+      });
+
+      it('sends data.autoplay = 0 when autoplay is disabled', function () {
+        sb.stub(autoplay, 'isAutoplayEnabled').returns(false);
+        const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+        expect(request.data.autoplay).to.equal(0);
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- `fluctBidAdapter` に **デバイスの autoplay 能力を生のシグナルとして付与**する変更に限定（video 対応への拡張は差し戻し）。
- `data.autoplay = isAutoplayEnabled() ? 1 : 0`（共有ライブラリ `libraries/autoplayDetection/autoplay.js`）を **全 bid リクエスト**に付与。`missenaBidAdapter` と同じ idiomatic な作法。
- アダプターはリクエストを**加工しない**（`mediaTypes.video` の読み取り・playbackmethod 上書き・supportedMediaTypes 宣言などは行わない）。autoplay シグナルの**使い方は bidder server 側が判断**（autoplay 無効時に autoplay 依存の動画在庫を避ける等）。

## Test plan
- [x] `npx eslint modules/fluctBidAdapter.js test/spec/modules/fluctBidAdapter_spec.js --cache --cache-strategy content` → クリーン（出力なし）
- [x] `npx gulp test --nolint --file test/spec/modules/fluctBidAdapter_spec.js` → **63 tests passed / 0 failed**（autoplay シグナルのテスト追加）

## Notes
- 当初の「正式 video 対応（instream/outstream・vastXml・renderer）」案は差し戻し、**autoplay 生シグナルのみ**に限定。fluct の video 配信はサーバー主導のため、アダプターが video を宣言・処理しなくても autoplay 能力さえ渡せばサーバー側で対応できる、という整理。
- サーバー側での autoplay シグナル消費（autoplay 無効時の playbackmethod/在庫制御）は別 Issue **voyagegroup/fluct_dlv#7948**。
- 本 PR は内部レビュー用。Upstream（prebid/Prebid.js）提出時はそのまま出せる最小変更。

Relates to voyagegroup/fluct_dlv#7948
